### PR TITLE
revert "Varnish: Only whitelist matomo.miraheze.org for connect-src"

### DIFF
--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -390,7 +390,7 @@ sub vcl_deliver {
 		set resp.http.X-Cache = "<%= scope.lookupvar('::hostname') %> MISS (0)";
 	}
 
-	set resp.http.Content-Security-Policy = "default-src 'self' blob: data: <%- @csp_whitelist.each_pair do |config, value| -%> <%= value %> <%- end -%> 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'self' <%- @frame_whitelist.each_pair do |config, value| -%> <%= value %> <%- end -%>; connect-src https://matomo.miraheze.org;";
+	set resp.http.Content-Security-Policy = "default-src 'self' blob: data: <%- @csp_whitelist.each_pair do |config, value| -%> <%= value %> <%- end -%> 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'self' <%- @frame_whitelist.each_pair do |config, value| -%> <%= value %> <%- end -%>; connect-src 'self'";
 }
 
 sub vcl_backend_error {


### PR DESCRIPTION
Likely causing `Refused to connect to 'https://meta.miraheze.org/wiki/Miraheze' because it violates the following Content Security Policy directive: "connect-src https://matomo.miraheze.org".`