### PR TITLE
mwscript: rewrite to use argparse

### DIFF
--- a/modules/mediawiki/files/bin/mwscript.py
+++ b/modules/mediawiki/files/bin/mwscript.py
@@ -30,7 +30,7 @@ def run(args):
     else:
         command = f'sudo -u www-data php {script} --wiki={wiki}'
     if args.arguments:
-        command = f'{command} {args.arguments}'
+        command += ' ' + ' '.join(args.arguments)
     logcommand = f'/usr/local/bin/logsalmsg "{command}'
     print("Will execute:")
     if 'generate' in locals():
@@ -54,9 +54,11 @@ def run(args):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Process some integers.')
-    parser.add_argument('script', required=True)
-    parser.add_argument('wiki', required=True)
-    parser.add_argument('arguments', nargs='*')
+    parser.add_argument('script')
+    parser.add_argument('wiki')
+    parser.add_argument('arguments', nargs='*', default='')
     parser.add_argument('--extension', '--skin', dest='extension')
     parser.add_argument('--no-log', dest='nolog', action='store_true')
-    run(parser.parse_args())
+
+    args, args.arguments = parser.parse_known_args()
+    run(args)

--- a/modules/mediawiki/files/bin/mwscript.py
+++ b/modules/mediawiki/files/bin/mwscript.py
@@ -38,14 +38,15 @@ def run(args):
     print(command)
     confirm = input("Type 'Y' to confirm: ")
     if confirm.upper() == 'Y':
-        if long:
+        if long and not args.nolog:
             os.system(f'{logcommand} (START)"')
         if 'generate' in locals():
             os.system(generate)
         return_value = os.system(command)
         logcommand = f'{logcommand} (END - exit={str(return_value)})"'
-        print(f'Logging via {logcommand}')
-        os.system(logcommand)
+        if not args.nolog:
+            print(f'Logging via {logcommand}')
+            os.system(logcommand)
         print('Done!')
     else:
         print('Aborted!')
@@ -57,4 +58,5 @@ if __name__ == '__main__':
     parser.add_argument('wiki', required=True)
     parser.add_argument('arguments', nargs='*')
     parser.add_argument('--extension', '--skin', dest='extension')
+    parser.add_argument('--no-log', dest='nolog', action='store_true')
     run(parser.parse_args())

--- a/modules/mediawiki/files/bin/mwscript.py
+++ b/modules/mediawiki/files/bin/mwscript.py
@@ -37,7 +37,7 @@ def run(args):
         print(generate)
     print(command)
     confirm = args.confirm or input("Type 'Y' to confirm: ")
-    if confirm == True or confirm.upper() == 'Y':
+    if confirm is True or confirm.upper() == 'Y':
         if long and not args.nolog:
             os.system(f'{logcommand} (START)"')
         if 'generate' in locals():

--- a/modules/mediawiki/files/bin/mwscript.py
+++ b/modules/mediawiki/files/bin/mwscript.py
@@ -1,46 +1,60 @@
 #! /usr/bin/python3
-# -*- coding: utf-8 -*-
-import sys
+
+import argparse
 import os
