### PR TITLE
mediawiki: Change git clone depth for cloning core to 1

### DIFF
--- a/modules/mediawiki/manifests/init.pp
+++ b/modules/mediawiki/manifests/init.pp
@@ -55,6 +55,7 @@ class mediawiki(
         group              => 'www-data',
         mode               => '0755',
         timeout            => '1500',
+        depth              => '1',
         recurse_submodules => true,
         require            => File['/srv/mediawiki'],
     }


### PR DESCRIPTION
Should speed things up, and also use less disk space