### PR TITLE
Fix installing luasandbox

### DIFF
--- a/modules/mediawiki/manifests/packages.pp
+++ b/modules/mediawiki/manifests/packages.pp
@@ -13,6 +13,7 @@ class mediawiki::packages {
         'libav-tools',
         'libvips-tools',
         'lilypond',
+        'php-luasandbox',
         'poppler-utils',
         'python-pip',
         'netpbm',

--- a/modules/php/manifests/php_fpm.pp
+++ b/modules/php/manifests/php_fpm.pp
@@ -85,7 +85,7 @@ class php::php_fpm(
             priority => 10,
     }
 
-    require_package('php-luasandbox', 'php-mail', 'php-mailparse', 'php-pear')
+    require_package('php-mail', 'php-mailparse', 'php-pear')
 
     # XML
     php::extension{ [


### PR DESCRIPTION
1. It’s only needed for MediaWiki
2. As far as I can tell the reason it isn’t working is because the INI file isn’t present

I can verify that luasandbox does indeed work with PHP 7.3 so that shouldn’t be an issue