### PR TITLE
puppetserver: +ssh key

### DIFF
--- a/modules/puppetserver/manifests/init.pp
+++ b/modules/puppetserver/manifests/init.pp
@@ -256,5 +256,13 @@ class puppetserver(
         vars          => {
             tcp_port    => '8140',
         },
+    users::user { 'puppet-users':
+        ensure      => present,
+        uid         => 2004,
+        gid         => 2004,
+        ssh_keys    => [
+            'puppet-users@jobrunner3.miraheze.org'
+        ],
+    }
     }
 }


### PR DESCRIPTION
This key should be generated from jbr3 and will be used to sync private keys from jbr3->puppet2 under a new system.

The jobrunner stuff will come shortly in a seperate pr.

It must only be available to puppet-users but most of the human work will soon be eliminated.