### PR TITLE
Add wildcard.miraheze.org.key key to postgresql ssl dir

### DIFF
--- a/modules/postgresql/files/ssl.conf
+++ b/modules/postgresql/files/ssl.conf
@@ -1,4 +1,4 @@
 ssl = on
 ssl_cert_file = '/etc/ssl/certs/wildcard.miraheze.org.crt'
-ssl_key_file = '/etc/ssl/private/wildcard.miraheze.org.key'
+ssl_key_file = '/etc/postgresql/9.6/main/ssl/wildcard.miraheze.org.key'
 ssl_ca_file  = '/etc/ssl/certs/GlobalSign.crt'

--- a/modules/postgresql/manifests/server.pp
+++ b/modules/postgresql/manifests/server.pp
@@ -79,9 +79,9 @@ class postgresql::server(
             source  => 'puppet:///ssl-keys/wildcard.miraheze.org.key',
             owner   => 'postgres',
             group   => 'postgres',
-            mode    => '0644',
+            mode    => '0600',
             require => File["${$data_dir}/ssl"],
-	    }
+	}
 
         file { "/etc/postgresql/${pgversion}/main/ssl.conf":
             ensure  => $ensure,

--- a/modules/postgresql/manifests/server.pp
+++ b/modules/postgresql/manifests/server.pp
@@ -68,6 +68,21 @@ class postgresql::server(
     if $use_ssl {
         include ssl::wildcard
 
+         file { "${$data_dir}/ssl":
+             ensure => directory,
+             owner  => 'postgres',
+             group  => 'postgres',
+         }
+
+        file { "${$data_dir}/ssl/wildcard.miraheze.org.key":
+            ensure  => 'present',
+            source  => 'puppet:///ssl-keys/wildcard.miraheze.org.key',
+            owner   => 'postgres',
+            group   => 'postgres',
+            mode    => '0644',
+            require => File["${$data_dir}/ssl"],
+	    }
+
         file { "/etc/postgresql/${pgversion}/main/ssl.conf":
             ensure  => $ensure,
             source  => 'puppet:///modules/postgresql/ssl.conf',
@@ -75,6 +90,7 @@ class postgresql::server(
             group   => 'root',
             mode    => '0444',
             before  => Service[$service_name],
+            require => File["${$data_dir}/ssl/wildcard.miraheze.org.key"],
         }
     }
 


### PR DESCRIPTION
there is permission errors when using the one from /etc/ssl so lets just fix this by adding it to postgresql dir.