### PR TITLE
jobrunner: Temporarily remove monitoring for JobQueue

### DIFF
--- a/modules/mediawiki/manifests/jobrunner.pp
+++ b/modules/mediawiki/manifests/jobrunner.pp
@@ -112,6 +112,7 @@ class mediawiki::jobrunner {
     }
 
     monitoring::services { 'JobQueue':
+        ensure        => absent,
         check_command => 'nrpe',
         vars          => {
             nrpe_command => 'check_jobqueue',


### PR DESCRIPTION
It currently does not work and is causing a ton of exceptions in mw3 log.