### PR TITLE
Remove non-*.miraheze.org domains from frame_whitelist

### DIFF
--- a/modules/varnish/data/frame_whitelist.yaml
+++ b/modules/varnish/data/frame_whitelist.yaml
@@ -1,5 +1,5 @@
 # Only add a domain if really necessary.
 # Allows external websites to frame Miraheze. 
-# DOES NOT allow miraheze wikis frame external sites.
+# DOES NOT allow miraheze wikis to frame external sites.
 # For that, use csp_whitelist.
 url1: '*.miraheze.org'

--- a/modules/varnish/data/frame_whitelist.yaml
+++ b/modules/varnish/data/frame_whitelist.yaml
@@ -1,2 +1,5 @@
 # Only add a domain if really necessary.
+# Allows external websites to frame Miraheze. 
+# DOES NOT allow miraheze wikis frame external sites.
+# For that, use csp_whitelist.
 url1: '*.miraheze.org'

--- a/modules/varnish/data/frame_whitelist.yaml
+++ b/modules/varnish/data/frame_whitelist.yaml
@@ -1,4 +1,2 @@
 # Only add a domain if really necessary.
 url1: '*.miraheze.org'
-url2: 'www.desmos.com'
-url3: 'snap.berkeley.edu'

--- a/modules/varnish/data/frame_whitelist.yaml
+++ b/modules/varnish/data/frame_whitelist.yaml
@@ -1,5 +1,5 @@
 # Only add a domain if really necessary.
 # Allows external websites to frame Miraheze. 
-# DOES NOT allow miraheze wikis to frame external sites.
+# DOES NOT allow Miraheze wikis to frame external sites.
 # For that, use csp_whitelist.
 url1: '*.miraheze.org'


### PR DESCRIPTION
the frame whitelist allows external domains to frame Miraheze, not allowing Miraheze wikis to frame them, therefore these should not be whitelisted here. 