### PR TITLE
CSP: add scratchblocks.github.io to `script-src` (T8002)

### DIFF
--- a/modules/varnish/data/csp.yaml
+++ b/modules/varnish/data/csp.yaml
@@ -30,6 +30,7 @@ script-src:
   - 'cdnjs.cloudflare.com'
   - 'cdn.jsdelivr.net'
   - 'cdn.syndication.twimg.com'
+  - 'scratchblocks.github.io'
 
 style-src:
   - "'self'"


### PR DESCRIPTION
Already in `img-src` so adding to `script-src` also.

I could not find a review task for this though. This can be a temporary measure until it's CSP is fully approved. It is possible I just missed the review task or it was missed during the mass creating of tasks.