### PR TITLE
Add Access-Control-Allow-Origin to sfnt (font) files

### DIFF
--- a/modules/mediawiki/templates/mediawiki.conf
+++ b/modules/mediawiki/templates/mediawiki.conf
@@ -132,7 +132,7 @@ server {
 		rewrite ^/(.*)wiki/thumb/(.+)$ https://$1.miraheze.org/w/thumb_handler.php/$2;
 	}
 
-	location ~* .(gif|jpe?g|pdf|png|css|js|json|woff|woff2|svg|eot|ttf|otf|ico)$ {
+	location ~* .(gif|jpe?g|pdf|png|css|js|json|woff|woff2|svg|eot|ttf|otf|ico|sfnt)$ {
 		expires 1w;
 
 		add_header Access-Control-Allow-Origin '*' always;


### PR DESCRIPTION
per request on discord, where such files are uploaded to csydeswiki but cannot be used until such change is made