### PR TITLE
Revert all OOM mitigations

### DIFF
--- a/hieradata/hosts/mw10.yaml
+++ b/hieradata/hosts/mw10.yaml
@@ -3,9 +3,8 @@ users::groups:
 jobrunner: true
 contactgroups: ['sre', 'mediawiki']
 role::mediawiki::use_strict_firewall: true
-mediawiki::php::fpm::childs: 12
-mediawiki::php::fpm::fpm_max_memory: 256
-mediawiki::php::fpm::fpm_min_restart_threshold: 6
+mediawiki::php::fpm::childs: 32
+mediawiki::php::fpm::fpm_min_restart_threshold: 14
 php::php_fpm::fpm_workers_multiplier: 1.0
 php::php_version: '7.3'
 nginx::use_graylog: true

--- a/hieradata/hosts/mw101.yaml
+++ b/hieradata/hosts/mw101.yaml
@@ -4,9 +4,8 @@ jobrunner: true
 mediawiki::jobqueue::runner::redis_ip: '[2a10:6740::6:306]:6379'
 contactgroups: ['sre', 'mediawiki']
 role::mediawiki::use_strict_firewall: true
-mediawiki::php::fpm::childs: 16
-mediawiki::php::fpm::fpm_min_restart_threshold: 8
-mediawiki::php::fpm::fpm_max_memory: 256
+mediawiki::php::fpm::childs: 32
+mediawiki::php::fpm::fpm_min_restart_threshold: 14
 php::php_fpm::fpm_workers_multiplier: 1.0
 php::php_version: '7.4'
 nginx::use_graylog: true

--- a/hieradata/hosts/mw102.yaml
+++ b/hieradata/hosts/mw102.yaml
@@ -4,9 +4,8 @@ jobrunner: true
 mediawiki::jobqueue::runner::redis_ip: '[2a10:6740::6:306]:6379'
 contactgroups: ['sre', 'mediawiki']
 role::mediawiki::use_strict_firewall: true
-mediawiki::php::fpm::childs: 16
-mediawiki::php::fpm::fpm_min_restart_threshold: 8
-mediawiki::php::fpm::fpm_max_memory: 256
+mediawiki::php::fpm::childs: 32
+mediawiki::php::fpm::fpm_min_restart_threshold: 14
 php::php_fpm::fpm_workers_multiplier: 1.0
 php::php_version: '7.4'
 nginx::use_graylog: true

--- a/hieradata/hosts/mw11.yaml
+++ b/hieradata/hosts/mw11.yaml
@@ -4,9 +4,8 @@ jobrunner: true
 contactgroups: ['sre', 'mediawiki']
 role::mediawiki::use_strict_firewall: true
 mediawiki::branch: 'REL1_37'
-mediawiki::php::fpm::childs: 12
-mediawiki::php::fpm::fpm_max_memory: 256
-mediawiki::php::fpm::fpm_min_restart_threshold: 6
+mediawiki::php::fpm::childs: 32
+mediawiki::php::fpm::fpm_min_restart_threshold: 14
 php::php_fpm::fpm_workers_multiplier: 1.0
 php::php_version: '7.3'
 nginx::use_graylog: true

--- a/hieradata/hosts/mw111.yaml
+++ b/hieradata/hosts/mw111.yaml
@@ -4,9 +4,8 @@ jobrunner: true
 mediawiki::jobqueue::runner::redis_ip: '[2a10:6740::6:306]:6379'
 contactgroups: ['sre', 'mediawiki']
 role::mediawiki::use_strict_firewall: true
-mediawiki::php::fpm::childs: 16
-mediawiki::php::fpm::fpm_min_restart_threshold: 8
-mediawiki::php::fpm::fpm_max_memory: 256
+mediawiki::php::fpm::childs: 32
+mediawiki::php::fpm::fpm_min_restart_threshold: 14
 php::php_fpm::fpm_workers_multiplier: 1.0
 php::php_version: '7.4'
 nginx::use_graylog: true

--- a/hieradata/hosts/mw112.yaml
+++ b/hieradata/hosts/mw112.yaml
@@ -4,9 +4,8 @@ jobrunner: true
 mediawiki::jobqueue::runner::redis_ip: '[2a10:6740::6:306]:6379'
 contactgroups: ['sre', 'mediawiki']
 role::mediawiki::use_strict_firewall: true
-mediawiki::php::fpm::childs: 16
-mediawiki::php::fpm::fpm_min_restart_threshold: 8
-mediawiki::php::fpm::fpm_max_memory: 256
+mediawiki::php::fpm::childs: 32
+mediawiki::php::fpm::fpm_min_restart_threshold: 14
 php::php_fpm::fpm_workers_multiplier: 1.0
 php::php_version: '7.4'
 nginx::use_graylog: true

