### PR TITLE
syslog: Add timestamp to output

### DIFF
--- a/modules/base/manifests/syslog.pp
+++ b/modules/base/manifests/syslog.pp
@@ -59,7 +59,8 @@ class base::syslog (
                                 ],
                         }
                 } ->
-                # The 
+                # This is needed as it appears the output doesn't have
+                # a timestamp.
                 syslog_ng::template {'t_add_timestamp':
                     params => [
                         {

--- a/modules/base/manifests/syslog.pp
+++ b/modules/base/manifests/syslog.pp
@@ -59,6 +59,23 @@ class base::syslog (
                                 ],
                         }
                 } ->
+                # The 
+                syslog_ng::template {'t_add_timestamp':
+                    params => [
+                        {
+                            'type' => 'template',
+                            'options' => [
+                                '"$ISODATE $MSGHDR$MESSAGE\n"'
+                            ]
+                        },
+                        {
+                            'type' => 'template_escape',
+                            'options' => [
+                                'no'
+                            ]
+                        }
+                    ]
+                } ->
                 syslog_ng::destination { 'd_graylog_syslog_tls':
                         params => {
                                 type    => 'syslog',
@@ -99,6 +116,13 @@ class base::syslog (
                                                         }
                                                 ]
                                         },
+                                        {
+                                                'template' => [
+                                                        { 
+                                                                't_add_timestamp'
+                                                        }
+                                                ]
+                                        }
                                 ],
                         },
                 } ->

--- a/modules/base/manifests/syslog.pp
+++ b/modules/base/manifests/syslog.pp
@@ -68,12 +68,6 @@ class base::syslog (
                             'options' => [
                                 '"$ISODATE $MSGHDR$MESSAGE\n"'
                             ]
-                        },
-                        {
-                            'type' => 'template_escape',
-                            'options' => [
-                                'no'
-                            ]
                         }
                     ]
                 } ->


### PR DESCRIPTION
It appears that the message didn't include a timestamp in the output. This change adds it to the output.