### PR TITLE
mariadb: Switch on threads pool

### DIFF
--- a/modules/mariadb/templates/config/mw.cnf.erb
+++ b/modules/mariadb/templates/config/mw.cnf.erb
@@ -44,13 +44,28 @@ local_infile                   = 0
 
 tmp-table-size                 = 12M
 max-heap-table-size            = 12M
-query-cache-type               = 0
-query-cache-size               = 0
 max-connections                = <%= @max_connections %>
 thread-cache-size              = 100
 open-files-limit               = 65535
 table-definition-cache         = 800
 table-open-cache               = 800
+
+
+# thread and connection handling
+thread_handling                = pool-of-threads
+<% if @server_role == 'master' %>
+thread_pool_stall_limit        = 10
+<% else %>
+thread_pool_stall_limit        = 100
+<% end %>
+thread_pool_size               = <%= @processorcount %>
+thread_pool_max_threads        = 2000
+back_log                       = 500
+extra_max_connections          = 10
+query-cache-type               = 0
+query-cache-size               = 0
+interactive_timeout            = 28800
+wait_timeout                   = 3600
 
 innodb-flush-method            = O_DIRECT
 innodb-log-files-in-group      = 2

--- a/modules/mariadb/templates/config/mw.cnf.erb
+++ b/modules/mariadb/templates/config/mw.cnf.erb
@@ -63,11 +63,17 @@ thread_pool_size               = <%= @processorcount %>
 <% end -%>
 thread_pool_max_threads        = 2000
 back_log                       = 500
+# For port 3307
+# https://github.com/wikimedia/puppet/commit/7927ece6f1c77b2279d3c84c23e90c207261c639
 extra_max_connections          = 10
 query-cache-type               = 0
 query-cache-size               = 0
 thread-cache-size              = 150
+# 8 hours timeout
+# Default 28800 (8 hours)
 interactive_timeout            = 28800
+# 1 hour timeout
+# Default 28800 (8 hours)
 wait_timeout                   = 3600
 
 innodb-flush-method            = O_DIRECT

--- a/modules/mariadb/templates/config/mw.cnf.erb
+++ b/modules/mariadb/templates/config/mw.cnf.erb
@@ -45,7 +45,6 @@ local_infile                   = 0
 tmp-table-size                 = 12M
 max-heap-table-size            = 12M
 max-connections                = <%= @max_connections %>
-thread-cache-size              = 100
 open-files-limit               = 65535
 table-definition-cache         = 1000
 table-open-cache               = 1000
@@ -67,6 +66,7 @@ back_log                       = 500
 extra_max_connections          = 10
 query-cache-type               = 0
 query-cache-size               = 0
+thread-cache-size              = 150
 interactive_timeout            = 28800
 wait_timeout                   = 3600
 

--- a/modules/mariadb/templates/config/mw.cnf.erb
+++ b/modules/mariadb/templates/config/mw.cnf.erb
@@ -60,13 +60,7 @@ back_log                       = 500
 extra_max_connections          = 10
 query-cache-type               = 0
 query-cache-size               = 0
-thread-cache-size              = 150
-# 8 hours timeout
-# Default 28800 (8 hours)
-interactive_timeout            = 28800
-# 1 hour timeout
-# Default 28800 (8 hours)
-wait_timeout                   = 3600
+thread-cache-size              = 100
 
 innodb-flush-method            = O_DIRECT
 innodb-log-files-in-group      = 2

--- a/modules/mariadb/templates/config/mw.cnf.erb
+++ b/modules/mariadb/templates/config/mw.cnf.erb
@@ -51,11 +51,7 @@ table-open-cache               = 1000
 
 # thread and connection handling
 thread_handling                = pool-of-threads
-<% if @server_role == 'master' -%>
 thread_pool_stall_limit        = 10
-<% else -%>
-thread_pool_stall_limit        = 100
-<% end -%>
 thread_pool_size               = 32
 thread_pool_max_threads        = 2000
 back_log                       = 500

--- a/modules/mariadb/templates/config/mw.cnf.erb
+++ b/modules/mariadb/templates/config/mw.cnf.erb
@@ -56,11 +56,7 @@ thread_pool_stall_limit        = 10
 <% else -%>
 thread_pool_stall_limit        = 100
 <% end -%>
-<% if Integer(@processorcount) <= 32 -%>
 thread_pool_size               = 32
-<% else -%>
-thread_pool_size               = <%= @processorcount %>
-<% end -%>
 thread_pool_max_threads        = 2000
 back_log                       = 500
 # For port 3307

--- a/modules/mariadb/templates/config/mw.cnf.erb
+++ b/modules/mariadb/templates/config/mw.cnf.erb
@@ -32,11 +32,11 @@ log-bin                        = <%= @datadir %>/mysql-bin
 <% if @server_role == 'slave' %>
 relay-log                      = /var/log/mysql/mysql-relay-bin.log
 <% end %>
-<% if @server_role == 'master' %>
+<% if @server_role == 'master' -%>
 expire-logs-days               = 4
-<% else %>
+<% else -%>
 expire-logs-days               = 2
-<% end %>
+<% end -%>
 sync-binlog                    = 1
 slave_compressed_protocol      = 1
 
@@ -47,18 +47,21 @@ max-heap-table-size            = 12M
 max-connections                = <%= @max_connections %>
 thread-cache-size              = 100
 open-files-limit               = 65535
-table-definition-cache         = 800
-table-open-cache               = 800
-
+table-definition-cache         = 1000
+table-open-cache               = 1000
 
 # thread and connection handling
 thread_handling                = pool-of-threads
-<% if @server_role == 'master' %>
+<% if @server_role == 'master' -%>
 thread_pool_stall_limit        = 10
-<% else %>
+<% else -%>
 thread_pool_stall_limit        = 100
-<% end %>
+<% end -%>
+<% if Integer(@processorcount) <= 32 -%>
+thread_pool_size               = 32
+<% else -%>
 thread_pool_size               = <%= @processorcount %>
+<% end -%>
 thread_pool_max_threads        = 2000
 back_log                       = 500
 extra_max_connections          = 10


### PR DESCRIPTION
Also adjust configs (which is from https://github.com/wikimedia/puppet/blob/production/modules/role/templates/mariadb/mysqld_config/production.my.cnf.erb)