### PR TITLE
varnish: Set max threads to at least 500+

### DIFF
--- a/modules/varnish/manifests/init.pp
+++ b/modules/varnish/manifests/init.pp
@@ -56,7 +56,7 @@ class varnish (
         group   => 'varnish',
     }
 
-    $max_threads = max($::processorcount * 250, '500')
+    $max_threads = max(floor($::processorcount * 250), '500')
     systemd::service { 'varnish':
         ensure  => present,
         content => systemd_template('varnish'),

--- a/modules/varnish/manifests/init.pp
+++ b/modules/varnish/manifests/init.pp
@@ -56,7 +56,7 @@ class varnish (
         group   => 'varnish',
     }
 
-    $max_threads = max(floor($::processorcount * 250), '500')
+    $max_threads = max(floor($::processorcount * 250), 500)
     systemd::service { 'varnish':
         ensure  => present,
         content => systemd_template('varnish'),

--- a/modules/varnish/manifests/init.pp
+++ b/modules/varnish/manifests/init.pp
@@ -56,6 +56,7 @@ class varnish (
         group   => 'varnish',
     }
 
+    $max_threads = max($::processorcount * 250, '500')
     systemd::service { 'varnish':
         ensure  => present,
         content => systemd_template('varnish'),

--- a/modules/varnish/templates/initscripts/varnish.systemd.erb
+++ b/modules/varnish/templates/initscripts/varnish.systemd.erb
@@ -25,7 +25,7 @@ ExecStart=/usr/sbin/varnishd \
 -a :81 \
 -T localhost:6082 \
 -f '' \
--p thread_pool_min=250 -p thread_pool_max=<%= @processorcount * 250 -%> -p thread_pool_timeout=120 \
+-p thread_pool_min=250 -p thread_pool_max=<%= @max_threads -%> -p thread_pool_timeout=120 \
 -p vsl_reclen=2048 \
 -p workspace_backend=128k \
 -S /etc/varnish/secret \


### PR DESCRIPTION
If cores is 1 x 250 which equals to 250 lets just make it 500.

Varnish default is 500 anyways.