### PR TITLE
cloud: Do not use syslog_ng

### DIFF
--- a/hieradata/hosts/cloud1.yaml
+++ b/hieradata/hosts/cloud1.yaml
@@ -1,3 +1,4 @@
+base::syslog::syslog_daemon: 'rsyslog'
 
 # Network setup
 role::cloud::main_ip4_address: 54.36.165.86

--- a/hieradata/hosts/cloud2.yaml
+++ b/hieradata/hosts/cloud2.yaml
@@ -1,3 +1,4 @@
+base::syslog::syslog_daemon: 'rsyslog'
 
 # Network setup
 role::cloud::main_ip4_address: 54.36.165.90

--- a/hieradata/hosts/cloud3.yaml
+++ b/hieradata/hosts/cloud3.yaml
@@ -1,3 +1,5 @@
+base::syslog::syslog_daemon: 'rsyslog'
+
 # Network setup
 role::cloud::main_ip4_address: 51.68.206.11
 role::cloud::main_ip4_netmask: 255.255.255.0

--- a/hieradata/hosts/cloud4.yaml
+++ b/hieradata/hosts/cloud4.yaml
@@ -1,3 +1,5 @@
+base::syslog::syslog_daemon: 'rsyslog'
+
 # Network setup
 role::cloud::main_interface: 'enp1s0f0'
 role::cloud::main_ip4_address: 51.68.206.138

--- a/hieradata/hosts/cloud5.yaml
+++ b/hieradata/hosts/cloud5.yaml
@@ -1,3 +1,5 @@
+base::syslog::syslog_daemon: 'rsyslog'
+
 # Network setup
 role::cloud::main_interface: 'enp1s0f0'
 role::cloud::main_ip4_address: 51.77.117.189


### PR DESCRIPTION
We need to log locally because incase of failures, it may not log to graylog.

This is to be on the safe side.