### PR TITLE
Add parsoid conf for walthamstowlabourwiki.

### DIFF
--- a/modules/parsoid/files/settings.js
+++ b/modules/parsoid/files/settings.js
@@ -23,6 +23,7 @@ exports.setup = function( parsoidConfig ) {
 	parsoidConfig.setInterwiki( 'spiralwiki', 'https://spiral.wiki/w/api.php' );
 	parsoidConfig.setInterwiki( 'torejorgwiki', 'https://torejorg.miraheze.org/w/api.php' );
 	parsoidConfig.setInterwiki( 'unikumwiki', 'https://unikum.miraheze.org/w/api.php' );
+	parsoidConfig.setInterwiki( 'walthamstowlabourwiki', 'https://walthamstowlabour.miraheze.org/w/api.php' );
 
 	// Don't load WMF wikis
 	parsoidConfig.loadWMF = false;


### PR DESCRIPTION
For miraheze/mw-config#206, ref: miraheze/puppet#29.