### PR TITLE
Add generateSitemapIndex script

### DIFF
--- a/modules/mediawiki/manifests/jobrunner.pp
+++ b/modules/mediawiki/manifests/jobrunner.pp
@@ -90,6 +90,16 @@ class mediawiki::jobrunner {
         month    => '*',
         weekday => [ '6' ],
     }
+    
+    cron { 'generate sitemap index':
+        ensure  => present,
+        command => '/usr/bin/nice -19 /usr/bin/python3 /srv/mediawiki/extensions/MirahezeMagic/py/generateSitemapIndex.py',
+        user    => 'www-data',
+        minute   => '0',
+        hour     => '0',
+        month    => '*',
+        weekday => [ '7' ],
+    }
 
     cron { 'update_statistics':
         ensure   => present,


### PR DESCRIPTION
This populates static.miraheze.org/sitemaps/sitemap.xml with an index of all sitemaps. It runs 24 hours after the sitemap script for each wiki to ensure that has finished.