### PR TITLE
Update default.vcl

### DIFF
--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -9,8 +9,8 @@
 # please contact Southparkfan <southparkfan [at] miraheze [dot] org>.
 
 # Marker to tell the VCL compiler that this VCL has been adapted to the
-# new 4.0 format.
-vcl 4.0;
+# new 4.1 format.
+vcl 4.1;
 
 import directors;
 import std;

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -370,11 +370,6 @@ sub vcl_backend_fetch {
 }
 
 sub vcl_backend_response {
-	# Don't cache 50x responses
-	if (beresp.status == 500 || beresp.status == 502 || beresp.status == 503 || beresp.status == 504) {
-		set beresp.uncacheable = true;
-	}
-
 	if (beresp.ttl <= 0s) {
 		set beresp.ttl = 1800s;
 		set beresp.uncacheable = true;


### PR DESCRIPTION
This should potentially fix [T7441](https://phabricator.miraheze.org/T7441).

If this does not fix it, we would have to see why the following is not called:
```vcl
sub recv_purge {
	if (req.method == "PURGE") {
		if (!client.ip ~ purge) {
			return (synth(405, "Denied."));
		} else {
			return (purge);
		}
	}
}
```
That is supposed to be called with [`call recv_purge;`](https://github.com/miraheze/puppet/blob/ea1e5bb/modules/varnish/templates/default.vcl#L306) from [`vcl_recv`](https://github.com/miraheze/puppet/blob/ea1e5bb/modules/varnish/templates/default.vcl#L305).

The only reason I can see why this would not be called is if [`client.ip`](https://github.com/miraheze/puppet/blob/ea1e5bb/modules/varnish/templates/default.vcl#L225) is not in the [`acl purge`](https://github.com/miraheze/puppet/blob/ea1e5bb/modules/varnish/templates/default.vcl#L110-L136). If that's the case I am not sure what `client.ip` is calling the purge request or what IP needs added to the purge access control level.


There is no guarantee that anything I've said here is accurate, and may be totally off-base.