### PR TITLE
move "sysadmin" to "staff"

### DIFF
--- a/modules/postfix/files/aliases
+++ b/modules/postfix/files/aliases
@@ -17,7 +17,7 @@ root: /dev/null
 
 # group aliases
 ops: operations
-sysadmin: operations
+sysadmin: staff
 
 # DMARC - potentially high volume, best recommended for mail admins on misc1
 dmarc: john


### PR DESCRIPTION
sysadmins include mw-admins and all staff are currently syadmins so I think it's better than redirecting them to operations