### PR TITLE
base: If running bullseye or above remove /var/log/journal

### DIFF
--- a/modules/base/manifests/syslog.pp
+++ b/modules/base/manifests/syslog.pp
@@ -2,8 +2,9 @@
 class base::syslog (
         String $syslog_daemon = lookup('base::syslog::syslog_daemon', {'default_value' => 'syslog_ng'}),
 ) {
-
         if os_version('debian >= bullseye') {
+                # Made the unit slower
+                # We don't need persistant journals
                 file { '/var/log/journal' :
                         ensure  => absent,
                         recurse => true,

--- a/modules/base/manifests/syslog.pp
+++ b/modules/base/manifests/syslog.pp
@@ -1,7 +1,17 @@
 # class base::syslog
 class base::syslog (
         String $syslog_daemon = lookup('base::syslog::syslog_daemon', {'default_value' => 'syslog_ng'}),
-    ) {
+) {
+
+        if os_version('debian >= bullseye') {
+                file { '/var/log/journal' :
+                        ensure  => absent,
+                        recurse => true,
+                        force   => true,
+                        notify  => Service['systemd-journald'],
+                }
+        }
+
         if $syslog_daemon == 'rsyslog' {
                 include ::rsyslog
 


### PR DESCRIPTION
It made looking at the unit slower and also we didn't need a persistent journal.