### PR TITLE
Add player.vimeo.com and docs.google.com to frame-src

### DIFF
--- a/modules/varnish/data/csp.yaml
+++ b/modules/varnish/data/csp.yaml
@@ -123,6 +123,7 @@ frame-src:
   - "'self'"
   - '*.miraheze.org'
   - 'www.google.com'
+  - 'docs.google.com'
   - 'www.recaptcha.net'
   - 'web.libera.chat'
   - 'snap.berkeley.edu'
@@ -139,6 +140,7 @@ frame-src:
   - 'archive.org'
   - 'w.soundcloud.com'
   - 'query.wikidata.org'
+  - 'player.vimeo.com'
 
 connect-src:
   - "'self'"


### PR DESCRIPTION
To fix https://meta.miraheze.org/wiki/Stewards%27_noticeboard#Help,_embeded_content_not_working.