### PR TITLE
adminlog: maintain text above the first header

### DIFF
--- a/modules/irc/files/logbot/adminlog.py
+++ b/modules/irc/files/logbot/adminlog.py
@@ -47,9 +47,9 @@ def log(config, message, project, author):
                 header_date = None
             break
     if header_date != [now.year, now.month, now.day]:
-        lines.insert(0, "")
-        lines.insert(0, logline)
-        lines.insert(0, now.strftime("{0} %Y-%m-%d {0}".format(header)))
+        lines.insert(position-1, "")
+        lines.insert(position-1, logline)
+        lines.insert(position-1, now.strftime("{0} %Y-%m-%d {0}".format(header)))
     else:
         lines.insert(position, logline)
     if config.wiki_category:


### PR DESCRIPTION
I ran a few tests and this seems to work.

This is so {{TOCRIGHT}} doesn't end up being stuck at a random part of the page.

Replaces #1664 by @dmehus 