### PR TITLE
Enable tideways for CLI

### DIFF
--- a/modules/mediawiki/manifests/php.pp
+++ b/modules/mediawiki/manifests/php.pp
@@ -71,6 +71,7 @@ class mediawiki::php (
 
     php::extension { 'tideways-xhprof':
         ensure   => $profiling_ensure,
+        package_name => '',
         priority => 30,
         config   => {
             'extension'                       => 'tideways_xhprof.so',

--- a/modules/mediawiki/manifests/php.pp
+++ b/modules/mediawiki/manifests/php.pp
@@ -3,7 +3,7 @@ class mediawiki::php (
     Integer $php_fpm_childs = lookup('mediawiki::php::fpm::childs', {'default_value' => 26}),
     Integer $fpm_min_restart_threshold = lookup('mediawiki::php::fpm::fpm_min_restart_threshold', {'default_value' => 6}),
     String $php_version = lookup('php::php_version', {'default_value' => '7.2'}),
-    Optional[Boolean] $use_tideways = undef,
+    Boolean $use_tideways = lookup('mediawiki::php::use_tideways', {'default_value' => false}),
 ) {
     
     if !defined(Class['php::php_fpm']) {
@@ -71,12 +71,10 @@ class mediawiki::php (
 
     php::extension { 'tideways-xhprof':
         ensure   => $profiling_ensure,
-        package_name => '',
         priority => 30,
-        sapis    => ['fpm'],
         config   => {
             'extension'                       => 'tideways_xhprof.so',
             'tideways_xhprof.clock_use_rdtsc' => '0',
-        },
+        }
     }
 }


### PR DESCRIPTION
Currently it only effects fpm, this should effect CLI also if `use_tideways` is enabled, which it is on test3 only. This should allow using the `--profiler` command line option in maintenance scripts on test3.

After further looking at this, it appears to have not been used at all, so this actually uses `mediawiki::php::use_tideways`