### PR TITLE
Add Salt apt puppet class

### DIFF
--- a/modules/salt/manifests/apt.pp
+++ b/modules/salt/manifests/apt.pp
@@ -1,0 +1,24 @@
+class apt {
+    include ::apt
+
+    if !defined(Apt::Source['salt_apt']) {
+        apt::key { 'salt_key':
+          id     => '126C0D24BD8A2942CC7DF8AC7638D0442B90D010',
+          source => 'https://repo.saltstack.com/apt/debian/9/amd64/2018.3/SALTSTACK-GPG-KEY.pub',
+        }
+
+        apt::source { 'salt_apt':
+          location => 'http://repo.saltstack.com/apt/debian/9/amd64/2018.3',
+          release  => "${::lsbdistcodename}",
+          repos    => 'main',
+          notify   => Exec['apt_update_salt'],
+        }
+
+        # First installs can trip without this
+        exec {'apt_update_salt':
+            command     => '/usr/bin/apt-get update',
+            refreshonly => true,
+            logoutput   => true,
+        }
+    }
+}

--- a/modules/salt/manifests/master.pp
+++ b/modules/salt/manifests/master.pp
@@ -15,8 +15,12 @@ class salt::master(
     String $salt_module_roots = '/srv/salt/_modules',
     String $salt_returner_roots = '/srv/salt/_returners',
 ) {
+
+    include salt::apt
+
     package { 'salt-master':
-        ensure => 'installed',
+        ensure  => 'installed',
+        require => Apt::Source['salt_apt'],
     }
 
     service { 'salt-master':

--- a/modules/salt/manifests/minion.pp
+++ b/modules/salt/manifests/minion.pp
@@ -67,6 +67,7 @@ class salt::minion(
     # will start it with the correct settings
     package { 'salt-minion':
         ensure  => present,
+        require => Apt::Source['salt_apt'],
     }
 
     service { 'salt-minion':

--- a/modules/salt/manifests/minion.pp
+++ b/modules/salt/manifests/minion.pp
@@ -43,6 +43,8 @@ class salt::minion(
     String $id        = $::fqdn,
     Hash $grains    = {},
 ) {
+    include salt::apt
+
     $config = {
         id                  => $id,
         master              => $master,


### PR DESCRIPTION
This is to install the latest salt from upstream (as the one from debian is broken)