### PR TITLE
nginx: Introduce nginx_worker_processes with the default set at auto

### DIFF
--- a/hieradata/hosts/cp2.yaml
+++ b/hieradata/hosts/cp2.yaml
@@ -1,2 +1,3 @@
 users::groups: cache-admins
 vpncloud::server_ip: 10.0.1.9
+nginx::worker_processes: 4

--- a/hieradata/hosts/cp3.yaml
+++ b/hieradata/hosts/cp3.yaml
@@ -1,1 +1,2 @@
 vpncloud::server_ip: 10.0.1.4
+nginx::worker_processes: 4

--- a/hieradata/hosts/cp4.yaml
+++ b/hieradata/hosts/cp4.yaml
@@ -1,2 +1,3 @@
 users::groups: cache-admins
 vpncloud::server_ip: 10.0.1.10
+nginx::worker_processes: 4

--- a/hieradata/hosts/mw1.yaml
+++ b/hieradata/hosts/mw1.yaml
@@ -8,3 +8,4 @@ role::mediawiki::use_strict_firewall: false
 vpncloud::server_ip: 10.0.1.7
 mediawiki::branch: 'REL1_33'
 php::php_fpm::fpm_workers_multiplier: 2.0
+nginx::worker_processes: 8

--- a/hieradata/hosts/mw2.yaml
+++ b/hieradata/hosts/mw2.yaml
@@ -7,3 +7,4 @@ role::mediawiki::use_strict_firewall: false
 vpncloud::server_ip: 10.0.1.8
 mediawiki::branch: 'REL1_33'
 php::php_fpm::fpm_workers_multiplier: 2.0
+nginx::worker_processes: 8

--- a/hieradata/hosts/mw3.yaml
+++ b/hieradata/hosts/mw3.yaml
@@ -6,3 +6,4 @@ role::mediawiki::use_strict_firewall: false
 vpncloud::server_ip: 10.0.1.9
 mediawiki::branch: 'REL1_33'
 php::php_fpm::fpm_workers_multiplier: 2.0
+nginx::worker_processes: 8

--- a/modules/nginx/manifests/init.pp
+++ b/modules/nginx/manifests/init.pp
@@ -1,5 +1,7 @@
 # nginx
-class nginx {
+class nginx (
+    Variant[String, Integer] $nginx_worker_processes = hiera('nginx::worker_processes', 'auto'),
+) {
     include ::apt
 
     apt::source { 'nginx_apt':

--- a/modules/nginx/templates/nginx.conf.erb
+++ b/modules/nginx/templates/nginx.conf.erb
@@ -1,5 +1,9 @@
 user www-data;
+<% if @nginx_worker_processes != 'auto' %>
+worker_processes <%= @nginx_worker_processes %>;
+<% else %>
 worker_processes <%= scope.lookupvar('::virtual_processor_count') %>;
+<% end %>
 pid /run/nginx.pid;
 worker_rlimit_nofile 16192; # Twice the number of worker_connections
 

--- a/modules/nginx/templates/nginx.conf.erb
+++ b/modules/nginx/templates/nginx.conf.erb
@@ -18,7 +18,7 @@ http {
     sendfile on;
     tcp_nopush on;
     tcp_nodelay on;
-    keepalive_timeout 90;
+    keepalive_timeout 30;
     client_max_body_size 250M;
 
     include /etc/nginx/mime.types;


### PR DESCRIPTION
Here's what's included:

* cp* set nginx::worker_processes to 4.
* mw* set nginx::worker_processes to 8.
* Reduce keep alive to 30. It was way to high. We doin't want to keep the connection to the same server for too long.