-long = False
-if len(sys.argv) < 3:
-    raise Exception("Not Enough Parameters")
-script = sys.argv[1]
-if script in ['importDump.php', 'deleteBatch.php', 'importImages.php', 'rebuildall.php']:
-    long = True
-if len(script.split('/')) == 1:
-    script = f'/srv/mediawiki/w/maintenance/{sys.argv[1]}'
-else:
-    scriptsplit = script.split('/')
-    script = script = f'/srv/mediawiki/w/{scriptsplit[0]}/{scriptsplit[1]}/maintenance/{scriptsplit[2]}'
-wiki = sys.argv[2]
-if wiki == 'all':
-    long = True
-    command = f'sudo -u www-data /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/databases.json {script}'
-elif wiki in ("extension", "skin"):
-    long = True
-    extension = input("Type the ManageWiki name of the extension or skin: ")
-    generate = f'php /srv/mediawiki/w/extensions/MirahezeMagic/maintenance/generateExtensionDatabaseList.php --wiki=loginwiki --extension={extension}'
-    command = f'sudo -u www-data /usr/local/bin/foreachwikiindblist /home/{os.getlogin()}/{extension}.json {script}'
-else:
-    command = f'sudo -u www-data php {script} --wiki={wiki}'
-if len(sys.argv) == 4:
-    command = f'{command} {sys.argv[3]}'
-logcommand = f'/usr/local/bin/logsalmsg "{command}'
-print("Will execute:")
-if 'generate' in locals():
-    print(generate)
-print(command)
-confirm = input("Type 'Y' to confirm: ")
-if confirm.upper() == 'Y':
-    if long:
-        os.system(f'{logcommand} (START)"')
+
+
+def run(args):
+    longScripts = ('importDump.php', 'deleteBatch.php', 'importImages.php', 'rebuildall.php')
+    long = False
+
+    script = args.script
+    if script in longScripts:
+        long = True
+    if len(script.split('/')) == 1:
+        script = f'/srv/mediawiki/w/maintenance/{script}'
+    else:
+        scriptsplit = script.split('/')
+        script = f'/srv/mediawiki/w/{scriptsplit[0]}/{scriptsplit[1]}/maintenance/{scriptsplit[2]}'
+        if scriptsplit[2] in longScripts:
+            long = True
+
+    wiki = args.wiki
+    if wiki == 'all':
+        long = True
+        command = f'sudo -u www-data /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/databases.json {script}'
+    elif args.extension:
+        long = True
+        generate = f'php /srv/mediawiki/w/extensions/MirahezeMagic/maintenance/generateExtensionDatabaseList.php --wiki=loginwiki --extension={args.extension}'
+        command = f'sudo -u www-data /usr/local/bin/foreachwikiindblist /home/{os.getlogin()}/{extension}.json {script}'
+    else:
+        command = f'sudo -u www-data php {script} --wiki={wiki}'
+    if args.arguments:
+        command = f'{command} {args.arguments}'
+    logcommand = f'/usr/local/bin/logsalmsg "{command}'
+    print("Will execute:")
     if 'generate' in locals():
-        os.system(generate)
-    return_value = os.system(command)
-    logcommand = f'{logcommand} (END - exit={str(return_value)})"'
-    print(f'Logging via {logcommand}')
-    os.system(logcommand)
-    print('Done!')
-else:
-    print('Aborted!')
+        print(generate)
+    print(command)
+    confirm = input("Type 'Y' to confirm: ")
+    if confirm.upper() == 'Y':
+        if long:
+            os.system(f'{logcommand} (START)"')
+        if 'generate' in locals():
+            os.system(generate)
+        return_value = os.system(command)
+        logcommand = f'{logcommand} (END - exit={str(return_value)})"'
+        print(f'Logging via {logcommand}')
+        os.system(logcommand)
+        print('Done!')
+    else:
+        print('Aborted!')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Process some integers.')
+    parser.add_argument('script', required=True)
+    parser.add_argument('wiki', required=True)
+    parser.add_argument('arguments', nargs='*')
+    parser.add_argument('--extension', '--skin', dest='extension')
+    run(parser.parse_args())

--- a/modules/mediawiki/files/bin/mwscript.py
+++ b/modules/mediawiki/files/bin/mwscript.py
@@ -36,8 +36,8 @@ def run(args):
     if 'generate' in locals():
         print(generate)
     print(command)
-    confirm = input("Type 'Y' to confirm: ")
-    if confirm.upper() == 'Y':
+    confirm = args.confirm or input("Type 'Y' to confirm: ")
+    if confirm == True or confirm.upper() == 'Y':
         if long and not args.nolog:
             os.system(f'{logcommand} (START)"')
         if 'generate' in locals():
@@ -59,6 +59,7 @@ if __name__ == '__main__':
     parser.add_argument('arguments', nargs='*', default='')
     parser.add_argument('--extension', '--skin', dest='extension')
     parser.add_argument('--no-log', dest='nolog', action='store_true')
