### PR TITLE
gluster: Monitor the service rather than the port

### DIFF
--- a/modules/base/templates/icinga/nrpe.cfg.erb
+++ b/modules/base/templates/icinga/nrpe.cfg.erb
@@ -42,6 +42,10 @@ command[check_jobchron]=/usr/lib/nagios/plugins/check_procs -a redisJobChronServ
 command[check_jobqueue]=/usr/bin/sudo -u www-data /usr/lib/nagios/plugins/check_jobqueue
 command[check_icinga_config]=/usr/lib/nagios/plugins/check_icinga_config /etc/icinga/icinga.cfg
 command[check_mysql-replication]=/usr/lib/nagios/plugins/check_mysql-replication.pl -sa localhost -sl icinga -spd <%= @icinga_password %> -a both -w 10 -c 30 -D "MariaDB replication - "
+# glusterfs deamon
+command[check_glusterd]=/usr/lib/nagios/plugins/check_procs -a /usr/sbin/glusterd -c 1:
+# glusterfs brick
+command[check_glusterd_volume]=/usr/lib/nagios/plugins/check_procs -a /usr/sbin/glusterfsd -c 1:
 
 # check stunnel http
 command[check_stunnel_mon1]=/usr/lib/nagios/plugins/check_http -H localhost:8201

--- a/modules/gluster/manifests/init.pp
+++ b/modules/gluster/manifests/init.pp
@@ -74,13 +74,18 @@ class gluster {
         }
     }
 
-    [24007, 49152].each |$port| {
-        monitoring::services { "GlusterFS port ${port}":
-            check_command => 'tcp',
-            vars          => {
-                tcp_port    => $port,
-            },
-        }
+    monitoring::services { 'glusterd':
+        check_command => 'nrpe',
+        vars          => {
+            nrpe_command => 'check_glusterd',
+        },
+    }
+
+    monitoring::services { 'glusterd_volume':
+        check_command => 'nrpe',
+        vars          => {
+            nrpe_command => 'check_glusterd_volume',
+        },
     }
 
     if lookup('gluster_client', {'default_value' => false}) {


### PR DESCRIPTION
The port changes when you restart the services, so is better to monitor by service.