### PR TITLE
fix monitoring check for phab.miraheze.wiki

### DIFF
--- a/modules/phabricator/manifests/init.pp
+++ b/modules/phabricator/manifests/init.pp
@@ -140,9 +140,10 @@ class phabricator {
     monitoring::services { 'phab.miraheze.wiki HTTPS':
         check_command => 'check_http',
         vars          => {
-            http_expect => 'HTTP/1.1 500 Internal Server Error',
+            http_expect => 'HTTP/2 200',
             http_ssl    => true,
             http_vhost  => 'phab.miraheze.wiki',
+            http_uri    => 'https://phab.miraheze.wiki/file/data/b6eckvcmsmmjwe6gb2as/PHID-FILE-c6u44mun2axi3qq63u5t/ManageWiki-GH.png'
         },
      }
 


### PR DESCRIPTION
- use a full URI to an avatar that should not change
- then we can stop expecting a 500
- expect to get "HTTP/2 200" (what i get when testing with curl), actually HTTP/2  not 1.1 (wow?)