--- a/hieradata/hosts/mw12.yaml
+++ b/hieradata/hosts/mw12.yaml
@@ -3,9 +3,8 @@ users::groups:
 jobrunner: true
 contactgroups: ['sre', 'mediawiki']
 role::mediawiki::use_strict_firewall: true
-mediawiki::php::fpm::childs: 12
-mediawiki::php::fpm::fpm_max_memory: 256
-mediawiki::php::fpm::fpm_min_restart_threshold: 6
+mediawiki::php::fpm::childs: 32
+mediawiki::php::fpm::fpm_min_restart_threshold: 14
 php::php_fpm::fpm_workers_multiplier: 1.0
 php::php_version: '7.3'
 nginx::use_graylog: true

--- a/hieradata/hosts/mw121.yaml
+++ b/hieradata/hosts/mw121.yaml
@@ -4,9 +4,8 @@ jobrunner: true
 mediawiki::jobqueue::runner::redis_ip: '[2a10:6740::6:306]:6379'
 contactgroups: ['sre', 'mediawiki']
 role::mediawiki::use_strict_firewall: true
-mediawiki::php::fpm::childs: 16
-mediawiki::php::fpm::fpm_min_restart_threshold: 8
-mediawiki::php::fpm::fpm_max_memory: 256
+mediawiki::php::fpm::childs: 32
+mediawiki::php::fpm::fpm_min_restart_threshold: 14
 php::php_fpm::fpm_workers_multiplier: 1.0
 php::php_version: '7.4'
 nginx::use_graylog: true

--- a/hieradata/hosts/mw122.yaml
+++ b/hieradata/hosts/mw122.yaml
@@ -4,9 +4,8 @@ jobrunner: true
 mediawiki::jobqueue::runner::redis_ip: '[2a10:6740::6:306]:6379'
 contactgroups: ['sre', 'mediawiki']
 role::mediawiki::use_strict_firewall: true
-mediawiki::php::fpm::childs: 16
-mediawiki::php::fpm::fpm_min_restart_threshold: 8
-mediawiki::php::fpm::fpm_max_memory: 256
+mediawiki::php::fpm::childs: 32
+mediawiki::php::fpm::fpm_min_restart_threshold: 14
 php::php_fpm::fpm_workers_multiplier: 1.0
 php::php_version: '7.4'
 nginx::use_graylog: true

--- a/hieradata/hosts/mw13.yaml
+++ b/hieradata/hosts/mw13.yaml
@@ -3,9 +3,8 @@ users::groups:
 jobrunner: true
 contactgroups: ['sre', 'mediawiki']
 role::mediawiki::use_strict_firewall: true
-mediawiki::php::fpm::childs: 12
-mediawiki::php::fpm::fpm_max_memory: 256
-mediawiki::php::fpm::fpm_min_restart_threshold: 6
+mediawiki::php::fpm::childs: 32
+mediawiki::php::fpm::fpm_min_restart_threshold: 14
 php::php_fpm::fpm_workers_multiplier: 1.0
 php::php_version: '7.3'
 nginx::use_graylog: true

--- a/hieradata/hosts/mw8.yaml
+++ b/hieradata/hosts/mw8.yaml
@@ -3,9 +3,8 @@ users::groups:
 jobrunner: true
 contactgroups: ['sre', 'mediawiki']
 role::mediawiki::use_strict_firewall: true
-mediawiki::php::fpm::childs: 12
-mediawiki::php::fpm::fpm_min_restart_threshold: 6
-mediawiki::php::fpm::fpm_max_memory: 256
+mediawiki::php::fpm::childs: 32
+mediawiki::php::fpm::fpm_min_restart_threshold: 14
 php::php_fpm::fpm_workers_multiplier: 1.0
 php::php_version: '7.4'
 nginx::use_graylog: true

--- a/hieradata/hosts/mw9.yaml
+++ b/hieradata/hosts/mw9.yaml
@@ -3,9 +3,8 @@ users::groups:
 jobrunner: true
 contactgroups: ['sre', 'mediawiki']
 role::mediawiki::use_strict_firewall: true
-mediawiki::php::fpm::childs: 12
-mediawiki::php::fpm::fpm_max_memory: 256
-mediawiki::php::fpm::fpm_min_restart_threshold: 6
+mediawiki::php::fpm::childs: 32
+mediawiki::php::fpm::fpm_min_restart_threshold: 14
 php::php_fpm::fpm_workers_multiplier: 1.0
 php::php_version: '7.3'
 nginx::use_graylog: true

--- a/hieradata/hosts/test101.yaml
+++ b/hieradata/hosts/test101.yaml
@@ -10,8 +10,7 @@ php::php_version: '7.4'
 mediawiki::php::use_tideways: true
 nginx::use_graylog: true
 puppetserver_hostname: 'puppet111.miraheze.org'
