### PR TITLE
rdns: allow flat CNAME for dreamhost too

### DIFF
--- a/modules/monitoring/files/check_reverse_dns.py
+++ b/modules/monitoring/files/check_reverse_dns.py
@@ -67,7 +67,7 @@ def check_records(hostname):
         for nameserver in nameserversans:
             nameserver = str(nameserver)
             nameservers.append(nameserver)
-            if nameserver.endswith('.ns.cloudflare.com.'):
+            if nameserver.endswith('.ns.cloudflare.com.') or nameserver.endswith('.dreamhost.com'):
                 uses_cf_at_root = True
 
         if sorted(list(nameservers)) == sorted(['ns1.miraheze.org.', 'ns2.miraheze.org.']):


### PR DESCRIPTION
They use an ALIAS type instead which is fine. It's impossible to tell whether this is actually an A/AAAA record.