### PR TITLE
CSP: add openlayers.org to `script-src`

### DIFF
--- a/modules/varnish/data/csp.yaml
+++ b/modules/varnish/data/csp.yaml
@@ -31,6 +31,7 @@ script-src:
   - 'cdn.jsdelivr.net'
   - 'cdn.syndication.twimg.com'
   - 'scratchblocks.github.io'
+  - 'openlayers.org'
 
 style-src:
   - "'self'"


### PR DESCRIPTION
This is needed by the Cargo extension to display OpenLayers maps