### PR TITLE
increase jobqueue threshold to 300

### DIFF
--- a/modules/mediawiki/files/jobrunner/check_jobqueue
+++ b/modules/mediawiki/files/jobrunner/check_jobqueue
@@ -6,11 +6,11 @@ do
         if [ ! $(echo "$count" | grep -E "^[0-9]+$") ]; then
                 echo "JOBQUEUE CRITICAL - check plugin (`basename $0`) or PHP errors"
                 exit 2
-        elif [ $count -gt 250 ]; then
-                echo "JOBQUEUE CRITICAL - job queue greater than 250 jobs. Current queue: $count"
+        elif [ $count -gt 300 ]; then
+                echo "JOBQUEUE CRITICAL - job queue greater than 300 jobs. Current queue: $count"
                 exit 2
         else
-                echo "JOBQUEUE OK - job queue below 250 jobs"
+                echo "JOBQUEUE OK - job queue below 300 jobs"
                 exit 0
         fi
 done < <( /usr/bin/php5 /srv/mediawiki/w/extensions/MirahezeMagic/maintenance/getJobQueueLengths.php --totalonly --wiki loginwiki)


### PR DESCRIPTION
We're getting many critical messages due to the jobqueue being over 250 many times. Since last time this was updated, we've expanded so it's normal to see more jobs.