### PR TITLE
Remove `Content-Length` and `Connection` headers

### DIFF
--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -250,8 +250,6 @@ sub vcl_synth {
 
 	if (resp.reason == "T217669") {
 		set resp.reason = "OK";
-		set resp.http.Connection = "keep-alive";
-		set resp.http.Content-Length = "0";
 		set resp.http.Access-Control-Allow-Origin = "*";
 		return (deliver);
 	}


### PR DESCRIPTION
* The `Content-Length` header results in 0 bytes being returned, therefore empty output.
* The `Connection` header is just unnecessary from what I can tell.