### PR TITLE
Use ${::lsbdistcodename} for apt::source nginx apt package

### DIFF
--- a/modules/nginx/manifests/init.pp
+++ b/modules/nginx/manifests/init.pp
@@ -5,7 +5,7 @@ class nginx {
     apt::source { 'nginx_apt':
         comment  => 'NGINX stable',
         location => 'http://nginx.org/packages/debian',
-        release  => 'jessie',
+        release  => "${::lsbdistcodename}",
         repos    => 'nginx',
         key      => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62',
     }


### PR DESCRIPTION
This is so nginx will install on jessie and stretch or any other debian os.