### PR TITLE
Remove update_database_lists cron

### DIFF
--- a/modules/mediawiki/manifests/cron.pp
+++ b/modules/mediawiki/manifests/cron.pp
@@ -2,14 +2,6 @@
 #
 # Used for CORE crons which should be ran on every MediaWiki server.
 class mediawiki::cron {
-    cron { 'update_database_lists':
-        ensure  => absent,
-        command => '/usr/bin/php /srv/mediawiki/w/extensions/CreateWiki/maintenance/DBListGenerator.php --wiki metawiki',
-        user    => 'www-data',
-        minute  => '*',
-        hour    => '*',
-    }
-
     cron { 'update.php for LocalisationUpdate':
         ensure  => present,
         command => '/usr/bin/php /srv/mediawiki/w/extensions/LocalisationUpdate/update.php --wiki loginwiki > /var/log/mediawiki/debuglogs/l10nupdate.log',


### PR DESCRIPTION
It has been absented for quite a while so is safe to remove now.