### PR TITLE
bastion: move firewall rule to role class

### DIFF
--- a/modules/base/manifests/firewall.pp
+++ b/modules/base/manifests/firewall.pp
@@ -48,17 +48,9 @@ class base::firewall {
         ' '
     )
 
-    if $::fqdn =~ /^bast[0-9]+.miraheze.org/ {
-        ferm::service { 'ssh':
-            proto => 'tcp',
-            port  => '22',
-        }
-    } else {
-        ferm::service { 'ssh':
-            proto  => 'tcp',
-            port   => '22',
-            srange => "(${firewall_bastion_hosts})"
-        }
+    ferm::service { 'ssh':
+        proto => 'tcp',
+        port  => '22',
     }
 
     class { '::ulogd': }

--- a/modules/role/manifests/bastion.pp
+++ b/modules/role/manifests/bastion.pp
@@ -5,7 +5,12 @@ class role::bastion {
         description => 'core access bastion host'
     }
 
-    $firewall_rules_str = join(
+    ferm::service { 'bastion-ssh-public':
+        proto => 'tcp',
+        port  => '22',
+    }
+
+    $squid_access_hosts_str = join(
         query_facts("domain='$domain'", ['ipaddress', 'ipaddress6'])
         .map |$key, $value| {
             "${value['ipaddress']} ${value['ipaddress6']}"
@@ -15,9 +20,10 @@ class role::bastion {
         .sort(),
         ' '
     )
-    ferm::service { 'bastion':
-        proto   => 'tcp',
-        port    => '8080',
-        srange  => "(${firewall_rules_str})",
+
+    ferm::service { 'bastion-squid':
+        proto  => 'tcp',
+        port   => '8080',
+        srange => "(${squid_access_hosts_str})",
     }
 }


### PR DESCRIPTION
Moves the bastion public ssh access firewall rule to the bastion role.
base::firewall should not set up firewall rules for individual services,
that responsibility should be left to the puppet modules configuring
those individual services.

Also clarify naming in the bastion role to make the names more clear.
