### PR TITLE
logsalmsg: keep $USER is $SUDO_USER blank

### DIFF
--- a/modules/base/files/logsalmsg
+++ b/modules/base/files/logsalmsg
@@ -7,4 +7,9 @@ else
   ACTOR=$USER
 fi
 
+if [ $ACTOR = '' ]
+then
+  ACTOR=$USER
+fi
+
 echo '!log' "[$ACTOR@$HOSTNAME] $*" | nc -q0 -u 51.195.236.249 5071


### PR DESCRIPTION
This means that logs from the automatic config sync (while they happen) should still keep 'www-data' rather than show '@test3' by itself