### PR TITLE
apt: Blacklist php unintended upgrades

### DIFF
--- a/modules/base/files/apt/50unattended-upgrades
+++ b/modules/base/files/apt/50unattended-upgrades
@@ -6,9 +6,9 @@ Unattended-Upgrade::Origins-Pattern {
 // List of packages to not update (regexp are supported)
 Unattended-Upgrade::Package-Blacklist {
 	"gdnsd";
-        "libc6";
-        "libc6-dev";
-        "libc6-i686";
+	"libc6";
+	"libc6-dev";
+	"libc6-i686";
 	"mariadb-";
 	"php-";
 	"php7.4-";

--- a/modules/base/files/apt/50unattended-upgrades
+++ b/modules/base/files/apt/50unattended-upgrades
@@ -6,10 +6,14 @@ Unattended-Upgrade::Origins-Pattern {
 // List of packages to not update (regexp are supported)
 Unattended-Upgrade::Package-Blacklist {
 	"gdnsd";
-	"mariadb-";
         "libc6";
         "libc6-dev";
         "libc6-i686";
+	"mariadb-";
+	"php-";
+	"php7.4-";
+	"php7.3-";
+	"php7.2-";
 };
 
 Unattended-Upgrade::Mail "operations@miraheze.org";


### PR DESCRIPTION
Today this caused an outage on mw[4567] when php-redis was upgraded.