### PR TITLE
varnish: Fix rate limiter

### DIFF
--- a/modules/varnish/manifests/nginx.pp
+++ b/modules/varnish/manifests/nginx.pp
@@ -3,6 +3,10 @@ class varnish::nginx {
     $sslcerts = loadyaml('/etc/puppetlabs/puppet/ssl-cert/certs.yaml')
     $sslredirects = loadyaml('/etc/puppetlabs/puppet/ssl-cert/redirects.yaml')
 
+    # Used to whitelist miraheze ips within the rate limiter
+    $ip_4 = query_nodes("domain='$domain'", 'ipaddress')
+    $ip_6 = query_nodes("domain='$domain'", 'ipaddress6')
+
     nginx::site { 'mediawiki':
         ensure       => present,
         content      => template('varnish/mediawiki.conf'),

--- a/modules/varnish/templates/mediawiki.conf
+++ b/modules/varnish/templates/mediawiki.conf
@@ -58,9 +58,7 @@ server {
 	ssl_stapling_verify on;
 
 	location / {
-		if ( $http_host != 'static.miraheze.org' ) {
-			limit_req zone=ratelimiting burst=25;
-		}
+		limit_req zone=ratelimiting burst=25;
 
 		proxy_pass http://127.0.0.1:81;
 		proxy_http_version 1.1;
@@ -161,9 +159,7 @@ server {
 	add_header X-Frame-Options "ALLOW-FROM static.miraheze.org";
 
 	location / {
-		if ( $http_host != 'static.miraheze.org' ) {
-			limit_req zone=ratelimiting burst=25;
-		}
+		limit_req zone=ratelimiting burst=25;
 
 		proxy_pass http://127.0.0.1:81;
 		proxy_http_version 1.1;

--- a/modules/varnish/templates/mediawiki.conf
+++ b/modules/varnish/templates/mediawiki.conf
@@ -3,10 +3,13 @@
 
 geo $whitelist {
 	default 0;
-	# CIDR in the list below are not limited
-	1.2.3.0/24 1;
-	9.10.11.12/32 1;
 	127.0.0.1/32 1;
+<%- @ip_4.sort.each do |ip| -%>
+	<%= ip %>/32 1;
+<%- end -%>
+<%- @ip_6.sort.each do |ip| -%>
+	<%= ip %>/32 1;
+<%- end -%>
 }
 
 map $whitelist $limit {
@@ -14,7 +17,7 @@ map $whitelist $limit {
 	1     "";
 }
 
-limit_req_zone $binary_remote_addr zone=ratelimiting:10m rate=10r/s;
+limit_req_zone $limit zone=ratelimiting:10m rate=10r/s;
 limit_req_status 429;
 
 server {
@@ -55,7 +58,9 @@ server {
 	ssl_stapling_verify on;
 
 	location / {
-		limit_req zone=ratelimiting burst=25;
+		if ( $http_host != 'static.miraheze.org' ) {
+			limit_req zone=ratelimiting burst=25;
+		}
 
 		proxy_pass http://127.0.0.1:81;
 		proxy_http_version 1.1;
@@ -156,7 +161,9 @@ server {
 	add_header X-Frame-Options "ALLOW-FROM static.miraheze.org";
 
 	location / {
-		limit_req zone=ratelimiting burst=25;
+		if ( $http_host != 'static.miraheze.org' ) {
+			limit_req zone=ratelimiting burst=25;
+		}
 
 		proxy_pass http://127.0.0.1:81;
 		proxy_http_version 1.1;

--- a/modules/varnish/templates/mediawiki.conf
+++ b/modules/varnish/templates/mediawiki.conf
@@ -1,5 +1,19 @@
 # Rate limit client requests at NGINX level. Experimenting with 10 requests/sec
 # per IP, with 25 requests/sec delayed burst (for example, when loading static resources?)
+
+geo $whitelist {
+	default 0;
+	# CIDR in the list below are not limited
+	1.2.3.0/24 1;
+	9.10.11.12/32 1;
+	127.0.0.1/32 1;
+}
+
+map $whitelist $limit {
+	0     $binary_remote_addr;
+	1     "";
+}
+
 limit_req_zone $binary_remote_addr zone=ratelimiting:10m rate=10r/s;
 limit_req_status 429;
 


### PR DESCRIPTION
* Whitelist all of Miraheze ips
* Do not rate limit static.miraheze.org as it can handle the traffic