### PR TITLE
icinga: change http version from 2 to 1.1 for phab check

### DIFF
--- a/modules/phabricator/manifests/init.pp
+++ b/modules/phabricator/manifests/init.pp
@@ -140,7 +140,7 @@ class phabricator {
     monitoring::services { 'phab.miraheze.wiki HTTPS':
         check_command => 'check_http',
         vars          => {
-            http_expect => 'HTTP/2 200',
+            http_expect => 'HTTP/1.1 200',
             http_ssl    => true,
             http_vhost  => 'phab.miraheze.wiki',
             http_uri    => 'https://phab.miraheze.wiki/file/data/b6eckvcmsmmjwe6gb2as/PHID-FILE-c6u44mun2axi3qq63u5t/ManageWiki-GH.png'


### PR DESCRIPTION
18:13 < icinga-miraheze> PROBLEM - misc4 phab.miraheze.wiki HTTPS on misc4 is CRITICAL: HTTP CRITICAL - Invalid HTTP response received from host on port 443: HTTP/1.1 200 OK

18:21 < mutante> JohnLewis: paladox : i did HTTP/2 because i got that when i used curl 
