### PR TITLE
Revert "add refreshed skin composer configuration"

### DIFF
--- a/modules/mediawiki/manifests/init.pp
+++ b/modules/mediawiki/manifests/init.pp
@@ -163,13 +163,4 @@ class mediawiki {
         user        => 'www-data',
         require     => Git::Clone['MediaWiki core'],
     }
-    exec { 'refreshed_composer':
-        command     => 'curl -sS https://getcomposer.org/installer | php && php composer.phar install',
-        creates     => '/srv/mediawiki/w/skins/Refreshed/composer.phar',
-        cwd         => '/srv/mediawiki/w/skins/Refreshed',
-        path        => '/usr/bin',
-        environment => 'HOME=/srv/mediawiki/w/skins/Refreshed',
-        user        => 'www-data',
-        require     => Git::Clone['MediaWiki core'],
-    }
 }


### PR DESCRIPTION
Reverts miraheze/puppet#265

There are no issues with the change - the skin does not ignore the composer-driven files.