### PR TITLE
Run update_statistics cron on the 1st and 15th of each month

### DIFF
--- a/modules/mediawiki/manifests/jobrunner.pp
+++ b/modules/mediawiki/manifests/jobrunner.pp
@@ -93,7 +93,7 @@ class mediawiki::jobrunner {
 
     cron { 'update_statistics':
         ensure   => present,
-        command  => '/usr/bin/nice -19 flock -n /var/lock/update-statistics /usr/local/bin/foreachwikiindblist /srv/mediawiki/dblist/all.dblist /srv/mediawiki/w/maintenance/initSiteStats.php --update > initSiteStats.log 2>&1',
+        command  => '/usr/bin/nice -19 /usr/local/bin/foreachwikiindblist /srv/mediawiki/dblist/all.dblist /srv/mediawiki/w/maintenance/initSiteStats.php --update > /dev/null',
         user     => 'www-data',
         minute   => 39,
         hour     => 05,

--- a/modules/mediawiki/manifests/jobrunner.pp
+++ b/modules/mediawiki/manifests/jobrunner.pp
@@ -91,6 +91,15 @@ class mediawiki::jobrunner {
         weekday => [ '6' ],
     }
 
+    cron { 'update_statistics':
+        ensure   => present,
+        command  => '/usr/bin/nice -n 0 flock -n /var/lock/update-statistics /usr/local/bin/foreachwikiindblist /srv/mediawiki/dblist/all.dblist /srv/mediawiki/w/maintenance/initSiteStats.php --update > initSiteStats.log 2>&1',
+        user     => 'www-data',
+        minute   => 39,
+        hour     => 05,
+        monthday => [1, 15],
+    }
+
     file { '/usr/lib/nagios/plugins/check_jobqueue':
         ensure => present,
         source => 'puppet:///modules/mediawiki/jobrunner/check_jobqueue',

--- a/modules/mediawiki/manifests/jobrunner.pp
+++ b/modules/mediawiki/manifests/jobrunner.pp
@@ -93,7 +93,7 @@ class mediawiki::jobrunner {
 
     cron { 'update_statistics':
         ensure   => present,
-        command  => '/usr/bin/nice -n 0 flock -n /var/lock/update-statistics /usr/local/bin/foreachwikiindblist /srv/mediawiki/dblist/all.dblist /srv/mediawiki/w/maintenance/initSiteStats.php --update > initSiteStats.log 2>&1',
+        command  => '/usr/bin/nice -19 flock -n /var/lock/update-statistics /usr/local/bin/foreachwikiindblist /srv/mediawiki/dblist/all.dblist /srv/mediawiki/w/maintenance/initSiteStats.php --update > initSiteStats.log 2>&1',
         user     => 'www-data',
         minute   => 39,
         hour     => 05,


### PR DESCRIPTION
Based on https://github.com/wikimedia/puppet/blob/b347052863d4d2e87b37d6c2d9f44f833cfd9dc2/modules/mediawiki/manifests/maintenance/initsitestats.pp#L2

Bug: T4312