### PR TITLE
Create web redirect for /donate, per suggestion of RobLa on Discord

### DIFF
--- a/modules/mediawiki/templates/mediawiki.conf.erb
+++ b/modules/mediawiki/templates/mediawiki.conf.erb
@@ -68,6 +68,11 @@ server {
 	location /discord {
 		return 301 https://discord.gg/v7HeT96;
 	}
+
+	location /donate {
+		return 301 https://donate.miraheze.org;
+	}
+
 }
 
 server {


### PR DESCRIPTION
Props to @Universal-Omega and @paladox for telling me which file to edit. Could also make the target https://meta.miraheze.org/wiki/Donate, but this seems reasonable, based on my discussions with Omega