### PR TITLE
add CVT email

### DIFF
--- a/modules/postfix/files/aliases
+++ b/modules/postfix/files/aliases
@@ -25,6 +25,7 @@ dmarc: john
 operations: southparkfan,john,ndkilla
 stewards: southparkfan,ndkilla,john,orduinvoidwalker@gmail.com
 staff: southparkfan,ndkilla,john,bslaabs@gmail.com,utilizator.receptie123@gmail.com,imbophilmh@gmail.com,revi
+cvt: stewards,utilizator.receptie123@gmail.com,revi
 
 # finances
 donate: bslaabs@gmail.com,southparkfan,john


### PR DESCRIPTION
not sure how useful it is but if a lock is made by a CVT it should probably be discussed with them as well (not only with stewards)