### PR TITLE
robots.php: set `MW_NO_SESSION` to only warn

### DIFF
--- a/modules/mediawiki/files/robots.php
+++ b/modules/mediawiki/files/robots.php
@@ -1,6 +1,6 @@
 <?php
 
-define( 'MW_NO_SESSION', 1 );
+define( 'MW_NO_SESSION', 'warn' );
 
 require_once( '/srv/mediawiki/w/includes/WebStart.php' );
 
@@ -77,5 +77,7 @@ if ( $databasesArray['combi'] ) {
 if ( $page->exists() ) {
 	echo "# -- BEGIN CUSTOM -- #\r\n\n";
 
-	echo ContentHandler::getContentText( $page->getContent() ) ?: '';
+	$content = $page->getContent();
+
+	echo ( $content instanceof TextContent ) ? $content->getText() : '';
 }


### PR DESCRIPTION
To avoid `BadMethodCallException: Sessions are disabled for this entry point in /srv/mediawiki/w/includes/session/SessionManager.php:849`
Should be set back to `1` once this becomes stable and does not warn anymore.

Also avoid using `ContentHandler::getContentText()`