### PR TITLE
Propose to serve boulderwiki.org directly

### DIFF
--- a/modules/mediawiki/files/nginx/mediawiki.conf
+++ b/modules/mediawiki/files/nginx/mediawiki.conf
@@ -22,7 +22,7 @@ server {
 server {
 	listen [::]:80;
 
-	server_name *.miraheze.org anuwiki.com spiral.wiki static.miraheze.org antiguabarbudacalypso.com permanentfuturelab.wiki secure.reviwiki.info wiki.printmaking.be private.revi.wiki oneagencydunedin.wiki publictestwiki.com boulderwiki.com www.boulderwiki.com;
+	server_name *.miraheze.org anuwiki.com spiral.wiki static.miraheze.org antiguabarbudacalypso.com permanentfuturelab.wiki secure.reviwiki.info wiki.printmaking.be private.revi.wiki oneagencydunedin.wiki publictestwiki.com boulderwiki.org www.boulderwiki.org;
 
 	if ($http_user_agent ~* "WordPress") {
 		return 403;

--- a/modules/mediawiki/files/nginx/mediawiki.conf
+++ b/modules/mediawiki/files/nginx/mediawiki.conf
@@ -22,7 +22,7 @@ server {
 server {
 	listen [::]:80;
 
-	server_name *.miraheze.org anuwiki.com spiral.wiki static.miraheze.org antiguabarbudacalypso.com permanentfuturelab.wiki secure.reviwiki.info wiki.printmaking.be private.revi.wiki oneagencydunedin.wiki publictestwiki.com;
+	server_name *.miraheze.org anuwiki.com spiral.wiki static.miraheze.org antiguabarbudacalypso.com permanentfuturelab.wiki secure.reviwiki.info wiki.printmaking.be private.revi.wiki oneagencydunedin.wiki publictestwiki.com boulderwiki.com www.boulderwiki.com;
 
 	if ($http_user_agent ~* "WordPress") {
 		return 403;
@@ -62,6 +62,30 @@ server {
 
 	include /etc/nginx/mediawiki-includes;
 }
+
+
+server {
+	listen [::]:443 ssl spdy;
+
+	server_name boulderwiki.org;
+	root /srv/mediawiki;
+
+	ssl_certificate /etc/ssl/certs/boulderwiki.org.crt;
+	ssl_certificate_key /etc/ssl/private/boulderwiki.org.key;
+
+	ssl_trusted_certificate /etc/ssl/certs/StartSSL.crt;
+
+	add_header Strict-Transport-Security "max-age=2419200";
+
+	include /etc/nginx/mediawiki-includes;
+}
+
+server {
+	# Redirect www.boulderwiki to straight boulderwiki
+	listen [::]:443 ssl spdy;
+	server_name www.boulderwiki.org;
+	return 301 https://boulderwiki.org$request_uri;
+}	
 
 server {
 	listen [::]:80;

--- a/modules/mediawiki/manifests/init.pp
+++ b/modules/mediawiki/manifests/init.pp
@@ -36,7 +36,7 @@ class mediawiki {
         ensure => present,
         install_options => ['--no-install-recommends'],
     }
-    
+
     ssl::cert { 'wildcard.miraheze.org': }
     ssl::cert { 'spiral.wiki': }
     ssl::cert { 'anuwiki.com': }
@@ -48,6 +48,7 @@ class mediawiki {
     ssl::cert { 'allthetropes.org': }
     ssl::cert { 'oneagencydunedin.wiki': }
     ssl::cert { 'publictestwiki.com': }
+    ssl::cert { 'boulderwiki.org': }
 
     nginx::site { 'mediawiki':
         ensure   => present,

--- a/modules/varnish/files/nginx/mediawiki.conf
+++ b/modules/varnish/files/nginx/mediawiki.conf
@@ -1,7 +1,7 @@
 server {
         listen [::]:80 ipv6only=off;
 
-        server_name *.miraheze.org anuwiki.com spiral.wiki static.miraheze.org antiguabarbudacalypso.com permanentfuturelab.wiki secure.reviwiki.info wiki.printmaking.be private.revi.wiki;
+        server_name *.miraheze.org anuwiki.com spiral.wiki static.miraheze.org antiguabarbudacalypso.com permanentfuturelab.wiki secure.reviwiki.info wiki.printmaking.be private.revi.wiki boulderwiki.org www.boulderwiki.org;
 
         return 301 https://$host$request_uri;
 }
@@ -47,6 +47,31 @@ server {
         }
 }
 
+server {
+        listen [::]:443 ssl spdy;
+
+        server_name boulderwiki.org;
+        root /var/www/html;
+
+        ssl_certificate /etc/ssl/certs/boulderwiki.org.crt;
+        ssl_certificate_key /etc/ssl/private/boulderwiki.org.key;
+
+        ssl_trusted_certificate /etc/ssl/certs/StartSSL.crt;
+
+        location / {
+                proxy_pass http://127.0.0.1:81;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+        }
+}
+
+server {
+        listen [::]:80;
+        server_name www.boulderwiki.org;
+        return 301 https://boulderwiki.org$request_uri;
+}
 
 server {
         listen [::]:443 ssl spdy;

--- a/modules/varnish/manifests/init.pp
+++ b/modules/varnish/manifests/init.pp
@@ -57,6 +57,7 @@ class varnish {
     ssl::cert { 'allthetropes.org': }
     ssl::cert { 'oneagencydunedin.wiki': }
     ssl::cert { 'publictestwiki.com': }
+    ssl::cert { 'boulderwiki.org': }
 
     nginx::site { 'mediawiki':
         ensure => present,


### PR DESCRIPTION
Please double check for me before/after merging:
- paths to ssl_cert, key, and trusted cert (wild guess on all three)
- line 88, I'm not 100% sure that I don't want a slash between ```boulderwiki.org``` and ```$request_uri```