### PR TITLE
monitoring: Update groups checks to use match()

### DIFF
--- a/modules/monitoring/files/groups.conf
+++ b/modules/monitoring/files/groups.conf
@@ -9,7 +9,7 @@ object HostGroup "bacula" {
 }
 
 object HostGroup "db" {
-  assign where host.name in [ "db6", "db7", "dbt1" ]
+  assign where match("db*", host.name)
 }
 
 object HostGroup "debian" {
@@ -17,7 +17,7 @@ assign where match("*", host.name)
 }
 
 object HostGroup "dns" {
-  assign where host.name in [ "ns1", "ns2" ]
+  assign where match("ns*", host.name)
 }
 
 object HostGroup "irc" {
@@ -25,27 +25,28 @@ object HostGroup "irc" {
 }
 
 object HostGroup "jobrunner" {
-  assign where host.name in [ "jobrunner1" ]
+  assign where match("jobrunner*", host.name)
 }
 
 object HostGroup "mail" {
-  assign where host.name in [ "misc1" ]
+  assign where match("mail*", host.name)
 }
 
 object HostGroup "mediawiki" {
-  assign where host.name in [ "mw4", "mw5", "mw6", "mw7", "test2" ]
+  assign where match("mw*", host.name)
+  assign where match("test*", host.name)
 }
 
 object HostGroup "phabricator" {
-  assign where host.name in [ "phab1" ]
+  assign where match("phab*", host.name)
 }
 
 object HostGroup "redis" {
-  assign where host.name in [ "rdb1", "rdb2" ]
+  assign where match("rdb*", host.name)
 }
 
 object HostGroup "services" {
-  assign where host.name in [ "services1", "services2" ]
+  assign where match("services*", host.name)
 }
 
 object HostGroup "sslchecks" {
@@ -53,13 +54,15 @@ object HostGroup "sslchecks" {
 }
 
 object HostGroup "static" {
-  assign where host.name in [ "gluster1" ]
+  assign where match("gluster*", host.name)
 }
 
 object HostGroup "varnish" {
-  assign where host.name in [ "cp3", "cp6", "cp7", "cp8" ]
+  assign where match("cp*", host.name)
 }
 
 object HostGroup "web" {
-  assign where host.name in [ "mw4", "mw5", "mw6", "mw7", "mon1", "cp3", "cp6", "cp7", "cp8", "test2" ]
+  assign where match("cp*", host.name)
+  assign where match("mw*", host.name)
+  assign where match("test*", host.name)
 }


### PR DESCRIPTION
This means we won't have to update this frequently to new hosts added.