-mediawiki::php::fpm::childs: 12
-mediawiki::php::fpm::fpm_max_memory: 256
+mediawiki::php::fpm::childs: 32
 mediawiki::use_staging: true
 mediawiki::remote_sync: false
 

--- a/hieradata/hosts/test3.yaml
+++ b/hieradata/hosts/test3.yaml
@@ -10,8 +10,7 @@ php::php_version: '7.4'
 mediawiki::php::use_tideways: true
 nginx::use_graylog: true
 puppetserver_hostname: 'puppet3.miraheze.org'
-mediawiki::php::fpm::childs: 12
-mediawiki::php::fpm::fpm_max_memory: 256
+mediawiki::php::fpm::childs: 32
 mediawiki::use_staging: true
 mediawiki::remote_sync: false
 

--- a/modules/mediawiki/manifests/php.pp
+++ b/modules/mediawiki/manifests/php.pp
@@ -2,7 +2,6 @@
 class mediawiki::php (
     Integer $php_fpm_childs = lookup('mediawiki::php::fpm::childs', {'default_value' => 26}),
     Integer $fpm_min_restart_threshold = lookup('mediawiki::php::fpm::fpm_min_restart_threshold', {'default_value' => 6}),
-    Integer $fpm_max_memory = lookup('mediawiki::php::fpm::fpm_max_memory', {'default_value' => 512}),
     String $php_version = lookup('php::php_version', {'default_value' => '7.2'}),
     Boolean $use_tideways = lookup('mediawiki::php::use_tideways', {'default_value' => false}),
 ) {
@@ -17,11 +16,11 @@ class mediawiki::php (
                 'error_log'                 => 'syslog',
                 'error_reporting'           => 'E_ALL & ~E_DEPRECATED & ~E_STRICT',
                 'log_errors'                => 'On',
-                'memory_limit'              => "${$fpm_max_memory}M",
+                'memory_limit'              => '512M',
                 'opcache'                   => {
                     'enable'                  => 1,
                     'interned_strings_buffer' => 50,
-                    'memory_consumption'      => $fpm_max_memory,
+                    'memory_consumption'      => 512,
                     'max_accelerated_files'   => 24000,
                     'max_wasted_percentage'   => 10,
                     'validate_timestamps'     => 1,

--- a/modules/php/manifests/fpm/pool.pp
+++ b/modules/php/manifests/fpm/pool.pp
@@ -54,7 +54,7 @@ define php::fpm::pool(
         'listen.backlog' => 256,
         'pm'     => 'static',
         'pm.max_children' => $facts['virtual_processor_count'],
-        'pm.max_requests' => 1000,
+        'pm.max_requests' => 5000,
         'pm.status_path' => '/php_status',
         'access.format'  => '%{%Y-%m-%dT%H:%M:%S}t [%p] %{microseconds}d %{HTTP_HOST}e/%r %m/%s %{mega}M',
         'process.dumpable' => yes,

--- a/modules/php/manifests/fpm/pool.pp
+++ b/modules/php/manifests/fpm/pool.pp
@@ -54,7 +54,7 @@ define php::fpm::pool(
         'listen.backlog' => 256,
         'pm'     => 'static',
         'pm.max_children' => $facts['virtual_processor_count'],
-        'pm.max_requests' => 5000,
+        'pm.max_requests' => 10000,
         'pm.status_path' => '/php_status',
         'access.format'  => '%{%Y-%m-%dT%H:%M:%S}t [%p] %{microseconds}d %{HTTP_HOST}e/%r %m/%s %{mega}M',
         'process.dumpable' => yes,

--- a/modules/php/manifests/init.pp
+++ b/modules/php/manifests/init.pp
@@ -34,7 +34,7 @@ class php(
         'display_errors'         => 'On',
         'log_errors'             => 'On',
         'include_path'           => '".:/usr/share/php"',
-        'max_execution_time'     => 59,
+        'max_execution_time'     => 180,
         'memory_limit'           => '128M',
         'mysql'                  => {
             'connect_timeout' => 1,

--- a/modules/php/manifests/php_fpm.pp
+++ b/modules/php/manifests/php_fpm.pp
@@ -176,7 +176,7 @@ class php::php_fpm(
     $base_fpm_pool_config = {
         'pm'                        => 'static',
         'pm.max_children'           => $num_workers,
-        'request_terminate_timeout' => 59,
+        'request_terminate_timeout' => 180,
     }
 
     php::fpm::pool { 'www':


### PR DESCRIPTION
Timeline:
* Servers were OOMing
* These changes were made
* OOMs reduced
* user-facing errors become 10x worse (502s/503s)

This was not the right fix (so it would seem), an investigation to what was causing the memory leak to begin with needs to be conducted. Not fixes that unintentionally create additional user-facing issues as a side effect. If this PR is merged and user-facing errors do not improve it can be reverted again.

Doing this after discussion about the timeline with @AgentIsai, waiting for feedback from @Reception123 in the conversation still.