### PR TITLE
Disallow indexing /w/ / /w/index.php?*

### DIFF
--- a/modules/mediawiki/files/robots.php
+++ b/modules/mediawiki/files/robots.php
@@ -32,6 +32,11 @@ echo "# Block SemrushBot" . "\r\n";
 echo "User-Agent: SemrushBot" . "\r\n";
 echo "Disallow: /" . "\r\n\n";
 
+# Disallow indexing /w/
+echo "# Disallow indexing /w/index.php?" . "\r\n\n";
+echo "Allow: /w/load.php?" . "\r\n\n";
+echo "Disallow: /w/" . "\r\n\n";
+
 if ( $databasesArray['combi'] ) {
 	if ( preg_match( '/^(.+)\.miraheze\.org$/', $_SERVER['HTTP_HOST'], $matches ) ) {
 		$wiki = "{$matches[1]}wiki";

--- a/modules/mediawiki/files/robots.php
+++ b/modules/mediawiki/files/robots.php
@@ -34,6 +34,7 @@ echo "Disallow: /" . "\r\n\n";
 
 # Disallow indexing /w/
 echo "# Disallow indexing /w/index.php?" . "\r\n\n";
+echo "User-agent: *" . "\r\n\n";
 echo "Allow: /w/load.php?" . "\r\n\n";
 echo "Disallow: /w/" . "\r\n\n";
 

--- a/modules/mediawiki/files/robots.php
+++ b/modules/mediawiki/files/robots.php
@@ -33,7 +33,7 @@ echo "User-Agent: SemrushBot" . "\r\n";
 echo "Disallow: /" . "\r\n\n";
 
 # Disallow indexing /w/
-echo "# Disallow indexing /w/index.php?" . "\r\n\n";
+echo "# Disallow indexing /w/" . "\r\n\n";
 echo "User-agent: *" . "\r\n\n";
 echo "Allow: /w/load.php?" . "\r\n\n";
 echo "Disallow: /w/" . "\r\n\n";


### PR DESCRIPTION
While reading documentation from MediaWiki.org regarding MediaWiki:Robots.txt, I stumbled upon a suggestion from the documentation on how to disallow pages starting in /w/index.php from being indexed if you have URL rewrites enabled. After checking the Google Search Console for miraheze.org, I saw that there are hundreds of thousands (millions?) of pages crawled by Google starting in "/w/index.php". Most if not all of these crawled pages starting in /w/index.php" clash with existing pages on /wiki/ and thus are not shown on Google meaning that Google has crawled thousands upon thousands of pages only to not show the pages served by index.php. All those thousands of extra hits surely cause undue burden to Miraheze's servers and end up not reaping any benefits if hidden away because Google correctly indexed pages in the /wiki/ directory of the wiki and then decided to not include the results from pages indexed via index.php.

The approach in my commit is one used by Wikimedia. I got it from the MediaWiki.org page "Manual:Robots.txt" and have verified against Wikipedia/Wikimedia Meta's robots.txt is the solution used by them to prevent unnecessary page hits from web crawlers. This will disallow all pages in /w/ from being indexed (including index.php) but allow for any necessary JS/CSS be loaded for things such as the Wayback Machine/other crawlers who need it to properly render the site.

For more info on this, see https://www.mediawiki.org/wiki/Manual:Robots.txt