### PR TITLE
cp7: Check allthetropeswiki instead of loginwiki temporarily

### DIFF
--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -21,7 +21,11 @@ import std;
 
 probe mwhealth {
 	.request = "GET /wiki/Main_Page HTTP/1.1"
+		<%- if @fqdn == "cp7.miraheze.org" -%>
+		"Host: allthetropes.miraheze.org"
+		<%- else -%>
 		"Host: login.miraheze.org"
+		<%- end -%>
 		"User-Agent: Varnish healthcheck"
 		"Connection: close";
 	# Check each 10s
@@ -324,11 +328,11 @@ sub mw_vcl_recv {
 		set req.backend_hint = test2;
 		return (pass);
 	} else {
-		<%- if @fqdn == "cp7.miraheze.org" %>
+		<%- if @fqdn == "cp7.miraheze.org" -%>
 		set req.backend_hint = mediawiki_new.backend();
-		<%- else %>
+		<%- else -%>
 		set req.backend_hint = mediawiki.backend();
-		<%- end %>
+		<%- end -%>
 	}
 
 	# We never want to cache non-GET/HEAD requests.


### PR DESCRIPTION
The new infrastructure seems better and latency decreases.