### PR TITLE
mediawiki: Fix proxying through rest base

### DIFF
--- a/modules/mediawiki/templates/mediawiki-includes.conf.erb
+++ b/modules/mediawiki/templates/mediawiki-includes.conf.erb
@@ -39,7 +39,11 @@ location = /apple-touch-icon.png {
 	try_files /../../usr/share/nginx/favicons/apple-touch-icon-$host.png /../../usr/share/nginx/favicons/apple-touch-icon-default.png;
 }
 
-location ^~ /wiki {
+location = /wiki {
+	return 301 /wiki/;
+}
+
+location ^~ /wiki/ {
 	include fastcgi_params;
 	fastcgi_param SCRIPT_FILENAME $document_root/w/index.php;
 	fastcgi_buffers 32 32k;


### PR DESCRIPTION
Due location ^~ /wiki {, it was matching urls like https://wiki.climatechange.ai/wiki.climatechange.ai/v1/?spec which meant it proxied through php-fpm rather than rest base. We fix this to ensure that just because the url contains wiki., it doesn't proxy through php-fpm.