### PR TITLE
irc: use irc.libera.chat rather than direct IPv6 address

### DIFF
--- a/modules/role/manifests/irc.pp
+++ b/modules/role/manifests/irc.pp
@@ -4,11 +4,7 @@ class role::irc {
 
     class { 'irc::ircrcbot':
         nickname     => 'MirahezeRC',
-        # irc.libera.chat (ipv6 address, have to hardcode it.
-        # This is because it's either picking up the ipv4 address
-        # for the hostname or it doesn't support getting the ipv6
-        # address from hostname.
-        network      => '2001:6b0:78::101',
+        network      => 'irc.libera.chat',
         network_port => '6697',
         channel      => '#miraheze-feed',
         udp_port     => '5070',
@@ -16,11 +12,7 @@ class role::irc {
 
     class { 'irc::irclogserverbot':
         nickname     => 'MirahezeLSBot',
-        # irc.libera.chat (ipv6 address, have to hardcode it.
-        # This is because it's either picking up the ipv4 address
-        # for the hostname or it doesn't support getting the ipv6
-        # address from hostname.
-        network      => '2001:6b0:78::101',
+        network      => 'irc.libera.chat',
         network_port => '6697',
         channel      => '#miraheze-sre',
         udp_port     => '5071',


### PR DESCRIPTION
This should theoretically work now after the following commits:
* 99796ef
* cd1ea41

Which were done after these were switched to use direct IPv6 addresses.

Using irc.libera.chat does work for other bots like MirahezeLogbot so I'm thinking that with the above commits it should also work here.