### PR TITLE
Add vimrc.local to /etc/vim/vimrc.local

### DIFF
--- a/modules/base/files/environment/vimrc.local
+++ b/modules/base/files/environment/vimrc.local
@@ -1,0 +1,6 @@
+" Don't let defaults.vim clobber our settings here
+" which is, oddly, the default behavior
+let skip_defaults_vim = 1
+
+" Avoid cross-hairs mouse control
+set mouse=

--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -52,4 +52,12 @@ class base {
             values  => { 'vm.swappiness' => 1, },
         }
     }
+
+    # Global vim defaults
+    file { '/etc/vim/vimrc.local':
+        owner  => 'root',
+        group  => 'root',
+        mode   => '0444',
+        source => 'puppet:///modules/base/vimrc.local',
+    }
 }

--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -58,6 +58,6 @@ class base {
         owner  => 'root',
         group  => 'root',
         mode   => '0444',
-        source => 'puppet:///modules/base/vimrc.local',
+        source => 'puppet:///modules/base/environment/vimrc.local',
     }
 }


### PR DESCRIPTION
Will fix vim so we can copy text without having to do ":set mouse=r"