### PR TITLE
icingaweb2: Work around an issue with groups

### DIFF
--- a/modules/icingaweb2/templates/roles.ini.erb
+++ b/modules/icingaweb2/templates/roles.ini.erb
@@ -10,8 +10,10 @@ permissions = "module/monitoring, monitoring/command/*"
 
 [sre-mediawiki-view]
 groups = "sre-mediawiki"
+monitoring/filter/objects = "host_name=*"
 permissions = "module/doc, module/monitoring"
 
 [guest]
 users = "guest"
+monitoring/filter/objects = "host_name=*"
 permissions = "no-user/password-change, module/doc, module/monitoring, module/translation"

--- a/modules/icingaweb2/templates/roles.ini.erb
+++ b/modules/icingaweb2/templates/roles.ini.erb
@@ -1,10 +1,7 @@
 [Administrators]
 groups = "sre-infrastructure,sre-management"
+monitoring/filter/objects = "host_name=*"
 permissions = "*"
-
-[guest]
-users = "guest"
-permissions = "no-user/password-change, module/doc, module/monitoring, module/translation"
 
 [sre-mediawiki]
 groups = "sre-mediawiki"
@@ -14,3 +11,7 @@ permissions = "module/monitoring, monitoring/command/*"
 [sre-mediawiki-view]
 groups = "sre-mediawiki"
 permissions = "module/doc, module/monitoring"
+
+[guest]
+users = "guest"
+permissions = "no-user/password-change, module/doc, module/monitoring, module/translation"


### PR DESCRIPTION
This is setting monitoring/filter/objects to "host_name=*" which appears to work around an issue if you are in the sre-infra group and sre-mediawiki group.

This fix was discovered by @JohnFLewis.