### PR TITLE
hieradata: set values for sync scripts

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -15,3 +15,5 @@ puppetserver_hostname: puppet3.miraheze.org
 role::salt::minions::salt_master: 'puppet3.miraheze.org'
 dns: false
 mediawiki::use_staging: false
+mediawiki::is_canary: false
+mediawiki::default_sync: 'skip'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -17,3 +17,4 @@ dns: false
 mediawiki::use_staging: false
 mediawiki::is_canary: false
 mediawiki::default_sync: 'skip'
+mediawiki::remote_sync: true

--- a/hieradata/hosts/mw10.yaml
+++ b/hieradata/hosts/mw10.yaml
@@ -11,6 +11,3 @@ nginx::use_graylog: true
 puppet_cron_time: '2,32'
 
 puppetserver_hostname: 'puppet3.miraheze.org'
-mediawiki::is_canary: true
-mediawiki::default_sync: 'all'
-mediawiki::remote_sync: false

--- a/hieradata/hosts/mw10.yaml
+++ b/hieradata/hosts/mw10.yaml
@@ -11,3 +11,6 @@ nginx::use_graylog: true
 puppet_cron_time: '2,32'
 
 puppetserver_hostname: 'puppet3.miraheze.org'
+mediawiki::is_canary: true
+mediawiki::default_sync: 'all'
+mediawiki::remote_sync: false

--- a/hieradata/hosts/mw11.yaml
+++ b/hieradata/hosts/mw11.yaml
@@ -11,3 +11,6 @@ nginx::use_graylog: true
 puppet_cron_time: '2,32'
 
 puppetserver_hostname: 'puppet3.miraheze.org'
+mediawiki::is_canary: true
+mediawiki::default_sync: 'all'
+mediawiki::remote_sync: false

--- a/hieradata/hosts/test3.yaml
+++ b/hieradata/hosts/test3.yaml
@@ -13,3 +13,4 @@ puppet_cron_time: '2,32'
 puppetserver_hostname: 'puppet3.miraheze.org'
 mediawiki::php::fpm::childs: 18
 mediawiki::use_staging: true
+mediawiki::remote_sync: false


### PR DESCRIPTION
This means:
- by default, install the ssh key for www-data syncing and do not be a staging/canary server
- On test3, don't install the www-data key / be a staging server so it has the git clone but only skip syncing to other servers (/srv/mediawiki locally will still be setup and come from the local staging folder)
- On mw10, (this is random but it's a server and the 8/9 struggle more with load) install staging and canary (this means it will have the public & private key pair for access in a deploy keys folder and armed in ssh agent. Do not allow remote access using the ssh keys. By default, sync files from the deploy command to all mediawiki servers except test3