### PR TITLE
mariadb: Remove server-id

### DIFF
--- a/modules/mariadb/manifests/config.pp
+++ b/modules/mariadb/manifests/config.pp
@@ -20,11 +20,6 @@ class mariadb::config(
     $roundcubemail_password = lookup('passwords::roundcubemail')
     $mariadb_replica_password = lookup('passwords::mariadb_replica_password')
 
-    $server_id = inline_template(
-        "<%= @virtual_ip_address.split('.').inject(0)\
-{|total,value| (total << 8 ) + value.to_i} %>"
-    )
-
     file { '/etc/my.cnf':
         owner   => 'root',
         group   => 'root',

--- a/modules/mariadb/templates/config/mw.cnf.erb
+++ b/modules/mariadb/templates/config/mw.cnf.erb
@@ -28,7 +28,6 @@ tmpdir                         = <%= @tmpdir %>
 transaction-isolation          = READ-COMMITTED
 binlog_format                  = ROW
 
-server-id                      = <%= @server_id %>
 log-bin                        = <%= @datadir %>/mysql-bin
 expire-logs-days               = 1
 sync-binlog                    = 1


### PR DESCRIPTION
We are not using replication so this is unneeded.