### PR TITLE
redis: Unset tcp-keepalive

### DIFF
--- a/modules/redis/templates/redis.conf.erb
+++ b/modules/redis/templates/redis.conf.erb
@@ -4,7 +4,6 @@ daemonize yes
 pidfile /var/run/redis/redis-server.pid
 port <%= @port %>
 timeout 0
-tcp-keepalive 0
 loglevel notice
 syslog-enabled yes
 syslog-ident redis-server


### PR DESCRIPTION
We want to allow keepalive to see if it helps alleviate issues with redis connections being disconnected.

This is trying to fix an issue with the jobrunner/jobchron.