### PR TITLE
varnish: Centralise Access-Control-Allow-Origin header

### DIFF
--- a/modules/mediawiki/templates/mediawiki-includes.conf.erb
+++ b/modules/mediawiki/templates/mediawiki-includes.conf.erb
@@ -51,12 +51,6 @@ location ^~ /wiki/ {
 	fastcgi_pass unix:/run/<%= @php_fpm_sock %>;
 }
 
-location ~* .(gif|ico|jpg|jpeg|png|svg)$ {
-	expires 1w;
-
-	add_header Access-Control-Allow-Origin '*' always;
-}
-
 location ~ ^/m/(.*) {
 	return 301 /w/index.php?title=Special:UrlRedirector/$1;
 }

--- a/modules/mediawiki/templates/mediawiki.conf.erb
+++ b/modules/mediawiki/templates/mediawiki.conf.erb
@@ -169,20 +169,9 @@ server {
 
 	add_header X-Frame-Options "ALLOW-FROM static.miraheze.org";
 
-	location ~* .(gif|jpe?g|pdf|png|css|js|json|woff|woff2|svg|eot|ttf|otf|ico|sfnt|stl|STL)$ {
-		expires 1w;
-
-		add_header Access-Control-Allow-Origin '*' always;
-	}
-
 	error_page 404 =404 @notfound;
 
 	location @notfound {
-		# Work around the issue affecting T5568.
-		if ($request_uri ~* "(.*\.(gif|jpe?g|pdf|png|css|js|json|woff|woff2|svg|eot|ttf|otf|ico|sfnt|stl|STL)$)") {
-			add_header Access-Control-Allow-Origin '*' always;
-		}
-
 		rewrite ^/(.*)wiki/thumb/(.+)$ https://$1.miraheze.org/w/thumb_handler.php/$2;
 	}
 

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -381,7 +381,7 @@ sub vcl_backend_response {
 
 sub vcl_deliver {
 	# We set Access-Control-Allow-Origin to * for all files hosted on
-	# static.miraheze.org. We also set a hack for T217669.
+	# static.miraheze.org. We also set a hack for phabricator.wikimedia.org/T217669.
 	# And finally we also set this header for some images hosted on the
 	# same site as the wiki (private).
 	if (

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -380,12 +380,16 @@ sub vcl_backend_response {
 }
 
 sub vcl_deliver {
-	if (req.url ~ "(?i)\.(gif|jpg|jpeg|pdf|png|css|js|json|woff|woff2|svg|eot|ttf|otf|ico|sfnt)$") {
-		set resp.http.Access-Control-Allow-Origin = "*";
-	}
-
+	# We set Access-Control-Allow-Origin to * for all files hosted on
+	# static.miraheze.org We also set a hack for T217669.
+	# Finally we also set this header for some images hosted on the same site
+	# as the wiki (private).
 	# HACK for T217669
-	if (req.url ~ "/w/api.php") {
+	if (
+		req.http.Host == "static.miraheze.org" ||
+		req.url ~ "/w/api.php" ||
+		req.url ~ "(?i)\.(gif|jpg|jpeg|pdf|png|css|js|json|woff|woff2|svg|eot|ttf|otf|ico|sfnt)$"
+	) {
 		set resp.http.Access-Control-Allow-Origin = "*";
 	}
 

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -381,10 +381,9 @@ sub vcl_backend_response {
 
 sub vcl_deliver {
 	# We set Access-Control-Allow-Origin to * for all files hosted on
-	# static.miraheze.org We also set a hack for T217669.
-	# Finally we also set this header for some images hosted on the same site
-	# as the wiki (private).
-	# HACK for T217669
+	# static.miraheze.org. We also set a hack for T217669.
+	# And finally we also set this header for some images hosted on the
+	# same site as the wiki (private).
 	if (
 		req.http.Host == "static.miraheze.org" ||
 		req.url ~ "/w/api.php" ||


### PR DESCRIPTION
We also set it for all files hosted on static.miraheze.org.

Bug: T6730