### PR TITLE
users: remove usage of the deprecated function is_array

### DIFF
--- a/modules/users/manifests/user.pp
+++ b/modules/users/manifests/user.pp
@@ -39,7 +39,7 @@ define users::user(
         }
     }
 
-    if !is_array($ssh_keys) {
+    if !($ssh_keys =~ Array) {
         fail("${name} is not a valid ssh_keys array: ${ssh_keys}")
     }
 


### PR DESCRIPTION
the function was deprecated as of puppet 5