### PR TITLE
mediawiki::dumps implementation

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1,3 +1,4 @@
 jobrunner: false
 mailserver: false
 arcanist: false
+mwdumps: false

--- a/hieradata/hosts/mw2.yaml
+++ b/hieradata/hosts/mw2.yaml
@@ -3,3 +3,4 @@ users::groups:
   - mediawiki-roots
 jobrunner: false
 arcanist: true
+mwdumps: true

--- a/modules/mediawiki/manifests/dumps.pp
+++ b/modules/mediawiki/manifests/dumps.pp
@@ -1,0 +1,16 @@
+# class: mediawiki::dumps
+#
+# Cron jobs of select wiki dumps
+class mediawiki::cron {
+	if $::hostname == 'cp1' {
+	    cron { 'update_database_lists':
+        	ensure		=> present,
+        	command		=> '/usr/bin/php /srv/mediawiki/w/maintenance/dumpBackups.php --wiki sterbalssundrystudieswiki --logs --full',
+        	user		=> 'www-data',
+        	minute		=> absent,
+        	hour		=> absent,
+        	month		=> absent,
+        	monthday	=> 1,
+    	}
+	}    	
+}

--- a/modules/mediawiki/manifests/dumps.pp
+++ b/modules/mediawiki/manifests/dumps.pp
@@ -2,15 +2,13 @@
 #
 # Cron jobs of select wiki dumps
 class mediawiki::cron {
-	if $::hostname == 'cp1' {
-	    cron { 'update_database_lists':
-        	ensure		=> present,
-        	command		=> '/usr/bin/php /srv/mediawiki/w/maintenance/dumpBackups.php --wiki sterbalssundrystudieswiki --logs --full',
-        	user		=> 'www-data',
-        	minute		=> absent,
-        	hour		=> absent,
-        	month		=> absent,
-        	monthday	=> 1,
-    	}
-	}    	
+    cron { 'update_database_lists':
+        ensure   => present,
+        command  => '/usr/bin/php /srv/mediawiki/w/maintenance/dumpBackups.php --wiki sterbalssundrystudieswiki --logs --full',
+        user     => 'www-data',
+        minute   => absent,
+        hour     => absent,
+        month    => absent,
+        monthday => 1,
+    }
 }

--- a/modules/mediawiki/manifests/dumps.pp
+++ b/modules/mediawiki/manifests/dumps.pp
@@ -2,13 +2,13 @@
 #
 # Cron jobs of select wiki dumps
 class mediawiki::dumps {
-    cron { 'sterbalssundrystudieswiki':
+    cron { 'Export sterbalssundrystudieswiki xml dump monthly':
         ensure   => present,
         command  => '/usr/bin/nice -n19 /usr/bin/php /srv/mediawiki/w/maintenance/dumpBackups.php --wiki sterbalssundrystudieswiki --logs --full > /mnt/mediawiki-static/dumps/sterbalssundrystudieswiki.xml',
         user     => 'www-data',
-        minute   => absent,
-        hour     => absent,
-        month    => absent,
+        minute   => '0',
+        hour     => '0',
+        month    => '*',
         monthday => 1,
     }
 }

--- a/modules/mediawiki/manifests/dumps.pp
+++ b/modules/mediawiki/manifests/dumps.pp
@@ -1,7 +1,7 @@
 # class: mediawiki::dumps
 #
 # Cron jobs of select wiki dumps
-class mediawiki::cron {
+class mediawiki::dumps {
     cron { 'sterbalssundrystudieswiki':
         ensure   => present,
         command  => '/usr/bin/php /srv/mediawiki/w/maintenance/dumpBackups.php --wiki sterbalssundrystudieswiki --logs --full > /mnt/mediawiki-static/dumps/sterbalssundrystudieswiki.xml',

--- a/modules/mediawiki/manifests/dumps.pp
+++ b/modules/mediawiki/manifests/dumps.pp
@@ -4,7 +4,7 @@
 class mediawiki::dumps {
     cron { 'sterbalssundrystudieswiki':
         ensure   => present,
-        command  => '/usr/bin/php /srv/mediawiki/w/maintenance/dumpBackups.php --wiki sterbalssundrystudieswiki --logs --full > /mnt/mediawiki-static/dumps/sterbalssundrystudieswiki.xml',
+        command  => '/usr/bin/nice -n19 /usr/bin/php /srv/mediawiki/w/maintenance/dumpBackups.php --wiki sterbalssundrystudieswiki --logs --full > /mnt/mediawiki-static/dumps/sterbalssundrystudieswiki.xml',
         user     => 'www-data',
         minute   => absent,
         hour     => absent,

--- a/modules/mediawiki/manifests/dumps.pp
+++ b/modules/mediawiki/manifests/dumps.pp
@@ -2,9 +2,9 @@
 #
 # Cron jobs of select wiki dumps
 class mediawiki::cron {
-    cron { 'update_database_lists':
+    cron { 'sterbalssundrystudieswiki':
         ensure   => present,
-        command  => '/usr/bin/php /srv/mediawiki/w/maintenance/dumpBackups.php --wiki sterbalssundrystudieswiki --logs --full',
+        command  => '/usr/bin/php /srv/mediawiki/w/maintenance/dumpBackups.php --wiki sterbalssundrystudieswiki --logs --full > /mnt/mediawiki-static/dumps/sterbalssundrystudieswiki.xml',
         user     => 'www-data',
         minute   => absent,
         hour     => absent,

--- a/modules/mediawiki/manifests/init.pp
+++ b/modules/mediawiki/manifests/init.pp
@@ -9,6 +9,9 @@ class mediawiki {
     if hiera(jobrunner) {
         include mediawiki::jobrunner
     }
+    if hiera(mwdumps) {
+        include mediawiki::dumps
+    }
 
     file { [ '/srv/mediawiki', '/srv/mediawiki/dblist', '/srv/mediawiki/cdb-config', '/var/log/mediawiki' ]:
         ensure => 'directory',


### PR DESCRIPTION
Puppet class and implementation to make mw2 export static dumps of select wikis.