### PR TITLE
Add a check to check for 1% of the disk

### DIFF
--- a/modules/base/templates/icinga/nrpe.cfg.erb
+++ b/modules/base/templates/icinga/nrpe.cfg.erb
@@ -15,6 +15,7 @@ connection_timeout=300
 
 # Simplify config with puppet
 command[check_disk]=/usr/lib/nagios/plugins/check_disk -w 20% -c 10% -p /
+command[check_disk_1_percent]=/usr/lib/nagios/plugins/check_disk -w 5% -c 1% -p /
 command[check_load]=/usr/lib/nagios/plugins/check_load -w <%= scope.lookupvar('::virtual_processor_count').to_i * 1.7 %> -c <%= scope.lookupvar('::virtual_processor_count').to_i * 2.0 %>
 command[check_puppet_run]=/usr/bin/sudo /usr/lib/nagios/plugins/check_puppet_run -w 3600 -c 43200
 command[check_varnishbackends]=/usr/bin/sudo /usr/lib/nagios/plugins/check_varnishbackends

--- a/modules/mariadb/manifests/config.pp
+++ b/modules/mariadb/manifests/config.pp
@@ -94,7 +94,7 @@ class mariadb::config(
     monitoring::services { 'Disk Space 1% left':
         check_command => 'nrpe',
         vars          => {
-            nrpe_command => 'check_disk_5_percent',
+            nrpe_command => 'check_disk_1_percent',
         },
     }
 

--- a/modules/mariadb/manifests/config.pp
+++ b/modules/mariadb/manifests/config.pp
@@ -91,6 +91,13 @@ class mariadb::config(
         notify => Exec['mariadb reload systemd'],
     }
 
+    monitoring::services { 'Disk Space 1% left':
+        check_command => 'nrpe',
+        vars          => {
+            nrpe_command => 'check_disk_5_percent',
+        },
+    }
+
     monitoring::services { 'MySQL':
         check_command => 'mysql',
         vars          => {


### PR DESCRIPTION
DB4 has been running out of space lately due to the build up of bin logs files. But because it's gone passed 10% left, we are not notified.

Adding another check for 1% left will make sure we will be able to respond quickly before db4 goes down.

Bug: T4444