### PR TITLE
varnish: Change rate limit rules

### DIFF
--- a/modules/varnish/templates/mediawiki.conf
+++ b/modules/varnish/templates/mediawiki.conf
@@ -19,7 +19,7 @@ map $whitelist $limit {
 }
 
 limit_req_zone $limit zone=ratelimiting:10m rate=30r/s;
-limit_req_zone $limit zone=staticratelimiting:10m rate=100r/s;
+limit_req_zone $limit zone=staticratelimiting:10m rate=300r/s;
 limit_req_status 429;
 
 server {
@@ -94,7 +94,7 @@ server {
 	ssl_stapling_verify on;
 
 	location / {
-		limit_req zone=ratelimiting burst=40 nodelay;
+		limit_req zone=ratelimiting burst=20 nodelay;
 
 		proxy_pass http://127.0.0.1:81;
 		proxy_http_version 1.1;
@@ -195,7 +195,7 @@ server {
 	add_header X-Frame-Options "ALLOW-FROM static.miraheze.org";
 
 	location / {
-		limit_req zone=ratelimiting burst=40;
+		limit_req zone=ratelimiting burst=20;
 
 		proxy_pass http://127.0.0.1:81;
 		proxy_http_version 1.1;

--- a/modules/varnish/templates/mediawiki.conf
+++ b/modules/varnish/templates/mediawiki.conf
@@ -18,7 +18,8 @@ map $whitelist $limit {
 	1     "";
 }
 
-limit_req_zone $limit zone=ratelimiting:10m rate=20r/s;
+limit_req_zone $limit zone=ratelimiting:10m rate=30r/s;
+limit_req_zone $limit zone=staticratelimiting:10m rate=100r/s;
 limit_req_status 429;
 
 server {
@@ -42,6 +43,40 @@ server {
                 if ($request_uri !~ "^/healthcheck$") {
 			return 301 https://$host$request_uri;
 		}
+	}
+}
+
+server {
+	listen 443 ssl http2 deferred backlog=1024;
+	listen [::]:443 ssl http2 deferred ipv6only=on backlog=1024;
+
+	server_name static.miraheze.org;
+	root /var/www/html;
+
+	ssl_certificate /etc/ssl/certs/wildcard.miraheze.org.crt;
+	ssl_certificate_key /etc/ssl/private/wildcard.miraheze.org.key;
+
+	ssl_trusted_certificate /etc/ssl/certs/Sectigo.crt;
+	ssl_stapling_verify on;
+
+	location / {
+		limit_req zone=staticratelimiting burst=200 nodelay;
+
+		proxy_pass http://127.0.0.1:81;
+		proxy_http_version 1.1;
+		proxy_set_header Connection close;
+		proxy_set_header Host $host;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_read_timeout 140s;
+		proxy_send_timeout 140s;
+		send_timeout       140s;
+		proxy_buffer_size       32k;
+		proxy_buffers         4 32k;
+		# Remove duplicate headers that is already added on the frontend
+		proxy_hide_header     X-XSS-Protection;
+		proxy_hide_header     X-Frame-Options;
 	}
 }
 

--- a/modules/varnish/templates/mediawiki.conf
+++ b/modules/varnish/templates/mediawiki.conf
@@ -50,7 +50,7 @@ server {
 	listen 443 ssl http2 deferred backlog=1024;
 	listen [::]:443 ssl http2 deferred ipv6only=on backlog=1024;
 
-	server_name static.miraheze.org;
+	server_name miraheze.org *.miraheze.org;
 	root /var/www/html;
 
 	ssl_certificate /etc/ssl/certs/wildcard.miraheze.org.crt;
@@ -60,7 +60,7 @@ server {
 	ssl_stapling_verify on;
 
 	location / {
-		limit_req zone=staticratelimiting burst=200 nodelay;
+		limit_req zone=ratelimiting burst=20 nodelay;
 
 		proxy_pass http://127.0.0.1:81;
 		proxy_http_version 1.1;
@@ -81,10 +81,10 @@ server {
 }
 
 server {
-	listen 443 ssl http2 deferred backlog=1024;
-	listen [::]:443 ssl http2 deferred ipv6only=on backlog=1024;
+	listen 443 ssl http2;
+	listen [::]:443 ssl http2;
 
-	server_name miraheze.org *.miraheze.org;
+	server_name static.miraheze.org;
 	root /var/www/html;
 
 	ssl_certificate /etc/ssl/certs/wildcard.miraheze.org.crt;
@@ -94,7 +94,7 @@ server {
 	ssl_stapling_verify on;
 
 	location / {
-		limit_req zone=ratelimiting burst=20 nodelay;
+		limit_req zone=staticratelimiting burst=200 nodelay;
 
 		proxy_pass http://127.0.0.1:81;
 		proxy_http_version 1.1;

--- a/modules/varnish/templates/mediawiki.conf
+++ b/modules/varnish/templates/mediawiki.conf
@@ -18,7 +18,7 @@ map $whitelist $limit {
 	1     "";
 }
 
-limit_req_zone $limit zone=ratelimiting:10m rate=10r/s;
+limit_req_zone $limit zone=ratelimiting:10m rate=20r/s;
 limit_req_status 429;
 
 server {
@@ -59,40 +59,8 @@ server {
 	ssl_stapling_verify on;
 
 	location / {
-		limit_req zone=ratelimiting burst=25;
+		limit_req zone=ratelimiting burst=40 nodelay;
 
-		proxy_pass http://127.0.0.1:81;
-		proxy_http_version 1.1;
-		proxy_set_header Connection close;
-		proxy_set_header Host $host;
-		proxy_set_header X-Real-IP $remote_addr;
-		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-		proxy_set_header X-Forwarded-Proto $scheme;
-		proxy_read_timeout 140s;
-		proxy_send_timeout 140s;
-		send_timeout       140s;
-		proxy_buffer_size       32k;
-		proxy_buffers         4 32k;
-		# Remove duplicate headers that is already added on the frontend
-		proxy_hide_header     X-XSS-Protection;
-		proxy_hide_header     X-Frame-Options;
-	}
-}
-
-server {
-	listen 443 ssl http2;
-	listen [::]:443 ssl http2;
-
-	server_name static.miraheze.org;
-	root /var/www/html;
-
-	ssl_certificate /etc/ssl/certs/wildcard.miraheze.org.crt;
-	ssl_certificate_key /etc/ssl/private/wildcard.miraheze.org.key;
-
-	ssl_trusted_certificate /etc/ssl/certs/Sectigo.crt;
-	ssl_stapling_verify on;
-
-	location / {
 		proxy_pass http://127.0.0.1:81;
 		proxy_http_version 1.1;
 		proxy_set_header Connection close;
@@ -192,7 +160,7 @@ server {
 	add_header X-Frame-Options "ALLOW-FROM static.miraheze.org";
 
 	location / {
-		limit_req zone=ratelimiting burst=25;
+		limit_req zone=ratelimiting burst=40;
 
 		proxy_pass http://127.0.0.1:81;
 		proxy_http_version 1.1;


### PR DESCRIPTION
* Increase rate limiting to 30r/s.
* Increase bursts to 20.
* Use nodelay (reference https://www.nginx.com/blog/rate-limiting-nginx/#Queueing-with-No-Delay).
* Introduces a static rate limiter allowing up to 300 requests a second with a burst of up to 200.