### PR TITLE
ImageMagick: limit memory usage to 128MB

### DIFF
--- a/modules/imagemagick/files/policy.xml
+++ b/modules/imagemagick/files/policy.xml
@@ -46,7 +46,6 @@
 -->
 <policymap>
   <!-- <policy domain="resource" name="temporary-path" value="/tmp"/> -->
-  <!-- <policy domain="resource" name="memory" value="2GiB"/> -->
   <!-- <policy domain="resource" name="map" value="4GiB"/> -->
   <!-- <policy domain="resource" name="area" value="1GB"/> -->
   <!-- <policy domain="resource" name="disk" value="16EB"/> -->
@@ -55,7 +54,8 @@
   <!-- <policy domain="resource" name="throttle" value="0"/> -->
   <!-- <policy domain="resource" name="time" value="3600"/> -->
   <!-- <policy domain="system" name="precision" value="6"/> -->
-  <policy domain="cache" name="shared-secret" value="passphrase"/>
+  <policy domain="resource" name="memory" value="128MiB" />
+  <policy domain="cache" name="shared-secret" value="passphrase" />
   <policy domain="coder" rights="none" pattern="EPHEMERAL" />
   <policy domain="coder" rights="none" pattern="URL" />
   <policy domain="coder" rights="none" pattern="HTTPS" />


### PR DESCRIPTION
Default is 256MB