### PR TITLE
@miraheze.org alias for all staff

### DIFF
--- a/modules/postfix/files/aliases
+++ b/modules/postfix/files/aliases
@@ -30,6 +30,12 @@ cvt: stewards,utilizator.receptie123@gmail.com,revi
 # finances
 donate: bslaabs@gmail.com,southparkfan
 
+# imbophil
+imbophil: imbophilmh@gmail.com
+
+# labster
+labster: bslaabs@gmail.com
+
 # southparkfan
 southparkfan: southparkfan223@hotmail.com
 
@@ -41,6 +47,9 @@ security: |/srv/phab/phabricator/scripts/mail/mail_handler.php,operations
 csr: |/srv/phab/phabricator/scripts/mail/mail_handler.php,operations
 phabricator: |/srv/phab/phabricator/scripts/mail/mail_handler.php
 bugs: |/srv/phab/phabricator/scripts/mail/mail_handler.php
+
+# reception123
+reception123: utilizator.receptie123@gmail.com
 
 # revi
 revi: revi@revi.wiki,revi@pobox.com

--- a/modules/postfix/files/aliases
+++ b/modules/postfix/files/aliases
@@ -30,15 +30,6 @@ cvt: stewards,utilizator.receptie123@gmail.com,revi
 # finances
 donate: bslaabs@gmail.com,southparkfan
 
-# imbophil
-imbophil: imbophilmh@gmail.com
-
-# labster
-labster: bslaabs@gmail.com
-
-# southparkfan
-southparkfan: southparkfan223@hotmail.com
-
 # apt changes list (temp. avoid upstream reputation issues with Hotmail)
 apt-list: ndkilla
 
@@ -48,8 +39,10 @@ csr: |/srv/phab/phabricator/scripts/mail/mail_handler.php,operations
 phabricator: |/srv/phab/phabricator/scripts/mail/mail_handler.php
 bugs: |/srv/phab/phabricator/scripts/mail/mail_handler.php
 
-# reception123
+# Staff aliases
+imbophil: imbophilmh@gmail.com
+labster: bslaabs@gmail.com
 reception123: utilizator.receptie123@gmail.com
-
-# revi
 revi: revi@revi.wiki,revi@pobox.com
+southparkfan: southparkfan223@hotmail.com
+


### PR DESCRIPTION
Discussed a bit in -staff with labster. I think that it is better (and more professional) if all staff have a @miraheze.org alias. It's currently a bit confusing that 3 sysadmins do have one, and 3 sysadmins don't.