### PR TITLE
add parsoid for teleswikiwiki

### DIFF
--- a/modules/parsoid/manifests/init.pp
+++ b/modules/parsoid/manifests/init.pp
@@ -69,6 +69,7 @@ class parsoid {
                 'soshomophobie',
                 'sirikot',
                 'taylor',
+                'teleswiki',
                 'test',
                 'tochki',
                 'torejorg',


### PR DESCRIPTION
Note that the db name is teleswikiwiki and the domain is teleswiki.mh.o so this is correct