### PR TITLE
Remove “temp” redirect to my personal email

### DIFF
--- a/modules/postfix/files/aliases
+++ b/modules/postfix/files/aliases
@@ -40,8 +40,6 @@ conduct: miraheze-cocc@googlegroups.com
 # finances
 donate: southparkfan,owen
 
-# temp - see T4930
-rhinosf1: rhinosf1@gmail.com
 
 # campaign email temp
 campaign: sre


### PR DESCRIPTION
That was still there? Long month!

https://bash.toolforge.org/quip/AU7VTzhg6snAnmqnK_pc