### PR TITLE
mediawiki::packages: reinstall lillypond

### DIFF
--- a/modules/mediawiki/manifests/packages.pp
+++ b/modules/mediawiki/manifests/packages.pp
@@ -13,6 +13,7 @@ class mediawiki::packages {
         'locales-all',
         'oggvideotools',
         'libvips-tools',
+        'lillypond',
         'poppler-utils',
         'python-pip',
         'netpbm',


### PR DESCRIPTION
Reverts 1045deb593d130fe92aa47f721bd7e44c0b139c5

We need various other stuff setup as well before the extension can come back but soon!