### PR TITLE
jobrunner: switch on new DC

### DIFF
--- a/hieradata/hosts/mw101.yaml
+++ b/hieradata/hosts/mw101.yaml
@@ -1,6 +1,7 @@
 users::groups:
   - mediawiki-admins
-jobrunner: false
+jobrunner: true
+mediawiki::jobqueue::runner::redis_ip: '2a10:6740::6:306:6379'
 contactgroups: ['sre', 'mediawiki']
 role::mediawiki::use_strict_firewall: true
 mediawiki::php::fpm::childs: 12

--- a/hieradata/hosts/mw102.yaml
+++ b/hieradata/hosts/mw102.yaml
@@ -1,6 +1,7 @@
 users::groups:
   - mediawiki-admins
-jobrunner: false
+jobrunner: true
+mediawiki::jobqueue::runner::redis_ip: '2a10:6740::6:306:6379'
 contactgroups: ['sre', 'mediawiki']
 role::mediawiki::use_strict_firewall: true
 mediawiki::php::fpm::childs: 12

--- a/hieradata/hosts/mw111.yaml
+++ b/hieradata/hosts/mw111.yaml
@@ -1,6 +1,7 @@
 users::groups:
   - mediawiki-admins
-jobrunner: false
+jobrunner: true
+mediawiki::jobqueue::runner::redis_ip: '2a10:6740::6:306:6379'
 contactgroups: ['sre', 'mediawiki']
 role::mediawiki::use_strict_firewall: true
 mediawiki::php::fpm::childs: 12

--- a/hieradata/hosts/mw112.yaml
+++ b/hieradata/hosts/mw112.yaml
@@ -1,6 +1,7 @@
 users::groups:
   - mediawiki-admins
-jobrunner: false
+jobrunner: true
+mediawiki::jobqueue::runner::redis_ip: '2a10:6740::6:306:6379'
 contactgroups: ['sre', 'mediawiki']
 role::mediawiki::use_strict_firewall: true
 mediawiki::php::fpm::childs: 12

--- a/hieradata/hosts/mw121.yaml
+++ b/hieradata/hosts/mw121.yaml
@@ -1,6 +1,7 @@
 users::groups:
   - mediawiki-admins
-jobrunner: false
+jobrunner: true
+mediawiki::jobqueue::runner::redis_ip: '2a10:6740::6:306:6379'
 contactgroups: ['sre', 'mediawiki']
 role::mediawiki::use_strict_firewall: true
 mediawiki::php::fpm::childs: 12

--- a/hieradata/hosts/mw122.yaml
+++ b/hieradata/hosts/mw122.yaml
@@ -1,6 +1,7 @@
 users::groups:
   - mediawiki-admins
-jobrunner: false
+jobrunner: true
+mediawiki::jobqueue::runner::redis_ip: '2a10:6740::6:306:6379'
 contactgroups: ['sre', 'mediawiki']
 role::mediawiki::use_strict_firewall: true
 mediawiki::php::fpm::childs: 12

--- a/hieradata/hosts/mwtask111.yaml
+++ b/hieradata/hosts/mwtask111.yaml
@@ -1,14 +1,15 @@
 users::groups:
   - mediawiki-admins
 letsencrypt: true
-jobrunner: false
-jobrunner::intensive: false
+jobrunner: true
+jobrunner::intensive: true
 contactgroups: ['sre', 'mediawiki']
 role::mediawiki::use_strict_firewall: true
 mediawiki::php::fpm::childs: 1
 php::php_fpm::fpm_workers_multiplier: 1.0
 php::php_version: '7.4'
-mediawiki::jobqueue::runner::cron: false
+mediawiki::jobqueue::runner::cron: true
+mediawiki::jobqueue::runner::redis_ip: '2a10:6740::6:306:6379'
 nginx::use_graylog: true
 puppetserver_hostname: 'puppet111.miraheze.org'
 mediawiki::is_canary: true


### PR DESCRIPTION
Jobchron is now available.

This will only process jobs received from the new DC.