### PR TITLE
openldap: redo access permissions

### DIFF
--- a/modules/profile/manifests/openldap.pp
+++ b/modules/profile/manifests/openldap.pp
@@ -18,13 +18,42 @@ class profile::openldap (
         rootpw    => $password,
     }
 
-    openldap::server::access { '0 on dc=miraheze,dc=org':
+    openldap::server::access { 'write access for admin':
         what     => 'attrs=userPassword,shadowLastChange',
         access   => [
             'by dn="cn=admin,dc=miraheze,dc=org" write',
             'by anonymous auth',
             'by self write',
             'by * none',
+        ],
+    }
+
+    # Allows users in the Administrators group to write
+    openldap::server::access { 'write access for admin':
+        what     => 'attrs=userPassword,shadowLastChange',
+        access   => [
+            'by group.exact="cn=Administrators,ou=groups,dc=miraheze,dc=org" write',
+            'by self write',
+            'by anonymous auth',
+            'by * none',
+        ],
+    }
+
+    openldap::server::access { 'dn children':
+        what     => 'dn.children="dc=miraheze,dc=org"',
+        access   => [
+            'by group.exact="cn=Administrators,ou=groups,dc=miraheze,dc=org" write',
+            'by users read',
+            'by * break',
+        ],
+    }
+
+    # Anonomous read access
+    openldap::server::access { 'read access':
+        what     => '*',
+        access   => [
+            'by self write',
+            'by * read',
         ],
     }
 

--- a/modules/profile/manifests/openldap.pp
+++ b/modules/profile/manifests/openldap.pp
@@ -32,7 +32,7 @@ class profile::openldap (
     openldap::server::access { 'write access for admin':
         what     => 'attrs=userPassword,shadowLastChange',
         access   => [
-            'by group.exact="cn=Administrators,ou=groups,dc=miraheze,dc=org" write',
+            'by dn="cn=writer,dc=miraheze,dc=org" write',
             'by self write',
             'by anonymous auth',
             'by * none',
@@ -42,7 +42,7 @@ class profile::openldap (
     openldap::server::access { 'dn children':
         what     => 'dn.children="dc=miraheze,dc=org"',
         access   => [
-            'by group.exact="cn=Administrators,ou=groups,dc=miraheze,dc=org" write',
+            'by dn="cn=writer,dc=miraheze,dc=org" write',
             'by users read',
             'by * break',
         ],

--- a/modules/profile/manifests/openldap.pp
+++ b/modules/profile/manifests/openldap.pp
@@ -18,23 +18,25 @@ class profile::openldap (
         rootpw    => $password,
     }
 
-    # Read Only access, includes access to passwords
-    openldap::server::access { 'read only access':
-        what     => '',
-        access   => [
-            'by dn="cn=read-only,dc=miraheze,dc=org" write',
-            'by anonymous auth',
-        ],
-    }
-
-    # Admin access
-    openldap::server::access { 'write access for admin':
+    # Allow everybody to try to bind
+    openldap::server::access { '0 write access for admin':
         what     => 'attrs=userPassword,shadowLastChange',
         access   => [
             'by dn="cn=admin,dc=miraheze,dc=org" write',
-            'by anonymous auth',
+            'by group.exact="cn=Administrators,ou=groups,dc=miraheze,dc=org" write',
             'by self write',
+            'by anonymous auth',
             'by * none',
+        ],
+    }
+
+    # Allow admin users to manage things and authed users to read
+    openldap::server::access { '1 write access for admin':
+        what     => 'dn.children="dc=miraheze,dc=org"',
+        access   => [
+            'by group.exact="cn=Administrators,ou=groups,dc=miraheze,dc=org" write',
+            'by users read',
+            'by * break',
         ],
     }
 

--- a/modules/profile/manifests/openldap.pp
+++ b/modules/profile/manifests/openldap.pp
@@ -18,6 +18,16 @@ class profile::openldap (
         rootpw    => $password,
     }
 
+    # Read Only access, includes access to passwords
+    openldap::server::access { 'read only access':
+        what     => '',
+        access   => [
+            'by dn="cn=read-only,dc=miraheze,dc=org" write',
+            'by anonymous auth',
+        ],
+    }
+
+    # Admin access
     openldap::server::access { 'write access for admin':
         what     => 'attrs=userPassword,shadowLastChange',
         access   => [
@@ -25,35 +35,6 @@ class profile::openldap (
             'by anonymous auth',
             'by self write',
             'by * none',
-        ],
-    }
-
-    # Allows users in the Administrators group to write
-    openldap::server::access { 'write access for admin':
-        what     => 'attrs=userPassword,shadowLastChange',
-        access   => [
-            'by dn="cn=writer,dc=miraheze,dc=org" write',
-            'by self write',
-            'by anonymous auth',
-            'by * none',
-        ],
-    }
-
-    openldap::server::access { 'dn children':
-        what     => 'dn.children="dc=miraheze,dc=org"',
-        access   => [
-            'by dn="cn=writer,dc=miraheze,dc=org" write',
-            'by users read',
-            'by * break',
-        ],
-    }
-
-    # Anonomous read access
-    openldap::server::access { 'read access':
-        what     => '*',
-        access   => [
-            'by self write',
-            'by * read',
         ],
     }
 


### PR DESCRIPTION
Creates an admin group. A admin account will be setup, separate to the one setup as the default.