### PR TITLE
up sleep time to 1

### DIFF
--- a/modules/irc/manifests/ircrcbot.pp
+++ b/modules/irc/manifests/ircrcbot.pp
@@ -5,7 +5,7 @@ class irc::ircrcbot(
     $network_port = '6697',
     $channel      = undef,
     $udp_port     = '5070',
-    $sleeptime    = '0.5',
+    $sleeptime    = '1',
 ) {
     include ::irc
 


### PR DESCRIPTION
Bot keeps flooding out and ideally we shouldn’t be sending more than 1 message every 2 seconds. Try upping to 1s sleep as I don’t think we’ll have any issues with that.