### PR TITLE
Noindex for /w/index.php?*

### DIFF
--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -447,7 +447,7 @@ sub vcl_deliver {
 		set resp.http.Age = 0;
 	}
 
-	if (req.url ~ "^(/w/api\.php*|/w/index\.php\?*|/wiki/Special\:|/wiki/Special%3A).+$") {
+	if (req.url ~ "^(/w/(api|index|rest)\.php*|/wiki/Special(\:|%3A)).+$") {
 		set resp.http.X-Robots-Tag = "noindex";
 	}
 

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -447,7 +447,7 @@ sub vcl_deliver {
 		set resp.http.Age = 0;
 	}
 
-	if (req.url ~ "^(/w/api\.php*|/w/index\.php\?title\=Special\:|/wiki/Special\:|/w/index\.php\?title\=Special%3A|/wiki/Special%3A).+$") {
+	if (req.url ~ "^(/w/api\.php*|/w/index\.php\?*|/wiki/Special\:|/wiki/Special%3A).+$") {
 		set resp.http.X-Robots-Tag = "noindex";
 	}
 


### PR DESCRIPTION
Per suggestion from @Universal-Omega (see https://github.com/miraheze/puppet/pull/2107). 

The goal is to prohibit Google/Bing from uselessly indexing /w/index.php and causing clashes with articles indexed via /wiki/ in search engines.