### PR TITLE
mariadb: Change all the dbs to use /tmp rather then /srv/tmp

### DIFF
--- a/hieradata/hosts/db11.yaml
+++ b/hieradata/hosts/db11.yaml
@@ -2,7 +2,7 @@ puppetserver_hostname: 'puppet3.miraheze.org'
 mariadb::config::innodb_buffer_pool_instances: 3
 mariadb::config::innodb_buffer_pool_size: '3G'
 mariadb::config::max_connections: 500
-mariadb::config::tmpdir: /srv/tmp
+mariadb::config::tmpdir: /tmp
 mariadb::config::table_definition_cache: 10000 
 mariadb::config::table_open_cache: 10000
 

--- a/hieradata/hosts/db11.yaml
+++ b/hieradata/hosts/db11.yaml
@@ -2,7 +2,6 @@ puppetserver_hostname: 'puppet3.miraheze.org'
 mariadb::config::innodb_buffer_pool_instances: 3
 mariadb::config::innodb_buffer_pool_size: '3G'
 mariadb::config::max_connections: 500
-mariadb::config::tmpdir: /tmp
 mariadb::config::table_definition_cache: 10000 
 mariadb::config::table_open_cache: 10000
 

--- a/hieradata/hosts/db12.yaml
+++ b/hieradata/hosts/db12.yaml
@@ -2,7 +2,7 @@ puppetserver_hostname: 'puppet3.miraheze.org'
 mariadb::config::innodb_buffer_pool_instances: 3
 mariadb::config::innodb_buffer_pool_size: '3G'
 mariadb::config::max_connections: 500
-mariadb::config::tmpdir: /srv/tmp
+mariadb::config::tmpdir: /tmp
 mariadb::config::table_definition_cache: 10000 
 mariadb::config::table_open_cache: 10000
 

--- a/hieradata/hosts/db12.yaml
+++ b/hieradata/hosts/db12.yaml
@@ -2,7 +2,6 @@ puppetserver_hostname: 'puppet3.miraheze.org'
 mariadb::config::innodb_buffer_pool_instances: 3
 mariadb::config::innodb_buffer_pool_size: '3G'
 mariadb::config::max_connections: 500
-mariadb::config::tmpdir: /tmp
 mariadb::config::table_definition_cache: 10000 
 mariadb::config::table_open_cache: 10000
 

--- a/hieradata/hosts/db13.yaml
+++ b/hieradata/hosts/db13.yaml
@@ -2,7 +2,7 @@ puppetserver_hostname: 'puppet3.miraheze.org'
 mariadb::config::innodb_buffer_pool_instances: 3
 mariadb::config::innodb_buffer_pool_size: '3G'
 mariadb::config::max_connections: 500
-mariadb::config::tmpdir: /srv/tmp
+mariadb::config::tmpdir: /tmp
 mariadb::config::table_definition_cache: 10000 
 mariadb::config::table_open_cache: 10000
 

--- a/hieradata/hosts/db13.yaml
+++ b/hieradata/hosts/db13.yaml
@@ -2,7 +2,6 @@ puppetserver_hostname: 'puppet3.miraheze.org'
 mariadb::config::innodb_buffer_pool_instances: 3
 mariadb::config::innodb_buffer_pool_size: '3G'
 mariadb::config::max_connections: 500
-mariadb::config::tmpdir: /tmp
 mariadb::config::table_definition_cache: 10000 
 mariadb::config::table_open_cache: 10000
 

--- a/modules/mariadb/manifests/config.pp
+++ b/modules/mariadb/manifests/config.pp
@@ -61,12 +61,14 @@ class mariadb::config(
         require => Package["mariadb-server-${version}"],
     }
 
-    file { $tmpdir:
-        ensure  => directory,
-        owner   => 'mysql',
-        group   => 'mysql',
-        mode    => '0775',
-        require => Package["mariadb-server-${version}"],
+    if $tmpdir != '/tmp' {
+        file { $tmpdir:
+            ensure  => directory,
+            owner   => 'mysql',
+            group   => 'mysql',
+            mode    => '0775',
+            require => Package["mariadb-server-${version}"],
+        }
     }
 
     file { '/etc/mysql/miraheze':


### PR DESCRIPTION
Also prevent creating /tmp if the tmpdir variable is set at /tmp.

/srv/tmp was causing mariadb to show "2021-08-19 16:53:18 0 [Note] mysqld: O_TMPFILE is not supported on /srv/tmp (disabling future attempts)" in the logs.