### PR TITLE
jobrunner: Split some jobs out so it has a dedicated process for that job

### DIFF
--- a/modules/mediawiki/templates/jobrunner.json.erb
+++ b/modules/mediawiki/templates/jobrunner.json.erb
@@ -1,52 +1,85 @@
 // Configuration file for MediaWiki Jobrunner
 // This file is managed by Puppet
 {
-        "groups": {
-            "basic": {
-                // Number of runner processes in this group
-                "runners": 2,
-                // Job types to include ("*" means "all")
-                "include": [
-                    "*"
-                ],
-                // Job types to exempt (useful when combined with "*")
-                "exclude": [
-                    "webVideoTranscode"
-                ]
-            }
-        },
-        "limits": {
-            // How many times to let jobs be recycled before abandoning
-            "attempts": {
-                "*": 2
-            },
-            // How long jobs can be claimed before being recycled
-            "claimTTL": {
-                "*": 3600
-            },
-            // runJobs.php process time limits
-            "real": {
-                "*": 120
-            },
-            // runJobs.php memory limits
-            "memory": {
-                "*": "128M"
-            }
-        },
-        "redis": {
-            // Ready queue trackers
-            "aggregators": [
-                "81.4.127.174:6379"
+    "groups": {
+        "basic": {
+            // Number of runner processes in this group
+            "runners": 1,
+            // Job types to include ("*" means "all")
+            "include": [
+                "*"
             ],
-            // Main queue servers
-            "queues": [
-                "81.4.127.174:6379"
+            // Job types to exempt (useful when combined with "*")
+            "exclude": [
+                "AssembleUploadChunks",
+                "LocalGlobalUserPageCacheUpdateJob",
+                "ParsoidCacheUpdateJobOnDependencyChange",
+                "ParsoidCacheUpdateJobOnEdit",
+                "PublishStashedFile",
+                "uploadFromUrl",
+                "webVideoTranscode"
             ],
-            "password": "<%= @redis_password %>"
+            "low-priority": [
+                "htmlCacheUpdate",
+                "refreshLinks"
+            ]
         },
-        // Address to send statsd metrics to
-        "statsd": "",
+        "GUP": {
+            "runners": 0,
+            "low-priority": [
+                "LocalGlobalUserPageCacheUpdateJob"
+            ]
+        }
+        "parsoid": {
+            "runners": 0,
+            "include": [
+                "ParsoidCacheUpdateJobOnEdit"
+            ],
+            "low-priority": [
+                "ParsoidCacheUpdateJobOnDependencyChange"
+            ]
+        },
+        "upload": {
+            "runners": 0,
+            "include": [
+                "AssembleUploadChunks",
+                "PublishStashedFile",
+                "uploadFromUrl"
+            ]
+        }
+    },
+    "limits": {
+        // How many times to let jobs be recycled before abandoning
+        "attempts": {
+            "*": 2
+        },
+        // How long jobs can be claimed before being recycled
+        "claimTTL": {
+            "*": 3600
+        },
+        // runJobs.php process time limits
+        "real": {
+            "*": 130
+        },
+        // runJobs.php memory limits
+        "memory": {
+            "*": "200M"
+        }
+    },
+    "redis": {
+        // Ready queue trackers
+        "aggregators": [
+            "81.4.127.174:6379"
+        ],
+        // Main queue servers
+        "queues": [
+            "81.4.127.174:6379"
+        ],
+        "password": "<%= @redis_password %>"
+    },
+    // Address to send statsd metrics to
+    "statsd": "",
 
-        // Command used to launch a runner for a given job queue
-        "dispatcher": "nice -15 php /srv/mediawiki/w/maintenance/runJobs.php --wiki=%(db)x --type=%(type)x --maxtime=%(maxtime)x --memory-limit=%(maxmem)x --result=json"
+    // Command used to launch a runner for a given job queue
+    "dispatcher": "nice -15 php /srv/mediawiki/w/maintenance/runJobs.php --wiki=%(db)x --type=%(type)x --maxtime=%(maxtime)x --memory-limit=%(maxmem)x --result=json"
 }


### PR DESCRIPTION
This may help alleviate the problem with the jobrunner when for example "LocalGlobalUserPageCacheUpdateJob" piles up. The job runner will be able to process other jobs too thus won't be stuck on LocalGlobalUserPageCacheUpdateJob.

Also increase memory to 200M