### PR TITLE
Retry ssl-acme up to 5 times

### DIFF
--- a/modules/acme/files/ssl-acme
+++ b/modules/acme/files/ssl-acme
@@ -62,22 +62,26 @@ WARNING)
             # blank message
         ;;
         HARD)
-                # Lets Renew here
-                git config --global core.sshCommand "ssh -i /var/lib/nagios/id_rsa -F /dev/null"
-                if [ ! -d /srv/ssl/ssl/ ]; then
-                  cd /srv/ssl/ && git clone git@github.com:miraheze/ssl.git
-                else
-                        cd /srv/ssl/ssl && git reset --hard origin/master && git pull
-                fi
-                git -C /srv/ssl/ssl/ config user.email "noreply@miraheze.org"
-                git -C /srv/ssl/ssl/ config user.name "MirahezeSSLBot"
-                sudo /root/ssl-certificate -r $URL > /srv/ssl/ssl/certificates/$URL.crt
-                sed -i "/Re-generating a new SSL cert for ${URL}/d" /srv/ssl/ssl/certificates/$URL.crt
-                sed -i "/LetsEncrypt certificate at: \/root\/ssl\/${URL}.crt/d" /srv/ssl/ssl/certificates/$URL.crt
-                git -C /srv/ssl/ssl add /srv/ssl/ssl/certificates/$URL.crt
-                git -C /srv/ssl/ssl/ commit -m "Bot: Update SSL cert for ${URL}"
-                git -C /srv/ssl/ssl/ push origin master
-                ;;
+                n=0
+                until [ $n -ge 5 ]
+                do
+                    # Lets Renew here
+                    git config --global core.sshCommand "ssh -i /var/lib/nagios/id_rsa -F /dev/null"
+                    if [ ! -d /srv/ssl/ssl/ ]; then
+                      cd /srv/ssl/ && git clone git@github.com:miraheze/ssl.git
+                    else
+                            cd /srv/ssl/ssl && git reset --hard origin/master && git pull
+                    fi
+                    git -C /srv/ssl/ssl/ config user.email "noreply@miraheze.org"
+                    git -C /srv/ssl/ssl/ config user.name "MirahezeSSLBot"
+                    sudo /root/ssl-certificate -r $URL > /srv/ssl/ssl/certificates/$URL.crt
+                    sed -i "/Re-generating a new SSL cert for ${URL}/d" /srv/ssl/ssl/certificates/$URL.crt
+                    sed -i "/LetsEncrypt certificate at: \/root\/ssl\/${URL}.crt/d" /srv/ssl/ssl/certificates/$URL.crt
+                    git -C /srv/ssl/ssl add /srv/ssl/ssl/certificates/$URL.crt
+                    git -C /srv/ssl/ssl/ commit -m "Bot: Update SSL cert for ${URL}"
+                    git -C /srv/ssl/ssl/ push origin master && break
+                    ;;
+                do
         esac
         ;;
 UNKNOWN)


### PR DESCRIPTION
This is to try and reduce race condition when alot of ssl certs need renewing thus all the checks are scheduled.