### PR TITLE
mirahezerenewssl: use force=True for logging

### DIFF
--- a/modules/letsencrypt/files/mirahezerenewssl.py
+++ b/modules/letsencrypt/files/mirahezerenewssl.py
@@ -8,7 +8,7 @@ import os
 
 app = Flask(__name__)
 
-logging.basicConfig(filename='/var/log/letsencrypt/miraheze-renewal.log', format='%(asctime)s - %(message)s', level=logging.DEBUG)
+logging.basicConfig(filename='/var/log/letsencrypt/miraheze-renewal.log', format='%(asctime)s - %(message)s', level=logging.DEBUG, force=True)
 
 
 @app.route('/renew', methods=['POST'])


### PR DESCRIPTION
This should work on both infrastructures since mwtask1 is also on bullseye/python3.9. This does require python3.8+ so wouldn't work on buster, which we are on python3.7 though.

From https://docs.python.org/3/library/logging.html#logging.basicConfig:
> If this keyword argument is specified as true, any existing handlers attached to the root logger are removed and closed, before carrying out the configuration as specified by the other arguments

It should prevent errors like FileNotFoundError in the future.