### PR TITLE
rdns-check: change regex to not match nonexistent cp*

### DIFF
--- a/modules/monitoring/templates/ssl.conf.erb
+++ b/modules/monitoring/templates/ssl.conf.erb
@@ -33,7 +33,7 @@ apply Service "<%= property['url'] %> - reverse DNS" {
   check_command = "reverse_dns"
   check_interval = 7m
   vars.hostname = "<%= property['url'] %>"
-  vars.regex = "^cp[0-9]+\\.miraheze\\.org$$"
+  vars.regex = "^cp[3|10|11|12]+\\.miraheze\\.org$$"
   assign where "sslchecks" in host.groups
 }
 <% end -%>

--- a/modules/monitoring/templates/ssl.conf.erb
+++ b/modules/monitoring/templates/ssl.conf.erb
@@ -33,7 +33,7 @@ apply Service "<%= property['url'] %> - reverse DNS" {
   check_command = "reverse_dns"
   check_interval = 7m
   vars.hostname = "<%= property['url'] %>"
-  vars.regex = "^cp[3|10|11|12]+\\.miraheze\\.org$$"
+  vars.regex = "^cp(3|10|11|12)+\\.miraheze\\.org$$"
   assign where "sslchecks" in host.groups
 }
 <% end -%>


### PR DESCRIPTION
Current regex will match cp4,5,6,7,8,9 etc all which don't exist and being pointed at that caused at least one wiki to go down. We should alert to find others.