+    parser.add_argument('--confirm', '--yes', '-y', dest='confirm', action='store_false')
 
     args, args.arguments = parser.parse_known_args()
     run(args)

--- a/modules/mediawiki/files/bin/mwscript.py
+++ b/modules/mediawiki/files/bin/mwscript.py
@@ -36,8 +36,7 @@ def run(args):
     if 'generate' in locals():
         print(generate)
     print(command)
-    confirm = args.confirm or input("Type 'Y' to confirm: ")
-    if confirm is True or confirm.upper() == 'Y':
+    if args.confirm or input("Type 'Y' to confirm: ").upper() == 'Y':
         if long and not args.nolog:
             os.system(f'{logcommand} (START)"')
         if 'generate' in locals():

--- a/modules/mediawiki/files/bin/mwscript.py
+++ b/modules/mediawiki/files/bin/mwscript.py
@@ -26,7 +26,7 @@ def run(args):
     elif args.extension:
         long = True
         generate = f'php /srv/mediawiki/w/extensions/MirahezeMagic/maintenance/generateExtensionDatabaseList.php --wiki=loginwiki --extension={args.extension}'
-        command = f'sudo -u www-data /usr/local/bin/foreachwikiindblist /home/{os.getlogin()}/{extension}.json {script}'
+        command = f'sudo -u www-data /usr/local/bin/foreachwikiindblist /home/{os.getlogin()}/{args.extension}.json {script}'
     else:
         command = f'sudo -u www-data php {script} --wiki={wiki}'
     if args.arguments:

--- a/modules/mediawiki/files/bin/mwscript.py
+++ b/modules/mediawiki/files/bin/mwscript.py
@@ -5,7 +5,7 @@ import os
 
 
 def run(args):
-    longscripts = ('importDump.php', 'deleteBatch.php', 'importImages.php', 'rebuildall.php')
+    longscripts = ('deleteBatch.php', 'importDump.php', 'importImages.php', 'nukeNS.php', 'rebuildall.php', 'refreshLinks.php')
     long = False
 
     script = args.script

--- a/modules/mediawiki/files/bin/mwscript.py
+++ b/modules/mediawiki/files/bin/mwscript.py
@@ -43,7 +43,7 @@ def run(args):
         if 'generate' in locals():
             os.system(generate)
         return_value = os.system(command)
-        logcommand = f'{logcommand} (END - exit={str(return_value)})"'
+        logcommand += f' (END - exit={str(return_value)})"'
         if not args.nolog:
             print(f'Logging via {logcommand}')
             os.system(logcommand)

--- a/modules/mediawiki/files/bin/mwscript.py
+++ b/modules/mediawiki/files/bin/mwscript.py
@@ -5,18 +5,18 @@ import os
 
 
 def run(args):
-    longScripts = ('importDump.php', 'deleteBatch.php', 'importImages.php', 'rebuildall.php')
+    longscripts = ('importDump.php', 'deleteBatch.php', 'importImages.php', 'rebuildall.php')
     long = False
 
     script = args.script
-    if script in longScripts:
+    if script in longscripts:
         long = True
     if len(script.split('/')) == 1:
         script = f'/srv/mediawiki/w/maintenance/{script}'
     else:
         scriptsplit = script.split('/')
         script = f'/srv/mediawiki/w/{scriptsplit[0]}/{scriptsplit[1]}/maintenance/{scriptsplit[2]}'
-        if scriptsplit[2] in longScripts:
+        if scriptsplit[2] in longscripts:
             long = True
 
     wiki = args.wiki


### PR DESCRIPTION
* use argparse
* running scripts for specific extensions or skins is now done with `--extension` or `--skin` instead of input prompt
* maintenance script arguments are no longer required to be in quotations, all unknown arguments to mwscript are now used for the maintenance script arguments
* adds `--no-log` argument
* adds `--confirm` argument
* converts long scripts to a defined tuple, and adds support to add extension maintenance scripts to the tuple if it is necessary in the future
* adds `nukeNS.php` and `refreshLinks.php` to `longscripts`