### PR TITLE
Have MirahezeLogbot insert {{TOC right}} on every edit

### DIFF
--- a/modules/irc/files/logbot/adminlog.py
+++ b/modules/irc/files/logbot/adminlog.py
@@ -33,7 +33,7 @@ def log(config, message, project, author):
     position = 0
     # Um, check the date
     now = datetime.datetime.utcnow()
-    logline = "* %02d:%02d %s: %s" % (now.hour, now.minute, author, message)
+    logline = "{{TOC right}} <br /> <br /> * %02d:%02d %s: %s" % (now.hour, now.minute, author, message)
 
     # Try extracting latest date header
     header = "=" * config.wiki_header_depth
@@ -47,7 +47,7 @@ def log(config, message, project, author):
                 header_date = None
             break
     if header_date != [now.year, now.month, now.day]:
-        lines.insert(0, "{{TOC right}} <br />")
+        lines.insert(0, "")
         lines.insert(0, logline)
         lines.insert(0, now.strftime("{0} %Y-%m-%d {0}".format(header)))
     else:

--- a/modules/irc/files/logbot/adminlog.py
+++ b/modules/irc/files/logbot/adminlog.py
@@ -47,7 +47,7 @@ def log(config, message, project, author):
                 header_date = None
             break
     if header_date != [now.year, now.month, now.day]:
-        lines.insert(0, "")
+        lines.insert(0, "{{TOC right}} <br />")
         lines.insert(0, logline)
         lines.insert(0, now.strftime("{0} %Y-%m-%d {0}".format(header)))
     else:


### PR DESCRIPTION
Might be a better way to fix this, but if MirahezeLogbot inserts `{{TOC right}}` with every edit, it'll always be at the top of `Tech:Server admin log`