### PR TITLE
Only run workflow on python files

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.7', '3.9']
+        python: ['3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,6 +1,11 @@
 on:
   push:
+    paths:
+      - '**.py'
+
   pull_request:
+    paths:
+      - '**.py'
 
 jobs:
   build:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,10 +2,12 @@ on:
   push:
     paths:
       - '**.py'
+      - '.github/**'
 
   pull_request:
     paths:
       - '**.py'
+      - '.github/**'
 
 jobs:
   build:


### PR DESCRIPTION
This should only run on python files with this. 

Also, if we want to only enforce things in the MediaWiki module, we can do:
```yaml
paths:
  - 'modules/mediawiki/**.py'
```