### PR TITLE
create a new defined type monitoring::wiki

### DIFF
--- a/modules/monitoring/manifests/wiki.pp
+++ b/modules/monitoring/manifests/wiki.pp
@@ -1,0 +1,24 @@
+define monitoring::wiki (
+    $ensure       = present,
+    $name         = undef,
+    $contacts     = hiera('contactgroups', [ 'icingaadmins', 'ops' ]),
+    $protocol     = 'https'
+    $domain       = 'miraheze.org',
+    $testpage     = 'Main_Page',
+    $http_version = '1.1',
+) {
+
+    $wikifqdn = "${name}.${domain}"
+    $testuri  = "${protocol}://${name}.${domain}/wiki/${testpage}"
+    $protocol_string = upcase($protocol)
+
+    monitoring::services {"${wikifqdn} ${protocol_string}":
+        check_command => 'check_http',
+        vars          => {
+            http_expect => "HTTP/${http_version} 200",
+            http_ssl    => true,
+            http_vhost  => $wikifqdn,
+            http_uri    => $testuri,
+        },
+    }
+}


### PR DESCRIPTION
This is a new defined type to make it simple to add monitoring for Miraheze user wikis.

The only mandatory parameter will be the name of any Miraheze wiki.  In the simplest form just a one line will be needed such as:

monitoring::wiki { 's23': }

to add an Icinga2 monitoring check for https://s23.miraheze.org/wiki/Main_Page

The test page defaults to Main_Page but can be adjusted.

Protocol and domain default to https and miraheze.org but can be adjusted.

The HTTP version defaults to 1.1 and can be changed to 2 if needed.

Note that "upcase" from stdlib is used to get the uppercase "HTTPS" in the Icinga monitoring output.

Because this is a defined type it can be used with an array to iterate over.  So the idea is to follow-up with a profile class that uses this and simply has an array with names of wikis and adding monitoring will be super easy.