### PR TITLE
NEEDS OPS OPINIONS promote macfan to admin in icingaweb2

### DIFF
--- a/modules/icingaweb2/templates/roles.ini.erb
+++ b/modules/icingaweb2/templates/roles.ini.erb
@@ -1,8 +1,8 @@
 [Administrators]
-users = "paladox, johnflewis, ndkilla, reception, southparkfan"
+users = "paladox, johnflewis, ndkilla, reception, southparkfan, MacFan4000"
 permissions = "*"
 groups = "Administrators"
 
 [guest]
-users = "guest, MacFan4000, Voidwalker"
+users = "guest, Voidwalker"
 permissions = "module/doc, module/monitoring, module/translation"


### PR DESCRIPTION
Per paladox message on IRC this will need OP opinions @JohnFLewis @paladox @NDKilla @Reception123 @Southparkfan

Also note that I’m familiar with icingaweb2 since I currently run an instance of it

AFAIK the only reason why mw-admins never had accounts before was because it required a shell account on misc1