### PR TITLE
monitoring: Increase ping critical/warning levels

### DIFF
--- a/modules/monitoring/files/services.conf
+++ b/modules/monitoring/files/services.conf
@@ -28,6 +28,11 @@ apply Service "ping4" {
 
   check_command = "ping4"
 
+	vars.ping_wrta = 500
+	vars.ping_wpl = 20
+	vars.ping_crta = 2000
+	vars.ping_cpl = 100
+
   assign where host.address
 }
 
@@ -35,6 +40,11 @@ apply Service "ping6" {
   import "generic-service"
 
   check_command = "ping6"
+
+	vars.ping_wrta = 500
+	vars.ping_wpl = 20
+	vars.ping_crta = 2000
+	vars.ping_cpl = 100
 
   assign where host.address6
 }

--- a/modules/monitoring/files/services.conf
+++ b/modules/monitoring/files/services.conf
@@ -1,0 +1,114 @@
+/*
+ * Service apply rules.
+ *
+ * The CheckCommand objects `ping4`, `ping6`, etc
+ * are provided by the plugin check command templates.
+ * Check the documentation for details.
+ *
+ * Tip: Use `icinga2 object list --type Service` to
+ * list all service objects after running
+ * configuration validation (`icinga2 daemon -C`).
+ */
+
+/*
+ * This is an example host based on your
+ * local host's FQDN. Specify the NodeName
+ * constant in `constants.conf` or use your
+ * own description, e.g. "db-host-1".
+ */
+
+/*
+ * These are generic `ping4` and `ping6`
+ * checks applied to all hosts having the
+ * `address` resp. `address6` attribute
+ * defined.
+ */
+apply Service "ping4" {
+  import "generic-service"
+
+  check_command = "ping4"
+
+  assign where host.address
+}
+
+apply Service "ping6" {
+  import "generic-service"
+
+  check_command = "ping6"
+
+  assign where host.address6
+}
+
+/*
+ * Apply the `ssh` service to all hosts
+ * with the `address` attribute defined and
+ * the custom variable `os` set to `Linux`.
+ */
+apply Service "ssh" {
+  import "generic-service"
+
+  check_command = "ssh"
+
+  assign where (host.address || host.address6) && host.vars.os == "Linux"
+}
+
+
+
+apply Service for (http_vhost => config in host.vars.http_vhosts) {
+  import "generic-service"
+
+  check_command = "http"
+
+  vars += config
+}
+
+apply Service for (disk => config in host.vars.disks) {
+  import "generic-service"
+
+  check_command = "disk"
+
+  vars += config
+}
+
+apply Service "icinga" {
+  import "generic-service"
+
+  check_command = "icinga"
+
+  assign where host.name == NodeName
+}
+
+apply Service "load" {
+  import "generic-service"
+
+  check_command = "load"
+
+  /* Used by the ScheduledDowntime apply rule in `downtimes.conf`. */
+  vars.backup_downtime = "02:00-03:00"
+
+  assign where host.name == NodeName
+}
+
+apply Service "procs" {
+  import "generic-service"
+
+  check_command = "procs"
+
+  assign where host.name == NodeName
+}
+
+apply Service "swap" {
+  import "generic-service"
+
+  check_command = "swap"
+
+  assign where host.name == NodeName
+}
+
+apply Service "users" {
+  import "generic-service"
+
+  check_command = "users"
+
+  assign where host.name == NodeName
+}

