### PR TITLE
Remove $wgReCaptchaSiteKey from PrivateSettings

### DIFF
--- a/modules/mediawiki/manifests/init.pp
+++ b/modules/mediawiki/manifests/init.pp
@@ -132,7 +132,6 @@ class mediawiki(
     $noreply_password      = lookup('passwords::mail::noreply')
     $mediawiki_upgradekey  = lookup('passwords::mediawiki::upgradekey')
     $mediawiki_secretkey   = lookup('passwords::mediawiki::secretkey')
-    $recaptcha_sitekey     = lookup('passwords::recaptcha::sitekey')
     $recaptcha_secretkey   = lookup('passwords::recaptcha::secretkey')
     $matomotoken           = lookup('passwords::mediawiki::matomotoken')
     $ldap_password         = lookup('passwords::mediawiki::ldap_password')

--- a/modules/mediawiki/templates/PrivateSettings.php
+++ b/modules/mediawiki/templates/PrivateSettings.php
@@ -14,7 +14,7 @@ $wmgSMTPPassword = "<%= @noreply_password %>";
 $wgUpgradeKey = "<%= @mediawiki_upgradekey %>";
 $wgSecretKey = "<%= @mediawiki_secretkey %>";
 
-// ReCaptchaNoCaptcha secret key
+// ReCaptcha secret key
 $wgReCaptchaSecretKey = "<%= @recaptcha_secretkey %>";
 
 // Matomo Token

--- a/modules/mediawiki/templates/PrivateSettings.php
+++ b/modules/mediawiki/templates/PrivateSettings.php
@@ -14,8 +14,7 @@ $wmgSMTPPassword = "<%= @noreply_password %>";
 $wgUpgradeKey = "<%= @mediawiki_upgradekey %>";
 $wgSecretKey = "<%= @mediawiki_secretkey %>";
 
-// ReCaptchaNoCaptcha secret keys
-$wgReCaptchaSiteKey = "<%= @recaptcha_sitekey %>";
+// ReCaptchaNoCaptcha secret key
 $wgReCaptchaSecretKey = "<%= @recaptcha_secretkey %>";
 
 // Matomo Token


### PR DESCRIPTION
This can be done just in LocalSettings.php, since the site key is not private, only the 'secret' key is 'secret'