### PR TITLE
set depth to 1 instead of 5 for cloning core

### DIFF
--- a/modules/mediawiki/manifests/init.pp
+++ b/modules/mediawiki/manifests/init.pp
@@ -59,7 +59,7 @@ class mediawiki(
         group              => 'www-data',
         mode               => '0755',
         timeout            => '1500',
-        depth              => '5',
+        depth              => '1',
         recurse_submodules => true,
         require            => File['/srv/mediawiki'],
     }


### PR DESCRIPTION
To hopefully fix puppet timeouts