### PR TITLE
deprecate mediawiki-roots group

### DIFF
--- a/hieradata/hosts/mw1.yaml
+++ b/hieradata/hosts/mw1.yaml
@@ -1,5 +1,4 @@
 users::groups:
   - mediawiki-admins
-  - mediawiki-roots
 jobrunner: true
 contactgroups: 'ops,mediawiki'

--- a/hieradata/hosts/mw2.yaml
+++ b/hieradata/hosts/mw2.yaml
@@ -1,6 +1,5 @@
 users::groups:
   - mediawiki-admins
-  - mediawiki-roots
 jobrunner: false
 arcanist: true
 mwdumps: true

--- a/hieradata/hosts/test1.yaml
+++ b/hieradata/hosts/test1.yaml
@@ -1,5 +1,4 @@
 users::groups:
   - mediawiki-admins
-  - mediawiki-roots
 contactgroups: 'ops,mediawiki'
 mediawiki::branch: 'REL1_29'


### PR DESCRIPTION
Since /srv/mediawiki/config is now owned by www-data and most logs are
readable (if not they can be defined) I see no current use for keeping
the mw-roots group.