### PR TITLE
Backup /mnt/mediawiki-static from lizardfs1

### DIFF
--- a/modules/bacula/templates/director/bacula-dir.conf
+++ b/modules/bacula/templates/director/bacula-dir.conf
@@ -93,57 +93,13 @@ Pool {
 }
 
 Pool {
-  Name = LizardFS-master
+  Name = Static
   Pool Type = Backup
-  Label Format = LIZARDFS-MASTER-
-  Recycle = yes
-  AutoPrune = yes
-  Volume Retention = 13 days
-  Maximum Volume Bytes = 5G
-  Maximum Volumes = 2
-}
-
-Pool {
-  Name = LizardFS-chunkserver
-  Pool Type = Backup
-  Label Format = LIZARDFS1-CHUNKSERVER-
-  Recycle = yes
-  AutoPrune = yes
-  Volume Retention = 13 days
-  Maximum Volume Bytes = 5G
-  Maximum Volumes = 2
-}
-
-Pool {
-  Name = LizardFS-chunkserver2
-  Pool Type = Backup
-  Label Format = LIZARDFS2-CHUNKSERVER-
-  Recycle = yes
-  AutoPrune = yes
-  Volume Retention = 13 days
-  Maximum Volume Bytes = 5G
-  Maximum Volumes = 2
-}
-
-Pool {
-  Name = Static1
-  Pool Type = Backup
-  Label Format = STATIC1-
+  Label Format = STATIC-
   Recycle = yes
   AutoPrune = yes
   Volume Retention = 27 days
-  Maximum Volume Bytes = 50G
-  Maximum Volumes = 2
-}
-
-Pool {
-  Name = Static2
-  Pool Type = Backup
-  Label Format = STATIC2-
-  Recycle = yes
-  AutoPrune = yes
-  Volume Retention = 27 days
-  Maximum Volume Bytes = 50G
+  Maximum Volume Bytes = 100G
   Maximum Volumes = 2
 }
 
@@ -191,17 +147,6 @@ FileSet {
   }
 }
 
-FileSet {
-  Name = "LizardFS"
-  Include {
-    Options {
-      signature = MD5
-      compression = GZIP
-    }
-    File = /var/lib/lizardfs
-  }
-}
-
 
 FileSet {
   Name = "Static"
@@ -210,7 +155,7 @@ FileSet {
       signature = MD5
       compression = GZIP
     }
-    File = /srv/mediawiki-static
+    File = /mnt/mediawiki-static
   }
 }
 
@@ -250,15 +195,6 @@ Client {
 Client {
   Name = lizardfs1-fd
   Address = lizardfs1.miraheze.org
-  FDPort = 9102
-  Catalog = Catalog
-  Password = <%= @password %>
-  AutoPrune = yes
-}
-
-Client {
-  Name = lizardfs2-fd
-  Address = lizardfs2.miraheze.org
   FDPort = 9102
   Catalog = Catalog
   Password = <%= @password %>
@@ -330,70 +266,10 @@ Job {
 }
 
 Job {
-  Name = "BackupLizardFSMaster"
-  JobDefs = "DefaultBackup"
-  Client = misc4-fd
-  Pool = LizardFS-master
-  FileSet = "LizardFS"
-  Schedule = "WeeklyCycle"
-}
-
-Job {
-  Name = "RestoreLizardFSMaster"
-  JobDefs = "DefaultRestore"
-  Client = misc4-fd
-  Pool = LizardFS-master
-  FileSet = "LizardFS"
-}
-
-Job {
-  Name = "BackupLizardFSChunkserver1"
+  Name = "BackupStatic"
   JobDefs = "DefaultBackup"
   Client = lizardfs1-fd
-  Pool = LizardFS-chunkserver
-  FileSet = "LizardFS"
-  Schedule = "WeeklyCycle"
-}
-
-Job {
-  Name = "RestoreLizardFSChunkserver1"
-  JobDefs = "DefaultRestore"
-  Client = lizardfs1-fd
-  Pool = LizardFS-chunkserver
-  FileSet = "LizardFS"
-}
-
-Job {
-  Name = "BackupLizardFSChunkserver2"
-  JobDefs = "DefaultBackup"
-  Client = lizardfs2-fd
-  Pool = LizardFS-chunkserver2
-  FileSet = "LizardFS"
-  Schedule = "WeeklyCycle"
-}
-
-Job {
-  Name = "RestoreLizardFSChunkserver2"
-  JobDefs = "DefaultRestore"
-  Client = lizardfs2-fd
-  Pool = LizardFS-chunkserver2
-  FileSet = "LizardFS"
-}
-
-Job {
-  Name = "BackupStaticLizardfs1"
-  JobDefs = "DefaultBackup"
-  Client = lizardfs1-fd
-  Pool = Static1
-  FileSet = "Static"
-  Schedule = "BiWeeklyCycle"
-}
-
-Job {
-  Name = "BackupStaticLizardfs2"
-  JobDefs = "DefaultBackup"
-  Client = lizardfs2-fd
-  Pool = Static2
+  Pool = Static
   FileSet = "Static"
   Schedule = "BiWeeklyCycle"
 }
@@ -402,15 +278,7 @@ Job {
   Name = "RestoreStaticLizardfs"
   JobDefs = "DefaultRestore"
   Client = lizardfs1-fd
-  Pool = Static1
-  FileSet = "Static"
-}
-
-Job {
-  Name = "RestoreStaticLizardfs2"
-  JobDefs = "DefaultRestore"
-  Client = lizardfs2-fd
-  Pool = Static2
+  Pool = Static
   FileSet = "Static"
 }
 

--- a/modules/bacula/templates/director/bacula-dir.conf
+++ b/modules/bacula/templates/director/bacula-dir.conf
@@ -275,7 +275,7 @@ Job {
 }
 
 Job {
-  Name = "RestoreStaticLizardfs"
+  Name = "RestoreStatic"
   JobDefs = "DefaultRestore"
   Client = lizardfs1-fd
   Pool = Static


### PR DESCRIPTION
Changes done in this patch:

* No longer backup the lizardfs master because if we need to restore everything because of corruption it's best to do it on a fresh master.

* No longer backup the lizardfs* /var/lib/lizardfs as it's pointless not much in there.

* Only backup /mnt/mediawiki-static on lizardfs1 so we can restore individual files.