### PR TITLE
Remove loading ssh_host_dsa_key

### DIFF
--- a/modules/ssh/templates/sshd_config.erb
+++ b/modules/ssh/templates/sshd_config.erb
@@ -4,7 +4,6 @@ Port <%= @listen_port %>
 Protocol 2
 # HostKeys for protocol version 2
 HostKey /etc/ssh/ssh_host_rsa_key
-HostKey /etc/ssh/ssh_host_dsa_key
 HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
 UsePrivilegeSeparation yes


### PR DESCRIPTION
OpenSSH the version in stretch disables dsa by default for security reasons.