### PR TITLE
mediawiki: Make fpm_min_restart_threshold configurable

### DIFF
--- a/hieradata/hosts/lizardfs6.yaml
+++ b/hieradata/hosts/lizardfs6.yaml
@@ -13,4 +13,5 @@ php::php_version: '7.3'
 jobrunner: true
 role::mediawiki::use_strict_firewall: false
 mediawiki::branch: 'REL1_34'
-mediawiki::php::fpm::childs: 40
+mediawiki::php::fpm::childs: 48
+mediawiki::php::fpm::fpm_min_restart_threshold: 32

--- a/modules/mediawiki/manifests/php.pp
+++ b/modules/mediawiki/manifests/php.pp
@@ -1,6 +1,7 @@
 # mediawiki::php
 class mediawiki::php (
     $php_fpm_childs = hiera('mediawiki::php::fpm::childs', 8),
+    $fpm_min_restart_threshold = hiera('mediawiki::php::fpm::fpm_min_restart_threshold', 6),
     $php_version = hiera('php::php_version', '7.2'),
     Optional[Boolean] $use_tideways = undef,
 ) {
@@ -31,7 +32,7 @@ class mediawiki::php (
             'request_terminate_timeout_track_finished' => 'yes',
         },
         'fpm_min_child' => $php_fpm_childs,
-        'fpm_min_restart_threshold' => 6,
+        'fpm_min_restart_threshold' => $fpm_min_restart_threshold,
         'version' => $php_version
     })
 


### PR DESCRIPTION
Also increase fpm_min_restart_threshold to 32 for lizardfs6