### PR TITLE
jobrunner3 cannot run intensive jobs

### DIFF
--- a/hieradata/hosts/jobrunner3.yaml
+++ b/hieradata/hosts/jobrunner3.yaml
@@ -2,7 +2,7 @@ users::groups:
   - mediawiki-admins
 jobchron: true
 jobrunner: true
-jobrunner::intensive: true
+jobrunner::intensive: false
 letsencrypt: true
 mwservices: true
 contactgroups: ['icingaadmins', 'sre', 'mediawiki']

--- a/hieradata/hosts/jobrunner4.yaml
+++ b/hieradata/hosts/jobrunner4.yaml
@@ -1,6 +1,7 @@
 users::groups:
   - mediawiki-admins
 jobrunner: true
+jobrunner::intensive: false
 letsencrypt: false
 mwservices: false
 contactgroups: ['icingaadmins', 'sre', 'mediawiki']


### PR DESCRIPTION
Much safer to run on jobrunner4, which has no critical processes