### PR TITLE
icinga: use correct http_vhost for phab and expect 200, not 500

### DIFF
--- a/modules/phabricator/manifests/init.pp
+++ b/modules/phabricator/manifests/init.pp
@@ -140,9 +140,9 @@ class phabricator {
     monitoring::services { 'phab.miraheze.wiki HTTPS':
         check_command => 'check_http',
         vars          => {
-            http_expect => 'HTTP/1.1 500 Internal Server Error',
+            http_expect => 'HTTP/1.1 200 OK',
             http_ssl    => true,
-            http_vhost  => 'phab.miraheze.wiki',
+            http_vhost  => 'phabricator.miraheze.org',
         },
      }
 


### PR DESCRIPTION
"This Phabricator install is configured as "https://phabricator.miraheze.org/",
but you are using the domain name "phab.miraheze.wiki" to access a page
which is trying to set a cookie..."

Do not expect/accept 500 as normal, that would be SNAFU.

Expect a 200 OK when using the actually configured http_vhost.