### PR TITLE
T7319: Change KillMode to control-group for Varnish

### DIFF
--- a/modules/varnish/templates/initscripts/varnish.systemd.erb
+++ b/modules/varnish/templates/initscripts/varnish.systemd.erb
@@ -11,7 +11,7 @@ ProtectSystem=full
 ProtectHome=true
 PIDFile=%t/%p.pid
 Restart=always
-KillMode=process
+KillMode=control-group
 SyslogIdentifier=varnish
 ExecReload=/usr/local/sbin/reload-vcl <%= @reload_vcl_opts %>
 # We start varnishd(1) without specifying a VCL file (-f ''). Use reload-vcl in


### PR DESCRIPTION
KillMode of process is not recommended as it silently kills the process but allows it to continue running unaware to system.d. In essence, this means an OOM killer would 'kill' a sub process, not trigger the master service to be killed and consequently keep running broken until restarted manually.