### PR TITLE
Require email verification

### DIFF
--- a/modules/phabricator/data/config.yaml
+++ b/modules/phabricator/data/config.yaml
@@ -16,6 +16,7 @@ metamta.single-reply-handler-prefix: 'phabricator'
 
 # Auth
 auth.require-approval: false
+auth.require-email-verification: true
 
 # Phabricator
 phabricator.show-prototypes: true


### PR DESCRIPTION
Ref [T1487](https://phabricator.miraheze.org/T1487). The user need to verify their email to get their email. It also shows black dots if email is not verified. Enforcing email verification requires additional steps for users but it makes sure user is notified of the change on the ticket.