### PR TITLE
Introduce new decommission role

### DIFF
--- a/modules/role/manifests/decommission.pp
+++ b/modules/role/manifests/decommission.pp
@@ -1,0 +1,8 @@
+# class: role::decommission
+class role::decommission {
+    include base
+    
+    motd::role { 'role::decommission':
+        description => 'Decommisioned role',
+    }
+}


### PR DESCRIPTION
This will allow us to automate removal of ips from the firewall, ensuring old ips are removed.

This will change how we decom servers:

1. Remove the roles/classes from the server
2. Add role::decommission to the server
3. Run puppet
4. Run puppet on some servers to make sure that it removes the ip (not all servers).
5. Remove the server from puppet

(Puppet will take a while to remove from puppetdb).