### PR TITLE
Add php module that installs php 7.2 on stretch and 5 on jessie

### DIFF
--- a/modules/icinga/manifests/init.pp
+++ b/modules/icinga/manifests/init.pp
@@ -5,6 +5,8 @@ class icinga(
 ) {
     include ::httpd
 
+    include ::php
+
     group { 'nagios':
         ensure    => present,
         name      => 'nagios',
@@ -33,26 +35,6 @@ class icinga(
     }
 
     if os_version('debian >= stretch') {
-        include ::apt
-
-        if !defined(Apt::Source['php72_apt']) {
-            apt::source { 'php72_apt':
-                comment  => 'PHP 7.2',
-                location => 'http://apt.wikimedia.org/wikimedia',
-                release  => "${::lsbdistcodename}-wikimedia",
-                repos    => 'thirdparty/php72',
-                key      => 'DB3DC2BD4CD504EF2D908FC509DBD9F93F6CD44A',
-                notify   => Exec['apt_update_php_icinga'],
-            }
-
-            # First installs can trip without this
-            exec {'apt_update_php_icinga':
-                command     => '/usr/bin/apt-get update',
-                refreshonly => true,
-                logoutput   => true,
-            }
-        }
-
         $php = '7.2'
     } else {
         $php = '5'

--- a/modules/phabricator/manifests/init.pp
+++ b/modules/phabricator/manifests/init.pp
@@ -5,63 +5,15 @@ class phabricator(
 ) {
     include ::httpd
 
+    include ::php
+
     if os_version('debian >= stretch') {
-        include ::apt
-
-        if !defined(Apt::Source['php72_apt']) {
-            apt::source { 'php72_apt':
-                comment  => 'PHP 7.2',
-                location => 'http://apt.wikimedia.org/wikimedia',
-                release  => "${::lsbdistcodename}-wikimedia",
-                repos    => 'thirdparty/php72',
-                key      => 'DB3DC2BD4CD504EF2D908FC509DBD9F93F6CD44A',
-                notify   => Exec['apt_update_php_phabricator'],
-            }
-
-            # First installs can trip without this
-            exec {'apt_update_php_phabricator':
-                command     => '/usr/bin/apt-get update',
-                refreshonly => true,
-                logoutput   => true,
-            }
-        }
-
         $php_version = '7.2'
-
-        $php_packages = [
-            'php-apcu',
-            'php-mailparse',
-            'php7.2-mysql',
-            'php7.2-gd',
-            'php7.2-dev',
-            'php7.2-curl',
-            'php7.2-cli',
-            'php7.2-json',
-            'php7.2-mbstring',
-            'libapache2-mod-php7.2',
-            'python-pygments',
-            'subversion',
-        ]
     } else {
         $php_version = '5'
-
-        $php_packages = [
-            'php5-apcu',
-            'php5-mysqlnd',
-            'php5-gd',
-            'php5-dev',
-            'php5-curl',
-            'php5-cli',
-            'php5-json',
-            'libapache2-mod-php5',
-            'python-pygments',
-            'subversion',
-        ]
     }
 
-    require_package($php_packages)
-
-    require_package(['python-pygments', 'subversion'])
+    require_package(["libapache2-mod-php${php_version}", 'python-pygments', 'subversion'])
 
     $password = hiera('passwords::irc::mirahezebots')
 

--- a/modules/php/manifests/init.pp
+++ b/modules/php/manifests/init.pp
@@ -1,0 +1,48 @@
+# class: php
+class php {
+    if os_version('debian >= stretch') {
+        include ::apt
+
+        if !defined(Apt::Source['php72_apt']) {
+            apt::source { 'php72_apt':
+                comment  => 'PHP 7.2',
+                location => 'http://apt.wikimedia.org/wikimedia',
+                release  => "${::lsbdistcodename}-wikimedia",
+                repos    => 'thirdparty/php72',
+                key      => 'DB3DC2BD4CD504EF2D908FC509DBD9F93F6CD44A',
+                notify   => Exec['apt_update_php'],
+            }
+
+            # First installs can trip without this
+            exec {'apt_update_php':
+                command     => '/usr/bin/apt-get update',
+                refreshonly => true,
+                logoutput   => true,
+            }
+        }
+
+        $php_packages = [
+            'php-apcu',
+            'php-mailparse',
+            'php7.2-mysql',
+            'php7.2-gd',
+            'php7.2-dev',
+            'php7.2-curl',
+            'php7.2-cli',
+            'php7.2-json',
+            'php7.2-mbstring',
+        ]
+    } else {
+        $php_packages = [
+            'php5-apcu',
+            'php5-mysql',
+            'php5-gd',
+            'php5-dev',
+            'php5-curl',
+            'php5-cli',
+            'php5-json',
+        ]
+    }
+    
+    require_package($php_packages)
+}


### PR DESCRIPTION
This should only be used with phabricator and icinga for now.

With plans to roll this out to other modules at later dates.