### PR TITLE
MediaWiki-packages: drop lillypond

### DIFF
--- a/modules/mediawiki/manifests/packages.pp
+++ b/modules/mediawiki/manifests/packages.pp
@@ -11,7 +11,6 @@ class mediawiki::packages {
         'locales-all',
         'oggvideotools',
         'libvips-tools',
-        'lilypond',
         'poppler-utils',
         'python-pip',
         'netpbm',


### PR DESCRIPTION
Per https://gerrit.wikimedia.org/r/c/operations/puppet/+/612274/2/modules/mediawiki/manifests/packages.pp and https://phabricator.wikimedia.org/T248418#6351818

This already off for all Miraheze Wikis.