### PR TITLE
mwscript: drop option to use foreachwikiindblist

### DIFF
--- a/modules/mediawiki/files/bin/mwscript.py
+++ b/modules/mediawiki/files/bin/mwscript.py
@@ -11,7 +11,7 @@ else:
     scriptsplit = script.split('/')
     script = script = f'/srv/mediawiki/w/{scriptsplit[0]}/{scriptsplit[1]}/maintenance/{scriptsplit[2]}'
 wiki = sys.argv[2]
-if wiki in ("all", "foreachwikiindblist"):
+if wiki == 'all':
     command = f'sudo -u www-data /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/databases.json {script}'
 elif wiki in ("extension", "skin"):
     extension = input("Type the ManageWiki name of the extension or skin: ")


### PR DESCRIPTION
It's never used. It makes sense for this to just be a comparison on `all` and drop the `tuple` all together, since only `all` is really used, and is easier to use.