### PR TITLE
db11/12/13: Change buffer pool instance to one including size

### DIFF
--- a/hieradata/hosts/db11.yaml
+++ b/hieradata/hosts/db11.yaml
@@ -1,6 +1,6 @@
 puppetserver_hostname: 'puppet3.miraheze.org'
-mariadb::config::innodb_buffer_pool_instances: 3
-mariadb::config::innodb_buffer_pool_size: '3G'
+mariadb::config::innodb_buffer_pool_instances: 1
+mariadb::config::innodb_buffer_pool_size: '1G'
 mariadb::config::max_connections: 500
 mariadb::config::tmpdir: /srv/tmp
 mariadb::config::table_definition_cache: 10000 

--- a/hieradata/hosts/db12.yaml
+++ b/hieradata/hosts/db12.yaml
@@ -1,6 +1,6 @@
 puppetserver_hostname: 'puppet3.miraheze.org'
-mariadb::config::innodb_buffer_pool_instances: 3
-mariadb::config::innodb_buffer_pool_size: '3G'
+mariadb::config::innodb_buffer_pool_instances: 1
+mariadb::config::innodb_buffer_pool_size: '1G'
 mariadb::config::max_connections: 500
 mariadb::config::tmpdir: /srv/tmp
 mariadb::config::table_definition_cache: 10000 

--- a/hieradata/hosts/db13.yaml
+++ b/hieradata/hosts/db13.yaml
@@ -1,6 +1,6 @@
 puppetserver_hostname: 'puppet3.miraheze.org'
-mariadb::config::innodb_buffer_pool_instances: 3
-mariadb::config::innodb_buffer_pool_size: '3G'
+mariadb::config::innodb_buffer_pool_instances: 1
+mariadb::config::innodb_buffer_pool_size: '1G'
 mariadb::config::max_connections: 500
 mariadb::config::tmpdir: /srv/tmp
 mariadb::config::table_definition_cache: 10000 


### PR DESCRIPTION
This is being done as both are OOM'g and reading up on the docs the benefit of the buffer pool are undone when swapping which each server is doing.