### PR TITLE
mwscript: note logging is for end -  pass return code

### DIFF
--- a/modules/mediawiki/files/bin/mwscript.py
+++ b/modules/mediawiki/files/bin/mwscript.py
@@ -33,8 +33,8 @@ confirm = input("Type 'Y' to confirm: ")
 if confirm.upper() == 'Y':
     if 'generate' in locals():
         os.system(generate)
-    os.system(command)
-    os.system(logcommand)
+    return_value = os.system(command)
+    os.system(f'{logcommand} (END - exit={str(return_value)}')
     print('Done!')
 else:
     print('Aborted!')


### PR DESCRIPTION
We should consider for long running scripts to log START too. (imports, foreachwikiindblist etc.)