### PR TITLE
Set ssh to false (was empty string)

### DIFF
--- a/modules/git/manifests/clone.pp
+++ b/modules/git/manifests/clone.pp
@@ -13,7 +13,7 @@ define git::clone(
     $directory,
     $origin=undef,
     $branch='',
-    $ssh='',
+    $ssh=false,
     $ensure='present',
     $owner='root',
     $group='root',


### PR DESCRIPTION
In puppet 3 an empty string returned false, in puppet 4 it returns true, so lets set it to false explicity.