### PR TITLE
MediaWiki: fix timeouts

### DIFF
--- a/modules/mediawiki/templates/mediawiki-includes.conf.erb
+++ b/modules/mediawiki/templates/mediawiki-includes.conf.erb
@@ -30,6 +30,7 @@ location ~ \.php {
 	fastcgi_buffers 32 32k;
 	fastcgi_buffer_size 64k;
 	fastcgi_pass unix:/run/<%= @php_fpm_sock %>;
+	fastcgi_read_timeout 1200;
 }
 
 location = / {
@@ -54,6 +55,7 @@ location ^~ /wiki/ {
 	fastcgi_buffers 32 32k;
 	fastcgi_buffer_size 64k;
 	fastcgi_pass unix:/run/<%= @php_fpm_sock %>;
+	fastcgi_read_timeout 1200;
 }
 
 location ~ ^/m/(.*) {


### PR DESCRIPTION
I'm not 100% sure this'll work, but did a bit of research and it might. Setting this to 1200 is the longest it value set in https://github.com/miraheze/mw-config/blob/7cf9810/LocalSettings.php#L8-L17, which should allow `set_time_limit` to properly work.