### PR TITLE
varnish: Stop varnishncsa service

### DIFF
--- a/modules/varnish/manifests/init.pp
+++ b/modules/varnish/manifests/init.pp
@@ -88,6 +88,11 @@ class varnish(
         require => Service['varnish'],
     }
 
+    service { 'varnishncsa':
+        ensure  => 'stop',
+        require => Package['varnish'],
+    }
+
     # Unfortunately, varnishlog can't log to syslog
     logrotate::conf { 'varnishlog_logs':
         ensure  => present,


### PR DESCRIPTION
This isn't producing interesting logs that we want, so we can stop this. This will reduce disk space issues.