### PR TITLE
mediawiki: Install python3-minimal

### DIFF
--- a/modules/mediawiki/manifests/packages.pp
+++ b/modules/mediawiki/manifests/packages.pp
@@ -27,6 +27,7 @@ class mediawiki::packages {
         'xvfb',
         'timidity',
         'librsvg2-bin',
+        'python3-minimal',
         'python3-requests',
         'rsync',
     ]


### PR DESCRIPTION
Since python the package is no longer available which installed python-minimal which did the work of making sure "python" was available. We manually install python3-minimal which does this work.