### PR TITLE
Possible fix for T581

### DIFF
--- a/modules/varnish/templates/mediawiki.conf
+++ b/modules/varnish/templates/mediawiki.conf
@@ -103,6 +103,21 @@ server {
 
 server {
 	listen 443 ssl http2;
+	listen [::]:443 ssl http2;
+	
+	server_name www.thinkingliquid.org
+	root /var/www/html;
+	
+	ssl_certificate /etc/ssl/certs/thinkingliquid.org.crt;
+	ssl_certificate_key /etc/ssl/private/thinkingliquid.org.key;
+	
+	ssl_trusted_certificate /etc/ssl/certs/LetsEncrypt.crt;
+	
+	return 301 https://thinkingliquid.org$request_uri;
+}
+
+server {
+	listen 443 ssl http2;
         listen [::]:443 ssl http2;
 
         server_name www.wikiparkinson.org;

--- a/modules/varnish/templates/mediawiki.conf
+++ b/modules/varnish/templates/mediawiki.conf
@@ -105,7 +105,7 @@ server {
 	listen 443 ssl http2;
 	listen [::]:443 ssl http2;
 	
-	server_name www.thinkingliquid.org
+	server_name www.thinkingliquid.org;
 	root /var/www/html;
 	
 	ssl_certificate /etc/ssl/certs/thinkingliquid.org.crt;


### PR DESCRIPTION
Possible fix for T581

Adding 301 redirect from www.thinkingliquid.org to thinkingliquid.org, guessed SSL cert locations based on pattern, filed alphabetically.

Please review this and prepare to roll back