### PR TITLE
demo for more complex redirects

### DIFF
--- a/modules/varnish/templates/mediawiki.conf
+++ b/modules/varnish/templates/mediawiki.conf
@@ -92,6 +92,14 @@ server {
 	add_header Strict-Transport-Security "max-age=604800";
 	<%- end -%>
 
+	<%- if property['alt_redirects'] -%>
+	<%- property['alt_redirects'].each_pair do | source, target | -%>
+	location <%= source %> {
+		return 301 https://<%= target %>$request_uri;
+	}
+	<%- end -%>
+	<%- end -%>
+
 	return 301 https://<%= property['redirect'] %>$request_uri;
 }
 
@@ -128,6 +136,14 @@ server {
 	add_header x-xss-protection "1; mode=block" always;
 
 	add_header X-Frame-Options "ALLOW-FROM static.miraheze.org";
+
+	<%- if property['alt_redirects'] -%>
+	<%- property['alt_redirects'].each_pair do | source, target | -%>
+	location <%= source %> {
+		return 301 https://<%= target %>$request_uri;
+	}
+	<%- end -%>
+	<%- end -%>
 
 	location / {
 		proxy_pass http://127.0.0.1:81;


### PR DESCRIPTION
In theory, adding
```yaml
alt_redirects:
  '/somepath/': 'somewiki.miraheze.org/target'
```
would work.

I'd want to test though, because I've not worked with this before. Also, I might have to update something else as well.