### PR TITLE
mediawiki: Lower apc.shm_size to 256M

### DIFF
--- a/modules/mediawiki/manifests/php.pp
+++ b/modules/mediawiki/manifests/php.pp
@@ -11,7 +11,7 @@ class mediawiki::php (
         class { 'php::php_fpm':
             config  => {
                 'apc'                       => {
-                    'shm_size' => '1024M'
+                    'shm_size' => '256M'
                 },
                 'display_errors'            => 'Off',
                 'error_log'                 => 'syslog',


### PR DESCRIPTION
1gb was way too high for the amount of ram we have.