### PR TITLE
rm non-automatic backups

### DIFF
--- a/modules/mediawiki/manifests/dumps.pp
+++ b/modules/mediawiki/manifests/dumps.pp
@@ -45,17 +45,7 @@ class mediawiki::dumps {
         month    => '*',
         monthday => ['1', '8', '15', '22', '29'],
     }
-
-    cron { 'Export icmscholarswiki xml dump every two weeks':
-        ensure   => present,
-        command  => '/usr/bin/nice -n19 /usr/bin/php /srv/mediawiki/w/maintenance/dumpBackup.php --wiki icmscholarswiki --logs --full > /home/reception/dumps/icmscholarswiki.xml',
-        user     => 'www-data',
-        minute   => '0',
-        hour     => '0',
-        month    => '*',
-        monthday => [ '15', '30'],
-    }
-
+    
     cron { 'Export jokowiki xml dump montly ':
         ensure   => present,
         command  => '/usr/bin/nice -n19 /usr/bin/php /srv/mediawiki/w/maintenance/dumpBackup.php --wiki jokowiki --logs --full > /mnt/mediawiki-static/dumps/jokowiki.xml',
@@ -114,16 +104,6 @@ class mediawiki::dumps {
         hour     => '0',
         month    => '*',
         monthday => ['15', '30'],
-    }
-
-    cron { 'Export scruffywiki xml dump weekly':
-        ensure   => present,
-        command  => '/usr/bin/nice -n19 /usr/bin/php /srv/mediawiki/w/maintenance/dumpBackup.php --wiki scruffywiki --logs --full > /home/reception/dumps/scruffywiki.xml',
-        user     => 'www-data',
-        minute   => '0',
-        hour     => '0',
-        month    => '*',
-        monthday => ['1', '8', '15', '22', '29'],
     }
 
     cron { 'Export speleowiki xml dump monthly':


### PR DESCRIPTION
There's no need to have automatic backups for a non-automatic process.

Until we set up a secure directory with a password/identification for individual dumps or find an automatic way to send via email these dumps are useless/unused.