### PR TITLE
include profile::wiki_monitoring and fix syntax errors

### DIFF
--- a/modules/monitoring/manifests/hosts.pp
+++ b/modules/monitoring/manifests/hosts.pp
@@ -6,9 +6,9 @@ define monitoring::hosts (
    # If on a container instead of a physical machine or real VM,
     # use the custom fact to get the IP.
     if $facts['virtual'] == 'openvz' {
-        $ip = $facts['virtual_ip_address'],
+        $ip = $facts['virtual_ip_address']
     } else {
-        $ip = $facts['ipaddress'],
+        $ip = $facts['ipaddress']
     }
 
     @@icinga2::object::host { $title:

--- a/modules/role/manifests/icinga2.pp
+++ b/modules/role/manifests/icinga2.pp
@@ -5,7 +5,8 @@ class role::icinga2 {
     }
 
     include ::profile::icinga2::main
-
+    include ::profile::wiki_monitoring
+    
     ensure_resource_duplicate('ufw::allow', 'http', {'proto' => 'tcp', 'port' => '80'})
 
     ensure_resource_duplicate('ufw::allow', 'https', {'proto' => 'tcp', 'port' => '443'})


### PR DESCRIPTION
fix the syntax errors spotted by Papaul and actually include the class in the Icinga role