### PR TITLE
php: Do not use sury php apt repo on 7.3

### DIFF
--- a/modules/php/manifests/init.pp
+++ b/modules/php/manifests/init.pp
@@ -13,7 +13,7 @@ class php(
  
     include ::apt
 
-    if !defined(Apt::Source['php_apt']) {
+    if $version != '7.3' and !defined(Apt::Source['php_apt']) {
         file { '/etc/apt/trusted.gpg.d/php.gpg':
             ensure => present,
             source => 'puppet:///modules/php/key/php.gpg',
@@ -27,17 +27,17 @@ class php(
             notify   => Exec['apt_update_php'],
         }
 
-	apt::pin { 'php_pin':
-		priority        => 600,
-		origin          => 'packages.sury.org'
-	}
+        apt::pin { 'php_pin':
+                priority        => 600,
+                origin          => 'packages.sury.org'
+        }
 
         # First installs can trip without this
         exec {'apt_update_php':
-            command     => '/usr/bin/apt-get update',
-            refreshonly => true,
-            logoutput   => true,
-	    require     => Apt::Pin['php_pin'],
+                command     => '/usr/bin/apt-get update',
+                refreshonly => true,
+                logoutput   => true,
+                require     => Apt::Pin['php_pin'],
         }
     }
 
@@ -45,7 +45,7 @@ class php(
     package { [ "php${version}-common", "php${version}-opcache" ]:
         ensure  => $ensure,
         require => Apt::Source['php_apt'],
-	}
+    }
 
     $config_dir = "/etc/php/${version}"
 

--- a/modules/php/manifests/php_fpm.pp
+++ b/modules/php/manifests/php_fpm.pp
@@ -86,7 +86,6 @@ class php::php_fpm(
     $core_extensions.each |$extension| {
         php::extension { $extension:
             package_name => "php${version}-${extension}",
-            require      => Apt::Source['php_apt'],
         }
     }
 
@@ -175,7 +174,6 @@ class php::php_fpm(
     class { '::php::fpm':
         ensure  => present,
         config  => merge($base_fpm_config, $base_fpm_config_kvm, $fpm_config),
-        require => Apt::Source['php_apt'],
     }
 
     $num_workers =  max(floor($facts['virtual_processor_count'] * $fpm_workers_multiplier), $fpm_min_child)


### PR DESCRIPTION
Due to a bug, we will be forcing usage of debian's repo which has 7.3.14.