### PR TITLE
Support using different puppet master host names

### DIFF
--- a/hieradata/hosts/test1.yaml
+++ b/hieradata/hosts/test1.yaml
@@ -1,6 +1,10 @@
 users::groups:
-  - mediawiki-admins
+  - puppet-users
 jobrunner: false
 contactgroups: 'ops,mediawiki'
 mediawiki::branch: 'REL1_30'
 puppetmaster_hostname: test1.miraheze.org
+puppetmaster: true
+puppetmaster::dbserver: db2.miraheze.org
+puppetmaster::dbuser: puppet
+puppetmaster::dbname: puppet

--- a/hieradata/hosts/test1.yaml
+++ b/hieradata/hosts/test1.yaml
@@ -3,3 +3,4 @@ users::groups:
 jobrunner: false
 contactgroups: 'ops,mediawiki'
 mediawiki::branch: 'REL1_30'
+puppetmaster_hostname: test1.miraheze.org

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -61,7 +61,7 @@ node 'puppet1.miraheze.org' {
 }
 node 'test1.miraheze.org' {
     include base
-    include role::mediawiki
+    include puppetmaster # Temporary for testing new Puppet version
 }
 
 # ensures all servers have basic class if puppet runs

--- a/modules/puppetmaster/manifests/init.pp
+++ b/modules/puppetmaster/manifests/init.pp
@@ -4,6 +4,9 @@ class puppetmaster(
     $dbname     = undef,
     $dbuser     = undef,
   ) {
+
+    $puppetmaster_hostname = hiera('puppetmaster_hostname', 'puppet1.miraheze.org')
+
     $packages = [
         'libmysqld-dev',
         'puppetmaster',

--- a/modules/puppetmaster/templates/puppet.conf
+++ b/modules/puppetmaster/templates/puppet.conf
@@ -4,7 +4,7 @@ vardir=/var/lib/puppet
 ssldir=/var/lib/puppet/ssl
 rundir=/var/run/puppet
 factpath=$vardir/lib/facter
-server=puppet1.miraheze.org
+server=<%= @puppetmaster_hostname %>
 
 [master]
 always_cache_features = true


### PR DESCRIPTION
The intention for this is to allow us to convert a test host into a puppetmaster to test some upcoming upgrades