### PR TITLE
Force registry.npmjs.org to use ipv6

### DIFF
--- a/modules/mediawiki/manifests/extensionsetup.pp
+++ b/modules/mediawiki/manifests/extensionsetup.pp
@@ -181,6 +181,10 @@ class mediawiki::extensionsetup {
         require     => [ Git::Clone['MediaWiki core'], Exec['install_composer'] ],
     }
 
+    host { 'registry.npmjs.org':
+        ip => '2606:4700::6810:1723',
+    }
+
     include ::nodejs
     exec { 'femiwiki_npm':
         command     => 'npm install --no-optional --only=production',


### PR DESCRIPTION
Otherwise it fails because somehow it's not falling back to ipv6? See https://npm.community/t/npm-fails-to-install-on-ipv6-only-networks/9508