### PR TITLE
Remove dead link T3645

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains our production Puppet configuration. Contributions (see
 
 # Contributing
 
-Pull requests are welcome! Please read [contributing.md](.github/CONTRIBUTING.md) for more information!
+Pull requests are welcome!
 
 # Issues
 


### PR DESCRIPTION
This link is dead - I’m not sure if it has been relocated elsewhere or what, but having a dead link in the main README for an entire repo probably isn’t the best thing in the world.