### PR TITLE
Handle CORS preflight requests + fix `Access-Control-Allow-Origin` for api.php

### DIFF
--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -255,19 +255,20 @@ sub vcl_synth {
 		set resp.http.Access-Control-Allow-Origin = "*";
 	}
 
-	if (req.http.Host == "static.miraheze.org") {
-		// Handle CORS preflight requests
-		if (resp.reason == "CORS Preflight") {
-			set resp.reason = "OK";
-			set resp.http.Connection = "keep-alive";
-			set resp.http.Content-Length = "0";
+	// Handle CORS preflight requests
+	if (
+		req.http.Host == "static.miraheze.org" &&
+		resp.reason == "CORS Preflight"
+	) {
+		set resp.reason = "OK";
+		set resp.http.Connection = "keep-alive";
+		set resp.http.Content-Length = "0";
 
-			// allow Range requests, and avoid other CORS errors when debugging from test3
-			set resp.http.Access-Control-Allow-Origin = "*";
-			set resp.http.Access-Control-Allow-Headers = "Range,X-Miraheze-Debug";
-			set resp.http.Access-Control-Allow-Methods = "GET, HEAD, OPTIONS";
-			set resp.http.Access-Control-Max-Age = "86400";
-		}
+		// allow Range requests, and avoid other CORS errors when debugging with X-Miraheze-Debug
+		set resp.http.Access-Control-Allow-Origin = "*";
+		set resp.http.Access-Control-Allow-Headers = "Range,X-Miraheze-Debug";
+		set resp.http.Access-Control-Allow-Methods = "GET, HEAD, OPTIONS";
+		set resp.http.Access-Control-Max-Age = "86400";
 	}
 }
 

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -434,6 +434,19 @@ sub vcl_deliver {
 		req.url ~ "(?i)\.(gif|jpg|jpeg|pdf|png|css|js|json|woff|woff2|svg|eot|ttf|otf|ico|sfnt|stl|STL)$"
 	) {
 		set resp.http.Access-Control-Allow-Origin = "*";
+
+		// Handle CORS preflight requests
+		if (resp.reason == "CORS Preflight") {
+			set resp.reason = "OK";
+			set resp.http.Connection = "keep-alive";
+			set resp.http.Content-Length = "0";
+
+			// allow Range requests, and avoid other CORS errors when debugging from test3
+			set resp.http.Access-Control-Allow-Origin = "*";
+			set resp.http.Access-Control-Allow-Headers = "Range,X-Miraheze-Debug";
+			set resp.http.Access-Control-Allow-Methods = "GET, HEAD, OPTIONS";
+			set resp.http.Access-Control-Max-Age = "86400";
+		}
 	}
 
 	if (req.url ~ "^/wiki/" || req.url ~ "^/w/index\.php") {


### PR DESCRIPTION
Hopefully will fix T7311


Always setting `Access-Control-Allow-Origin = "*"` for api.php is not good practice, as it allows unauthenticated requests to the API from anywhere (and for requests with `Access-Control-Allow-Credentials: true`, and `credentials: 'include'` this would be a security risk if the browsers did not block this). This removes that while attempting to maintain the hack for https://phabricator.wikimedia.org/T217669.

Currently, for example any API requests like `
```js
fetch('https://login.miraheze.org/w/api.php', {
  mode: 'cors',
  credentials: 'include'
})
```
will fail because `Access-Control-Allow-Origin = "*"` is being set which the browser will block for security reasons when `credentials: 'include'`. I am hoping this will resolve all of these issues, while still maintaining the fix that it was originally intended for.