### PR TITLE
mediawiki.conf.erb: remove comment

### DIFF
--- a/modules/mediawiki/templates/mediawiki.conf.erb
+++ b/modules/mediawiki/templates/mediawiki.conf.erb
@@ -1,13 +1,3 @@
-# Traffic going to URLs like https://meta.miraheze.org/api/rest_v1
-# is proxied to services backends. In DNS, the subdomain restbase-lb
-# uses a weighted load balancing configuration to balance traffic.
-# However, there are no health checks in DNS and by default, NGINX caches
-# DNS lookups in proxy_pass forever, thus DNS changes are not picked up
-# until NGINX is reloaded or restarted.
-# There are several workaround available (such as using the resolver option
-# with a low cache expiration timeout), but that's not recommended due to DNS
-# spoofing attacks. This is not the preferred solution, but works reliably.
-
 server {
 	listen 80 backlog=1024;
 	listen [::]:80 ipv6only=on backlog=1024;


### PR DESCRIPTION
The whole comment seems to be centered around restbase-lb, which was removed.