### PR TITLE
Add `--no-log` to automatic deploys of landing and ErrorPages

### DIFF
--- a/modules/mediawiki/manifests/init.pp
+++ b/modules/mediawiki/manifests/init.pp
@@ -60,7 +60,7 @@ class mediawiki(
             group  => 'www-data',
             mode   => '0400',
         }
-        
+
         file { '/srv/mediawiki-staging/deploykey':
             ensure => present,
             source => 'puppet:///private/mediawiki/mediawiki-deploy-key-private',
@@ -69,7 +69,7 @@ class mediawiki(
             mode   => '0400',
         }
     }
-    
+
     if lookup(mediawiki::use_staging) {
         include mediawiki::extensionsetup
         file { '/srv/mediawiki-staging':


### PR DESCRIPTION
Because these two will have TranslateWiki updates, this can get spammy.