### PR TITLE
csp: add *.wikipedia.org to connect-src

### DIFF
--- a/modules/varnish/data/csp.yaml
+++ b/modules/varnish/data/csp.yaml
@@ -143,3 +143,5 @@ connect-src:
   - '*.wikipedia.org'
   - 'www.mediawiki.org'
   - '*.wikimedia.org'
+  - '*.wikinews.org'
+  - '*.wiktionary.org'


### PR DESCRIPTION
A lot of user scripts and gadgets are loaded from Wikipedia. WMF Commons could be added here, too.