### PR TITLE
make host monitoring work also on non-containers again

### DIFF
--- a/modules/monitoring/manifests/hosts.pp
+++ b/modules/monitoring/manifests/hosts.pp
@@ -1,8 +1,16 @@
 define monitoring::hosts (
     $ensure   = present,
-    $ip       = $facts['virtual_ip_address'],
     $contacts = hiera('contactgroups', [ 'icingaadmins', 'ops' ]),
 ) {
+
+   # If on a container instead of a physical machine or real VM,
+    # use the custom fact to get the IP.
+    if $facts['virtual'] == 'openvz' {
+        $ip = $facts['virtual_ip_address'],
+    } else {
+        $ip = $facts['ipaddress'],
+    }
+
     @@icinga2::object::host { $title:
         ensure  => $ensure,
         import  => ['generic-host'],


### PR DESCRIPTION
In #951 support for openvz containers was added where you have to use a custom fact to get the virtual IP address. This removed support for regular non-containers though where the regular ipaddress fact should be used. Make the module flexible to support both.