### PR TITLE
create new profile for monitoring of user wikis

### DIFF
--- a/modules/profile/manifests/wiki_monitoring.pp
+++ b/modules/profile/manifests/wiki_monitoring.pp
@@ -1,0 +1,9 @@
+# monitoring for user wikis
+class profile::wiki_monitoring {
+
+    # to add a wiki to monitoring just add the short name to this array
+    $monitored_wikis = [ 'meta', 's23' ]
+
+    monitoring::wiki { $monitored_wikis: }
+
+}


### PR DESCRIPTION
use the new defined type created in #946 to add monitoring for the meta wiki and s23 wiki. use a a defined type and array to iterate over so code does not have to be repeated and it's really easy to add more wikis