### PR TITLE
slightly adjust mw10/11/12/13 puppet run times

### DIFF
--- a/hieradata/hosts/mw10.yaml
+++ b/hieradata/hosts/mw10.yaml
@@ -8,6 +8,6 @@ mediawiki::php::fpm::childs: 32
 php::php_fpm::fpm_workers_multiplier: 1.0
 php::php_version: '7.3'
 nginx::use_graylog: true
-puppet_cron_time: '2,32'
+puppet_cron_time: '3,33'
 
 puppetserver_hostname: 'puppet3.miraheze.org'

--- a/hieradata/hosts/mw11.yaml
+++ b/hieradata/hosts/mw11.yaml
@@ -8,7 +8,7 @@ mediawiki::php::fpm::childs: 32
 php::php_fpm::fpm_workers_multiplier: 1.0
 php::php_version: '7.3'
 nginx::use_graylog: true
-puppet_cron_time: '2,32'
+puppet_cron_time: '3,33'
 
 puppetserver_hostname: 'puppet3.miraheze.org'
 mediawiki::is_canary: true

--- a/hieradata/hosts/mw12.yaml
+++ b/hieradata/hosts/mw12.yaml
@@ -8,7 +8,7 @@ mediawiki::php::fpm::childs: 32
 php::php_fpm::fpm_workers_multiplier: 1.0
 php::php_version: '7.3'
 nginx::use_graylog: true
-puppet_cron_time: '2,32'
+puppet_cron_time: '4,34'
 
 puppetserver_hostname: 'puppet3.miraheze.org'
 mediawiki::is_canary: true

--- a/hieradata/hosts/mw13.yaml
+++ b/hieradata/hosts/mw13.yaml
@@ -8,5 +8,5 @@ mediawiki::php::fpm::childs: 32
 php::php_fpm::fpm_workers_multiplier: 1.0
 php::php_version: '7.3'
 nginx::use_graylog: true
-puppet_cron_time: '2,32'
+puppet_cron_time: '4,34'
 puppetserver_hostname: 'puppet3.miraheze.org'


### PR DESCRIPTION
This is to prevent puppet3 being overloaded which would lead to unexpected consequences on mw* leading to higher load/user impact.