### PR TITLE
add transaction icon for stalled status on phab

### DIFF
--- a/modules/phabricator/data/config.yaml
+++ b/modules/phabricator/data/config.yaml
@@ -92,6 +92,7 @@ maniphest.statuses:
     name: 'Stalled'
     name.full: 'Open, Stalled'
     closed: false
+    transaction.icon: 'fa-spinner'
 
 # Disable some Phabricator applications
 phabricator.uninstalled-applications:


### PR DESCRIPTION
not important, but why not?