### PR TITLE
Don't allow RemovePII to ever be ran with mwscript

### DIFF
--- a/modules/mediawiki/files/mwscript.py
+++ b/modules/mediawiki/files/mwscript.py
@@ -10,7 +10,7 @@ if len(script.split('/')) == 1:
 else:
     scriptsplit = script.split('/')
     if scriptsplit[2] == "removePII.php":
-        raise Exception("Can not run removePII with mwscript")
+        raise Exception("Can not run RemovePII with mwscript")
     script = script = f'/srv/mediawiki/w/{scriptsplit[0]}/{scriptsplit[1]}/maintenance/{scriptsplit[2]}'
 wiki = sys.argv[2]
 command = f'sudo -u www-data php {script} --wiki={wiki}'

--- a/modules/mediawiki/files/mwscript.py
+++ b/modules/mediawiki/files/mwscript.py
@@ -9,6 +9,8 @@ if len(script.split('/')) == 1:
     script = f'/srv/mediawiki/w/maintenance/{sys.argv[1]}'
 else:
     scriptsplit = script.split('/')
+    if scriptsplit[2] == "removePII.php":
+        raise Exception("Can not run removePII with mwscript")
     script = script = f'/srv/mediawiki/w/{scriptsplit[0]}/{scriptsplit[1]}/maintenance/{scriptsplit[2]}'
 wiki = sys.argv[2]
 command = f'sudo -u www-data php {script} --wiki={wiki}'

--- a/modules/mediawiki/files/mwscript.py
+++ b/modules/mediawiki/files/mwscript.py
@@ -10,7 +10,7 @@ if len(script.split('/')) == 1:
 else:
     scriptsplit = script.split('/')
     if scriptsplit[2] == "removePII.php":
-        raise Exception("Can not run RemovePII with mwscript")
+        raise Exception("RemovePII can't be executed with mwscript")
     script = script = f'/srv/mediawiki/w/{scriptsplit[0]}/{scriptsplit[1]}/maintenance/{scriptsplit[2]}'
 wiki = sys.argv[2]
 command = f'sudo -u www-data php {script} --wiki={wiki}'


### PR DESCRIPTION
Just as a precaution if someone did it would log the information its supposed to remove.

Alternatively we could do something like (possibly not exact but likely similar):
```python3
if scriptsplit[2] != "removePII.php":
    os.system(logcommand)
```
Feel free to close if really unnecessary.