### PR TITLE
Install  netcat-openbsd globally

### DIFF
--- a/modules/base/manifests/packages.pp
+++ b/modules/base/manifests/packages.pp
@@ -18,6 +18,7 @@ class base::packages {
         'molly-guard',
         'mtr',
         'nano',
+        'netcat-openbsd',
         'net-tools',
         'parted',
         'pigz',


### PR DESCRIPTION
This is to get extra features like ipv6 support