### PR TITLE
ensure absent on LocalisationUpdate cron

### DIFF
--- a/modules/mediawiki/manifests/cron.pp
+++ b/modules/mediawiki/manifests/cron.pp
@@ -3,7 +3,7 @@
 # Used for CORE crons which should be ran on every MediaWiki server.
 class mediawiki::cron {
     cron { 'update.php for LocalisationUpdate':
-        ensure  => present,
+        ensure  => absent,
         command => '/usr/bin/nice -n 15 /usr/bin/php /srv/mediawiki/w/extensions/LocalisationUpdate/update.php --quiet --wiki=loginwiki > /var/log/mediawiki/debuglogs/l10nupdate.log',
         user    => 'www-data',
         minute  => '0',


### PR DESCRIPTION
* Before it can be removed (#2029), it needs to be set to `ensure => absent` first.