### PR TITLE
mediawiki: Add global headers to local {}

### DIFF
--- a/modules/mediawiki/templates/mediawiki.conf
+++ b/modules/mediawiki/templates/mediawiki.conf
@@ -20,6 +20,13 @@ server {
 
 	add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload";
 
+	add_header X-Served-By '<%= scope.lookupvar('::fqdn') %>';
+
+	# XSS Protection
+	add_header x-xss-protection "1; mode=block" always;
+
+	add_header X-Frame-Options "ALLOW-FROM static.miraheze.org";
+
 	location /.well-known/acme-challenge/ {
 		alias /var/www/challenges/;
 		try_files $uri =404;
@@ -82,6 +89,13 @@ server {
 
 	add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload";
 
+	add_header X-Served-By '<%= scope.lookupvar('::fqdn') %>';
+
+	# XSS Protection
+	add_header x-xss-protection "1; mode=block" always;
+
+	add_header X-Frame-Options "ALLOW-FROM static.miraheze.org";
+
 	include /etc/nginx/mediawiki-includes;
 
 	location = /robots.txt {
@@ -125,6 +139,13 @@ server {
 	ssl_trusted_certificate /etc/ssl/certs/Sectigo.crt;
 
 	add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload";
+
+	add_header X-Served-By '<%= scope.lookupvar('::fqdn') %>';
+
+	# XSS Protection
+	add_header x-xss-protection "1; mode=block" always;
+
+	add_header X-Frame-Options "ALLOW-FROM static.miraheze.org";
 
 	error_page 404 =404 @notfound;
 
@@ -181,6 +202,13 @@ server {
 
 	add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload";
 
+	add_header X-Served-By '<%= scope.lookupvar('::fqdn') %>';
+
+	# XSS Protection
+	add_header x-xss-protection "1; mode=block" always;
+
+	add_header X-Frame-Options "ALLOW-FROM static.miraheze.org";
+
 	location ~ \.php {
 		include fastcgi_params;
 		fastcgi_index index.php;
@@ -217,6 +245,13 @@ server {
 <% else %>
 	add_header Strict-Transport-Security "max-age=604800";
 <% end %>
+
+	add_header X-Served-By '<%= scope.lookupvar('::fqdn') %>';
+
+	# XSS Protection
+	add_header x-xss-protection "1; mode=block" always;
+
+	add_header X-Frame-Options "ALLOW-FROM static.miraheze.org";
 
 	include /etc/nginx/mediawiki-includes;
 

--- a/modules/nginx/templates/nginx.conf.erb
+++ b/modules/nginx/templates/nginx.conf.erb
@@ -25,6 +25,8 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
+    server_tokens off;
+
     # SSL Settings
     ssl_ciphers EECDH+CHACHA20:EECDH+AES128:EECDH+AES256:EECDH+3DES:!MD5;
     ssl_protocols TLSv1.2 TLSv1.3;
@@ -69,7 +71,7 @@ http {
     set_real_ip_from 128.199.139.216; # cp3 (Singapore)
     set_real_ip_from 81.4.109.133; # cp4 (Netherlands)
     real_ip_header X-Real-IP;
-    
+
     # VHosts
     include /etc/nginx/conf.d/*.conf;
 


### PR DESCRIPTION
Setting headers in the local {} block, will prevent the global headers from taking effect. We have to add the global headers in the local {} block for it to take effect again.

Also switch off server_tokens.