### PR TITLE
Temp comment manageInactiveWikis (due to T6403)

### DIFF
--- a/modules/mediawiki/manifests/jobrunner.pp
+++ b/modules/mediawiki/manifests/jobrunner.pp
@@ -67,13 +67,14 @@ class mediawiki::jobrunner {
             hour    => '18',
         }
 
-        cron { 'managewikis':
+        /*cron { 'managewikis':
             ensure  => absent,
             command => '/usr/bin/php /srv/mediawiki/w/extensions/CreateWiki/maintenance/manageInactiveWikis.php --wiki loginwiki --write > /var/log/mediawiki/cron/managewikis.log',
             user    => 'www-data',
             minute  => '5',
             hour    => '12',
-        }
+        }*/
+
 
         cron { 'update rottenlinks on all wikis':
             ensure  => present,


### PR DESCRIPTION
I apologize if this is not the right action to take but it shouldn't be on if it's malfunctioning anyway. I am not all that familiar with puppet either, so I may not have done it correctly either.