### PR TITLE
mwdeploy: add --inplace when syncing without timestamp

### DIFF
--- a/modules/mediawiki/files/bin/deploy-mediawiki
+++ b/modules/mediawiki/files/bin/deploy-mediawiki
@@ -14,7 +14,7 @@ def check_up(server):
 
 def run(args, start):
     if args.ignoretime:
-        rsyncparams = ''
+        rsyncparams = '--inplace'
     else:
         rsyncparams = '--update'
     loginfo = {}


### PR DESCRIPTION
I will do a second & third round but this definitely has a performance advantage