### PR TITLE
monitoring: Fix check_mediawiki command

### DIFF
--- a/modules/mediawiki/manifests/monitoring.pp
+++ b/modules/mediawiki/manifests/monitoring.pp
@@ -5,7 +5,7 @@ class mediawiki::monitoring {
         check_command => 'check_mediawiki',
         vars          => {
             host    => 'login.miraheze.org',
-            address => 'host.address',
+            address => $::fqdn,
         },
     }
 

--- a/modules/monitoring/files/commands.conf
+++ b/modules/monitoring/files/commands.conf
@@ -204,7 +204,7 @@ object CheckCommand "check_mediawiki" {
      command = [ PluginDir + "/check_http" ]
      arguments = {
          "-H"    = "$host$",
-         "-s"    = "$address$",
+         "-I"    = "$address$",
          "--ssl" = "",
          "-u"    = "/wiki/Main_Page"
      }


### PR DESCRIPTION
We want to use -I so that the check, checks the individual servers. -s is a string match which we don't want (which didn't work for us anyways as host.address was returning as a string)