### PR TITLE
Add support for php 7.2+ in icinga and phabricator class

### DIFF
--- a/modules/phabricator/templates/php72.ini.erb
+++ b/modules/phabricator/templates/php72.ini.erb
@@ -1,0 +1,25 @@
+; Custom Miraheze config changes that overide the defaults in
+; /etc/php/7.2/apache2/php.ini
+[PHP]
+
+expose_php = Off
+
+max_execution_time = 30
+
+track_errors = Off
+
+post_max_size = 32M
+
+upload_max_filesize = 2M
+
+[mail function]
+
+mail.add_x_header = On
+
+[opcache]
+
+opcache.enable=1
+
+opcache.memory_consumption=52
+
+opcache.validate_timestamps=0


### PR DESCRIPTION
Phabricator requires php5 or php 7.1+.

Php 7.0 is not supported.