### PR TITLE
Addition of 29tb.github.io to CSP

### DIFF
--- a/modules/varnish/data/csp.yaml
+++ b/modules/varnish/data/csp.yaml
@@ -145,6 +145,7 @@ frame-src:
   - 'w.soundcloud.com'
   - 'query.wikidata.org'
   - 'player.vimeo.com'
+  - '29tb.github.io'
 
 connect-src:
   - "'self'"


### PR DESCRIPTION
Completely dependent on T8687 being accepted; do NOT merge unless approved.