### PR TITLE
check_rdns: throw away anything after /

### DIFF
--- a/modules/monitoring/files/check_reverse_dns.py
+++ b/modules/monitoring/files/check_reverse_dns.py
@@ -63,7 +63,7 @@ def get_reverse_dnshostname(hostname):
                 dns_resolver = resolver.Resolver(configure=False)
                 dns_resolver.nameservers = ['1.1.1.1']
 
-                resolved_ip_addr = str(dns_resolver.query(hostname, 'A')[0])
+                resolved_ip_addr = str(dns_resolver.query(hostname.split('/')[0], 'A')[0])
                 ptr_record = reversename.from_address(resolved_ip_addr)
                 rev_host = str(resolver.query(ptr_record, "PTR")[0]).rstrip('.')
 


### PR DESCRIPTION
We have a path based redirect. Without messing around with checking schema's and stuff urlparse won't be useful. Just split it at / and chuck anything after away as you won't see a / in a url