### PR TITLE
MediaWiki: add custom 502 error page for nginx

### DIFF
--- a/modules/mediawiki/templates/mediawiki.conf.erb
+++ b/modules/mediawiki/templates/mediawiki.conf.erb
@@ -111,6 +111,7 @@ server {
 	add_header X-Frame-Options "ALLOW-FROM static.miraheze.org";
 
 	error_page 404 /ErrorPages/404.php;
+	error_page 502 /ErrorPages/502.php;
 
 	include /etc/nginx/mediawiki-includes;
 


### PR DESCRIPTION
* miraheze/ErrorPages#3 creates the error page.

This is just so it looks neater then the default 502 error page which is just "502 Bad Gateway".