### PR TITLE
puppet: rebalance MediaWiki puppet times 

### DIFF
--- a/hieradata/hosts/jobrunner3.yaml
+++ b/hieradata/hosts/jobrunner3.yaml
@@ -14,5 +14,5 @@ php::php_version: '7.3'
 redis::heap: '1000mb'
 mediawiki::jobqueue::runner::cron: true
 nginx::use_graylog: true
-puppet_cron_time: '2,32'
+puppet_cron_time: '6,36'
 puppetserver_hostname: 'puppet3.miraheze.org'

--- a/hieradata/hosts/jobrunner4.yaml
+++ b/hieradata/hosts/jobrunner4.yaml
@@ -11,5 +11,5 @@ mediawiki::php::fpm::childs: 1
 mediawiki::php::fpm::fpm_min_restart_threshold: 1
 php::php_version: '7.3'
 nginx::use_graylog: true
-puppet_cron_time: '2,32'
+puppet_cron_time: '7,37'
 puppetserver_hostname: 'puppet3.miraheze.org'

--- a/hieradata/hosts/mw10.yaml
+++ b/hieradata/hosts/mw10.yaml
@@ -8,6 +8,6 @@ mediawiki::php::fpm::childs: 32
 php::php_fpm::fpm_workers_multiplier: 1.0
 php::php_version: '7.3'
 nginx::use_graylog: true
-puppet_cron_time: '2,32'
+puppet_cron_time: '3,33'
 
 puppetserver_hostname: 'puppet3.miraheze.org'

--- a/hieradata/hosts/mw11.yaml
+++ b/hieradata/hosts/mw11.yaml
@@ -8,6 +8,6 @@ mediawiki::php::fpm::childs: 32
 php::php_fpm::fpm_workers_multiplier: 1.0
 php::php_version: '7.3'
 nginx::use_graylog: true
-puppet_cron_time: '2,32'
+puppet_cron_time: '5,35'
 
 puppetserver_hostname: 'puppet3.miraheze.org'

--- a/hieradata/hosts/mw9.yaml
+++ b/hieradata/hosts/mw9.yaml
@@ -8,6 +8,6 @@ mediawiki::php::fpm::childs: 32
 php::php_fpm::fpm_workers_multiplier: 1.0
 php::php_version: '7.3'
 nginx::use_graylog: true
-puppet_cron_time: '2,32'
+puppet_cron_time: '4,34'
 
 puppetserver_hostname: 'puppet3.miraheze.org'

--- a/hieradata/hosts/test3.yaml
+++ b/hieradata/hosts/test3.yaml
@@ -9,6 +9,6 @@ php::php_fpm::fpm_workers_multiplier: 1.0
 php::php_version: '7.3'
 mediawiki::php::use_tideways: true
 nginx::use_graylog: true
-puppet_cron_time: '2,32'
+puppet_cron_time: '1,31'
 puppetserver_hostname: 'puppet3.miraheze.org'
 mediawiki::php::fpm::childs: 18

--- a/hieradata/hosts/test3.yaml
+++ b/hieradata/hosts/test3.yaml
@@ -9,6 +9,6 @@ php::php_fpm::fpm_workers_multiplier: 1.0
 php::php_version: '7.3'
 mediawiki::php::use_tideways: true
 nginx::use_graylog: true
-puppet_cron_time: '1,31'
+puppet_cron_time: '2,32'
 puppetserver_hostname: 'puppet3.miraheze.org'
 mediawiki::php::fpm::childs: 18


### PR DESCRIPTION
To reduce load, this starts running puppet at 1,31 on test3 then proceeds down mw*,jobrunner* every minute alternating between cloud servers. This should reduce the chance of high load on things.