### PR TITLE
varnish: Increase rate limit for static to 500/1s

### DIFF
--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -169,7 +169,7 @@ sub mw_identify_device {
 sub mw_rate_limit {
 	# Allow higher limits for static.mh.o, we can handle more of those requests
 	if (req.http.Host == "static.miraheze.org") {
-		if (vsthrottle.is_denied("static:" + req.http.X-Real-IP, 120, 10s)) {
+		if (vsthrottle.is_denied("static:" + req.http.X-Real-IP, 500, 1s)) {
 			return (synth(429, "Varnish Rate Limit Exceeded"));
 		}
 	} else {


### PR DESCRIPTION
The reason is static can handle much more without issues. So 120 over 10s was little especially for static which can handle even more than 500 but I think 500 is a good in between number in the meantime till I get @Southparkfan thoughts.