### PR TITLE
Revert "MirahezeLogbot: Don't join #miraheze-sre-security"

### DIFF
--- a/modules/irc/templates/logbot/config.py
+++ b/modules/irc/templates/logbot/config.py
@@ -29,7 +29,7 @@ twitter_api_params = {
 }
 
 # Channels to join
-targets = ("#miraheze-sre")
+targets = ("#miraheze-sre", "#miraheze-sre-security")
 
 # Name of nickserv user
 nickserv = "nickserv"
@@ -43,7 +43,7 @@ nick_username = "mirahezebots"
 # Password to identify with
 nick_password = "<%= @mirahezebots_password %>"
 
-# Network to join (ex: irc.libera.chat)
+# Network to join (ex: irc.freenode.net)
 network = "irc.libera.chat"
 
 # Port to use when joining network (ex: 7000). Should support SSL.


### PR DESCRIPTION
Reverts miraheze/puppet#1757

Quoting John from 2018 heh, but just figured this out:
[2018-07-03 02:48:46] <JohnLewis> paladox: for some reason, only having 1 channel causes the logbot to fail to join
[2018-07-03 02:48:55] <JohnLewis> which may explain why I left it like that intentionally 