### PR TITLE
base::puppet: Set release to buster

### DIFF
--- a/modules/base/manifests/puppet.pp
+++ b/modules/base/manifests/puppet.pp
@@ -13,6 +13,8 @@ class base::puppet (
 
     apt::source { 'puppetlabs':
         location => 'http://apt.puppetlabs.com',
+        # Temporarily until bullseye is supported
+        release  => 'buster',
         repos    => "puppet${puppet_major_version}",
         require  => File['/etc/apt/trusted.gpg.d/puppetlabs.gpg'],
         notify   => Exec['apt_update_puppetlabs'],


### PR DESCRIPTION
Bullseye isn't support for the server or db package yet so use the buster version for now.