### PR TITLE
gluster: Remove gluster.[pem|key|ca] file

### DIFF
--- a/modules/gluster/manifests/init.pp
+++ b/modules/gluster/manifests/init.pp
@@ -11,37 +11,6 @@ class gluster {
         require  => Class['gluster::apt'],
     }
 
-    if !defined(File['glusterfs.pem']) {
-        file { 'glusterfs.pem':
-            ensure => 'present',
-            source => 'puppet:///ssl/certificates/wildcard.miraheze.org-2020-2.crt',
-            path   => '/etc/ssl/glusterfs.pem',
-            owner  => 'root',
-            group  => 'root',
-        }
-    }
-
-    if !defined(File['glusterfs.key']) {
-        file { 'glusterfs.key':
-            ensure => 'present',
-            source => 'puppet:///ssl-keys/wildcard.miraheze.org-2020-2.key',
-            path   => '/etc/ssl/glusterfs.key',
-            owner  => 'root',
-            group  => 'root',
-            mode   => '0660',
-        }
-    }
-
-    if !defined(File['glusterfs.ca']) {
-        file { 'glusterfs.ca':
-            ensure => 'present',
-            source => 'puppet:///ssl/ca/Sectigo.crt',
-            path   => '/etc/ssl/glusterfs.ca',
-            owner  => 'root',
-            group  => 'root',
-        }
-    }
-
     if !defined(File['/var/lib/glusterd/secure-access']) {
         file { '/var/lib/glusterd/secure-access':
             ensure  => present,

--- a/modules/gluster/manifests/mount.pp
+++ b/modules/gluster/manifests/mount.pp
@@ -79,37 +79,6 @@ define gluster::mount (
 		group  => 'www-data',
 	}
 
-	if !defined(File['glusterfs.pem']) {
-		file { 'glusterfs.pem':
-			ensure => 'present',
-			source => 'puppet:///ssl/certificates/wildcard.miraheze.org-2020-2.crt',
-			path   => '/etc/ssl/glusterfs.pem',
-			owner  => 'root',
-			group  => 'root',
-		}
-	}
-
-	if !defined(File['glusterfs.key']) {
-		file { 'glusterfs.key':
-			ensure => 'present',
-			source => 'puppet:///ssl-keys/wildcard.miraheze.org-2020-2.key',
-			path   => '/etc/ssl/glusterfs.key',
-			owner  => 'root',
-			group  => 'root',
-			mode   => '0660',
-		}
-	}
-
-	if !defined(File['glusterfs.ca']) {
-		file { 'glusterfs.ca':
-			ensure => 'present',
-			source => 'puppet:///ssl/ca/Sectigo.crt',
-			path   => '/etc/ssl/glusterfs.ca',
-			owner  => 'root',
-			group  => 'root',
-		}
-	}
-
 	if !defined(File['/var/lib/glusterd/secure-access']) {
 		file { '/var/lib/glusterd':
 			ensure  => directory,


### PR DESCRIPTION
This is not needed as we set a different a different path to our certificate.