### PR TITLE
gluster: Add secure-access file

### DIFF
--- a/modules/gluster/files/secure-access
+++ b/modules/gluster/files/secure-access
@@ -1,0 +1,1 @@
+option transport.socket.ssl-cert-depth 2

--- a/modules/gluster/files/secure-access
+++ b/modules/gluster/files/secure-access
@@ -1,6 +1,3 @@
 option transport.socket.ssl-enabled on
-option transport.socket.ssl-own-cert /etc/ssl/certs/wildcard.miraheze.org.crt
-option transport.socket.ssl-private-key /etc/ssl/private/wildcard.miraheze.org.key
-option transport.socket.ssl-ca-list /etc/ssl/certs/Sectigo.crt
 option transport.socket.ssl-cert-depth 2
 option transport.socket.ssl-cipher-list 'HIGH:!SSLv2:!SSLv3:!TLSv1:!TLSv1.1:TLSv1.2:TLSv1.3:!3DES:!RC4:!aNULL:!ADH'

--- a/modules/gluster/files/secure-access
+++ b/modules/gluster/files/secure-access
@@ -1,1 +1,5 @@
+option transport.socket.ssl-enabled on
+option transport.socket.ssl-own-cert /etc/ssl/private/wildcard.miraheze.org.crt
+option transport.socket.ssl-private-key /etc/ssl/private/wildcard.miraheze.org.key
+option transport.socket.ssl-ca-list /etc/ssl/certs/Sectigo.crt
 option transport.socket.ssl-cert-depth 2

--- a/modules/gluster/files/secure-access
+++ b/modules/gluster/files/secure-access
@@ -1,5 +1,6 @@
 option transport.socket.ssl-enabled on
-option transport.socket.ssl-own-cert /etc/ssl/private/wildcard.miraheze.org.crt
+option transport.socket.ssl-own-cert /etc/ssl/certs/wildcard.miraheze.org.crt
 option transport.socket.ssl-private-key /etc/ssl/private/wildcard.miraheze.org.key
 option transport.socket.ssl-ca-list /etc/ssl/certs/Sectigo.crt
 option transport.socket.ssl-cert-depth 2
+option transport.socket.ssl-cipher-list 'HIGH:!SSLv2:!SSLv3:!TLSv1:!TLSv1.1:TLSv1.2:TLSv1.3:!3DES:!RC4:!aNULL:!ADH'

--- a/modules/gluster/manifests/init.pp
+++ b/modules/gluster/manifests/init.pp
@@ -43,7 +43,7 @@ class gluster {
     if !defined(File['/var/lib/glusterd/secure-access']) {
         file { '/var/lib/glusterd/secure-access':
             ensure  => present,
-            content => 'option transport.socket.ssl-cert-depth 2',
+            source  => 'puppet:///modules/gluster/secure-access',
             require => Package['glusterfs-server'],
         }
     }

--- a/modules/gluster/manifests/mount.pp
+++ b/modules/gluster/manifests/mount.pp
@@ -154,7 +154,7 @@ define gluster::mount (
   if !defined(File['/var/lib/glusterd/secure-access']) {
     file { '/var/lib/glusterd/secure-access':
       ensure  => present,
-      content => 'option transport.socket.ssl-cert-depth 2',
+      source  => 'puppet:///modules/gluster/secure-access',
       require => Package['glusterfs-client'],
     }
   }


### PR DESCRIPTION
What this does is:

* Sets ssl certificate, CA and private key instead of using a default file.

* Sets ssl-cert-depth to 2.