### PR TITLE
cp12: Unset nginx::worker_processes

### DIFF
--- a/hieradata/hosts/cp12.yaml
+++ b/hieradata/hosts/cp12.yaml
@@ -1,5 +1,4 @@
 users::groups: 'cache-admins'
-nginx::worker_processes: 4
 varnish::cache_file_size: '15G'
 base::syslog::syslog_daemon: 'rsyslog'
 puppetserver_hostname: 'puppet3.miraheze.org'


### PR DESCRIPTION
We don't need to set it to 4. We use a NVME now so I/O isn't much of an issue.