### PR TITLE
Add sudo rule for puppet-users

### DIFF
--- a/hieradata/hosts/mw1.yaml
+++ b/hieradata/hosts/mw1.yaml
@@ -1,5 +1,6 @@
 users::groups:
   - mediawiki-admins
+  - puppet-users
 jobrunner: false
 contactgroups: ['icingaadmins', 'ops', 'mediawiki']
 acme: false

--- a/modules/users/data/data.yaml
+++ b/modules/users/data/data.yaml
@@ -34,7 +34,7 @@ groups:
     gid: 2004
     descriptions: limited access on puppet1 to add SSL private keys
     members: [macfan]
-    privileges: ['ALL = (puppet-users) NOPASSWD: ALL']
+    privileges: ['ALL = (ALL) NOPASSWD: /home/puppet-users/ssl-keys']
 
 users:
   johnflewis:

--- a/modules/users/data/data.yaml
+++ b/modules/users/data/data.yaml
@@ -34,7 +34,7 @@ groups:
     gid: 2004
     descriptions: limited access on puppet1 to add SSL private keys
     members: [macfan]
-    privileges: []                 
+    privileges: ['ALL = (puppet-users) NOPASSWD: ALL']
 
 users:
   johnflewis:

--- a/modules/users/data/data.yaml
+++ b/modules/users/data/data.yaml
@@ -34,7 +34,8 @@ groups:
     gid: 2004
     descriptions: limited access on puppet1 to add SSL private keys
     members: [macfan]
-    privileges: ['ALL = (ALL) NOPASSWD: /home/puppet-users/ssl-keys']
+    privileges: ['ALL = (ALL) NOPASSWD: /home/puppet-users/ssl-keys',
+                 'ALL = (ALL) NIPASSWD: /etc/letsencrypt/live/*']
 
 users:
   johnflewis:


### PR DESCRIPTION
The repo is owned by puppet-users so this would allow puppet-users to touch it