### PR TITLE
remove double declaration of variable

### DIFF
--- a/modules/mediawiki/manifests/dumps.pp
+++ b/modules/mediawiki/manifests/dumps.pp
@@ -125,16 +125,6 @@ class mediawiki::dumps {
         month    => '*',
         monthday => ['1', '8', '15', '22', '29'],
     }
-    
-    cron { 'Export scruffywiki images weekly':
-        ensure   => present,
-        command  => '/usr/bin/zip -r /mnt/mediawiki-static/dumps/scruffywiki.zip /mnt/mediawiki-static/scruffywiki/',
-        user     => 'www-data',
-        minute   => '0',
-        hour     => '0',
-        month    => '*',
-        monthday => ['1', '8', '15', '22', '29'],
-    }
 
     cron { 'Export speleowiki xml dump monthly':
         ensure   => present,


### PR DESCRIPTION
Export scruffywiki images weekly is there twice (since both mine and the users PRs got merged, instead of just one). 
Causing mw2 puppet fail, please merge ASAP @NDKilla