### PR TITLE
Spread backups across multiple files

### DIFF
--- a/modules/bacula/templates/director/bacula-dir.conf
+++ b/modules/bacula/templates/director/bacula-dir.conf
@@ -88,8 +88,8 @@ Pool {
   Recycle = yes
   AutoPrune = yes
   Volume Retention = 27 days
-  Maximum Volume Bytes = 40G
-  Maximum Volumes = 10
+  Maximum Volume Bytes = 5G
+  Maximum Volumes = 80
 }
 
 Pool {
@@ -99,8 +99,8 @@ Pool {
   Recycle = yes
   AutoPrune = yes
   Volume Retention = 27 days
-  Maximum Volume Bytes = 40G
-  Maximum Volumes = 6
+  Maximum Volume Bytes = 5G
+  Maximum Volumes = 50
 }
 
 Pool {
@@ -110,8 +110,8 @@ Pool {
   Recycle = yes
   AutoPrune = yes
   Volume Retention = 27 days
-  Maximum Volume Bytes = 10G
-  Maximum Volumes = 2
+  Maximum Volume Bytes = 5G
+  Maximum Volumes = 4
 }
 
 Pool {


### PR DESCRIPTION
This spreads db4 so that it's 5x80 (5gb each file)

Same for static 5x50 (5gb each file)