### PR TITLE
Robots Improvement

### DIFF
--- a/modules/mediawiki/files/robots.txt
+++ b/modules/mediawiki/files/robots.txt
@@ -7,3 +7,7 @@ Disallow: /wiki/Special:
 # Throttle YandexBot
 User-Agent: YandexBot
 Crawl-Delay: 2.5
+
+# Allow the Internet Archiver to index action=raw and thereby store the raw wikitext of pages
+User-agent: ia_archiver
+Allow: /*&action=raw

--- a/modules/mediawiki/files/robots.txt
+++ b/modules/mediawiki/files/robots.txt
@@ -1,7 +1,7 @@
 # Disallow API and special pages
 User-Agent: *
-Disallow: /w/api.php
-Disallow: /w/index.php?title=Special:
+Allow: /w/load.php?
+Disallow: /w/
 Disallow: /wiki/Special:
 
 # Throttle YandexBot


### PR DESCRIPTION
Hi

Current robots.txt doesn't prevent search engines from indexing diffs or revisions. 

> spiders may try to index thousands of similar pages, overloading the webserver. [reference](https://www.mediawiki.org/wiki/Manual:Robots.txt#Prevent_indexing_of_non-article_pages)

e78c0c5 fixes that according to mediawiki's manual on robots.txt like other mediawiki farms.
[this](https://github.com/miraheze/puppet/compare/master...Mehran-Baghi:robots-improvement?expand=1#diff-294b0003d876502ab99f22e56cf95283R4) is equal to [this](https://github.com/miraheze/puppet/compare/master...Mehran-Baghi:robots-improvement?expand=1#diff-294b0003d876502ab99f22e56cf95283L3) and [this](https://github.com/miraheze/puppet/compare/master...Mehran-Baghi:robots-improvement?expand=1#diff-294b0003d876502ab99f22e56cf95283L4).

6cd3644 allows Internet Archive to <del>only</del> index raw wikitext of pages. I recommend this so in case of downtimes or lost we will have a redundant backup. [reference](https://www.mediawiki.org/wiki/Manual:Robots.txt#Allow_indexing_of_raw_pages_by_the_Internet_Archiver)
  
  