### PR TITLE
bacula: Overhaul firewall rules

### DIFF
--- a/modules/bacula/manifests/director.pp
+++ b/modules/bacula/manifests/director.pp
@@ -62,19 +62,19 @@ class bacula::director {
         notify  => Service['bacula-director'],
     }
 
-    ufw::allow { 'bacula_9101':
-        proto => 'tcp',
-        port  => 9101,
-    }
+    $firewall = query_facts('Class[Bacula::Client]', ['ipaddress', 'ipaddress6'])
+    $firewall.each |$key, $value| {
+        ufw::allow { 'bacula 9102 ${value['ipaddress']}':
+            proto => 'tcp',
+            port  => 9102,
+            from  => $value['ipaddress'],
+        }
 
-    ufw::allow { 'bacula_9102':
-        proto => 'tcp',
-        port  => 9102,
-    }
-
-    ufw::allow { 'bacula_9103':
-        proto => 'tcp',
-        port  => 9103,
+        ufw::allow { 'bacula 9102 ${value['ipaddress6']}':
+            proto => 'tcp',
+            port  => 9102,
+            from  => $value['ipaddress6'],
+        }
     }
 
     file { '/usr/lib/nagios/plugins/check_bacula_backups':


### PR DESCRIPTION
Remove firewall for 9101/9103 (bacula uses localhost so no firewall is needed for those ports yet).

9102 will be limited to servers that have the bacula client class installed.