### PR TITLE
php: drop max_requests by 50%

### DIFF
--- a/modules/php/manifests/fpm/pool.pp
+++ b/modules/php/manifests/fpm/pool.pp
@@ -54,7 +54,7 @@ define php::fpm::pool(
         'listen.backlog' => 256,
         'pm'     => 'static',
         'pm.max_children' => $facts['virtual_processor_count'],
-        'pm.max_requests' => 5000,
+        'pm.max_requests' => 2500,
         'pm.status_path' => '/php_status',
         'access.format'  => '%{%Y-%m-%dT%H:%M:%S}t [%p] %{microseconds}d %{HTTP_HOST}e/%r %m/%s %{mega}M',
         'process.dumpable' => yes,


### PR DESCRIPTION
The previous mitigations have reduced memory by quite a bit and limited the rate of OOMs but the graphs still aren't amazing.

Restarting an individual worker isn't much of an impact for user facing performance but it might help flatten the graphs a bit more and limit the leak even further. This should help us increase confidence in bullseye even if we haven't found the root cause and limit any impact of any issue which is always good.