--- a/modules/monitoring/files/services.conf
+++ b/modules/monitoring/files/services.conf
@@ -34,7 +34,7 @@ apply Service "ping4" {
    * it's expected they will have higher ping levels
    * due to their location.
    */
-  if ( regex("^cp.+", host.name) || host.name == "ns1.miraheze.org" ) {
+  if ( regex("^cp.+", host.name) || host.name == "ns1" ) {
     vars.ping_wrta = 500
     vars.ping_wpl = 20
     vars.ping_crta = 2000
@@ -55,7 +55,7 @@ apply Service "ping6" {
    * it's expected they will have higher ping levels
    * due to their location.
    */
-  if ( regex("^cp.+", host.name) || host.name == "ns1.miraheze.org" ) {
+  if ( regex("^cp.+", host.name) || host.name == "ns1" ) {
     vars.ping_wrta = 500
     vars.ping_wpl = 20
     vars.ping_crta = 2000

--- a/modules/monitoring/files/services.conf
+++ b/modules/monitoring/files/services.conf
@@ -28,10 +28,10 @@ apply Service "ping4" {
 
   check_command = "ping4"
 
-	vars.ping_wrta = 500
-	vars.ping_wpl = 20
-	vars.ping_crta = 2000
-	vars.ping_cpl = 100
+  vars.ping_wrta = 500
+  vars.ping_wpl = 20
+  vars.ping_crta = 2000
+  vars.ping_cpl = 100
 
   assign where host.address
 }
@@ -41,10 +41,10 @@ apply Service "ping6" {
 
   check_command = "ping6"
 
-	vars.ping_wrta = 500
-	vars.ping_wpl = 20
-	vars.ping_crta = 2000
-	vars.ping_cpl = 100
+  vars.ping_wrta = 500
+  vars.ping_wpl = 20
+  vars.ping_crta = 2000
+  vars.ping_cpl = 100
 
   assign where host.address6
 }

--- a/modules/monitoring/files/services.conf
+++ b/modules/monitoring/files/services.conf
@@ -33,6 +33,7 @@ apply Service "ping4" {
    * for the cache proxies and ns1. This is because
    * it's expected they will have higher ping levels
    * due to their location.
+   * Task: T5669
    */
   if ( regex("^cp.+", host.name) || host.name == "ns1" ) {
     vars.ping_wrta = 500
@@ -54,6 +55,7 @@ apply Service "ping6" {
    * for the cache proxies and ns1. This is because
    * it's expected they will have higher ping levels
    * due to their location.
+   * Task: T5669
    */
   if ( regex("^cp.+", host.name) || host.name == "ns1" ) {
     vars.ping_wrta = 500

--- a/modules/monitoring/files/services.conf
+++ b/modules/monitoring/files/services.conf
@@ -28,10 +28,18 @@ apply Service "ping4" {
 
   check_command = "ping4"
 
-  vars.ping_wrta = 500
-  vars.ping_wpl = 20
-  vars.ping_crta = 2000
-  vars.ping_cpl = 100
+  /*
+   * We want to enforce a higher ping warning/critical level
+   * for the cache proxies and ns1. This is because
+   * it's expected they will have higher ping levels
+   * due to their location.
+   */
+  if ( regex("^cp.+", host.name) || host.name == "ns1.miraheze.org" ) {
+    vars.ping_wrta = 500
+    vars.ping_wpl = 20
+    vars.ping_crta = 2000
+    vars.ping_cpl = 100
+  }
 
   assign where host.address
 }
@@ -41,10 +49,18 @@ apply Service "ping6" {
 
   check_command = "ping6"
 
-  vars.ping_wrta = 500
-  vars.ping_wpl = 20
-  vars.ping_crta = 2000
-  vars.ping_cpl = 100
+  /*
+   * We want to enforce a higher ping warning/critical level
+   * for the cache proxies and ns1. This is because
+   * it's expected they will have higher ping levels
+   * due to their location.
+   */
+  if ( regex("^cp.+", host.name) || host.name == "ns1.miraheze.org" ) {
+    vars.ping_wrta = 500
+    vars.ping_wpl = 20
+    vars.ping_crta = 2000
+    vars.ping_cpl = 100
+  }
 
   assign where host.address6
 }

--- a/modules/monitoring/manifests/init.pp
+++ b/modules/monitoring/manifests/init.pp
@@ -107,6 +107,15 @@ class monitoring (
         notify  => Service['icinga2'],
     }
 
+    file { '/etc/icinga2/conf.d/services.conf':
+        source  => 'puppet:///modules/monitoring/services.conf',
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
+        require => Package['icinga2'],
+        notify  => Service['icinga2'],
+    }
+
     file { '/etc/icinga2/conf.d/templates.conf':
         source  => 'puppet:///modules/monitoring/templates.conf',
         owner   => 'root',


### PR DESCRIPTION
Set these vars:

```
	vars.ping_wrta = 500
 	vars.ping_wpl = 20
 	vars.ping_crta = 2000
 	vars.ping_cpl = 100
```

This means we up when we alert to 500ms+ (warning) and 2000ms (critical).

Packet loss is 20% (warning) and 100% (critical).

Defaults are:

```
	vars.ping_wrta = 100
	vars.ping_wpl = 5
	vars.ping_crta = 200
	vars.ping_cpl = 15
```