### PR TITLE
mariadb: Grant REPLICA MONITOR to exporter on bullseye+

### DIFF
--- a/modules/mariadb/templates/grants/default-grants.sql.erb
+++ b/modules/mariadb/templates/grants/default-grants.sql.erb
@@ -14,9 +14,15 @@ GRANT REPLICATION CLIENT ON *.* TO 'icinga'@'%'
 
 -- Grants for 'exporter'@'localhost'
 
+<% if ['buster'].include? @facts['os']['distro']['codename'] -%>
 GRANT USAGE, PROCESS, REPLICATION CLIENT
     ON *.* TO 'exporter'@'localhost'
     IDENTIFIED BY '<%= @exporter_password %>';
+<%- else -%>
+GRANT USAGE, PROCESS, REPLICATION CLIENT, REPLICA MONITOR
+    ON *.* TO 'exporter'@'localhost'
+    IDENTIFIED BY '<%= @exporter_password %>';
+<%- end -%>
 
 -- Grants for 'replica'@'%'
 


### PR DESCRIPTION
This is a new permission under 10.5.