### PR TITLE
Remove mathoid from misc3

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -43,7 +43,6 @@ node 'misc3.miraheze.org' {
     include base
     include role::parsoid
     include role::electron
-    include role::mathoid
     include role::restbase
     include role::salt::masters
     include role::salt::minions

--- a/modules/restbase/files/miraheze_project.yaml
+++ b/modules/restbase/files/miraheze_project.yaml
@@ -25,20 +25,22 @@ paths:
             /transform:
               x-modules:
                 - path: v1/transform.yaml
-            /media:
-               x-modules:
-                 - path: /etc/mediawiki/restbase/mathoid.yaml
-                   options: '{{options.mathoid}}'
+            # in case this is needed later, crossing out for now.
+            # /media:
+            #   x-modules:
+            #     - path: /etc/mediawiki/restbase/mathoid.yaml
+            #       options: '{{options.mathoid}}'
         options: '{{options}}'
 
   /{api:sys}:
     x-modules:
       - spec:
           paths:
-            /mathoid:
-              x-modules:
-                - path: sys/mathoid.js
-                  options: '{{options.mathoid}}'
+            # in case this is needed later, crossing out for now.
+            # /mathoid:
+            #  x-modules:
+            #    - path: sys/mathoid.js
+            #      options: '{{options.mathoid}}'
             /table: &sys_table
               x-modules:
                 - path: sys/table.js

--- a/modules/restbase/templates/config.yaml.erb
+++ b/modules/restbase/templates/config.yaml.erb
@@ -33,10 +33,11 @@ default_project: &default_project
           # XXX Check Parsoid URL!
           host: https://parsoid-lb.miraheze.org
           grace_ttl: 1
-        mathoid:
-           host: http://127.0.0.1:10044
-           # 10 days Varnish caching, one day client-side
-           cache-control: s-maxage=864000, max-age=86400
+        # in case this is needed later but for now cross out
+        # mathoid:
+        #   host: http://127.0.0.1:10044
+        #   # 10 days Varnish caching, one day client-side
+        #   cache-control: s-maxage=864000, max-age=86400
         table:
           backend: sqlite
           dbname: db.sqlite3


### PR DESCRIPTION
Now that we have mathoid on mw* locally we doin't need it running on misc3 aswell.