### PR TITLE
mediawiki: Fix private location

### DIFF
--- a/modules/mediawiki/templates/mediawiki.conf.erb
+++ b/modules/mediawiki/templates/mediawiki.conf.erb
@@ -190,11 +190,11 @@ server {
 		try_files /../../usr/share/nginx/favicons/apple-touch-icon-$host.png /../../usr/share/nginx/favicons/apple-touch-icon-default.png;
 	}
 
-	location /private {
+	location /private/ {
 		deny all;
 	}
 
-	location /dumps {
+	location /dumps/ {
 		autoindex on;
 	}
 }


### PR DESCRIPTION
Some wikis contained private in their name so fix this by adding a slash.