### PR TITLE
Grafana: Set allow_sign_up to false

### DIFF
--- a/modules/grafana/templates/grafana.ini.erb
+++ b/modules/grafana/templates/grafana.ini.erb
@@ -4,7 +4,7 @@ root_url = %(protocol)s://%(domain)s/
 
 [users]
 # user signup / registration
-allow_sign_up = true
+allow_sign_up = false
 default_theme = light
 auto_assign_org_role = Viewer
 auto_assign_org = true


### PR DESCRIPTION
Only allow admins to create accounts.