### PR TITLE
jobrunner: Reduce runners to 2

### DIFF
--- a/modules/mediawiki/templates/jobrunner.json.erb
+++ b/modules/mediawiki/templates/jobrunner.json.erb
@@ -4,7 +4,7 @@
     "groups": {
         "basic": {
             // Number of runner processes in this group
-            "runners": 4,
+            "runners": 2,
             // Job types to include ("*" means "all")
             "include": [
                 "*"


### PR DESCRIPTION
Per @Southparkfan, we are over utilising, so going to reduce some of the pressure by lowering the amount of runners.