### PR TITLE
Change !defined to defined

### DIFF
--- a/modules/ssl/manifests/wildcard.pp
+++ b/modules/ssl/manifests/wildcard.pp
@@ -1,6 +1,6 @@
 # class: ssl::wildcard
 class ssl::wildcard {
-    if !defined(File['/etc/ssl/certs/wildcard.miraheze.org.crt']) {
+    if defined(File['/etc/ssl/certs/wildcard.miraheze.org.crt']) {
         file { '/etc/ssl/certs/wildcard.miraheze.org.crt':
             ensure => 'present',
             source => 'puppet:///ssl/certificates/wildcard.miraheze.org.crt',


### PR DESCRIPTION
This fixes an issue where it try to add the file again leading to puppet errors as you carn't do the same thing twice.