### PR TITLE
Pull SSL cert on MariaDB

### DIFF
--- a/modules/mariadb/manifests/config.pp
+++ b/modules/mariadb/manifests/config.pp
@@ -69,4 +69,6 @@ class mariadb::config(
         description   => 'MySQL',
         check_command => 'check_mysql!icinga',
     }
+    
+    ssl::cert { 'wildcard.miraheze.org': }
 }

--- a/modules/mariadb/templates/config/root.my.cnf.erb
+++ b/modules/mariadb/templates/config/root.my.cnf.erb
@@ -5,4 +5,4 @@ socket=/var/run/mysqld/mysqld.sock
 
 #SSL
 ssl-cert=/etc/ssl/certs/wildcard.miraheze.org.crt
-ssl-key=/etc/ssl/private/wildcard.miraheze.org-nopass.key
+ssl-key=/etc/ssl/private/wildcard.miraheze.org.key


### PR DESCRIPTION
With the renew, the SSL cert on db2 won't be valid anymore.

db3 doesn't have the cert at all.

Will reduce noise on db3 in regards to SSL and prevent noise on db2 about an invalid certificate soon.

[MERGE ONLY NECESSARY] Services will not be restarted as root.my.cnf is a my.cnf in /root/ and is not used at all by MariaDB.