### PR TITLE
Varnish: update 503 error message

### DIFF
--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -542,11 +542,10 @@ sub vcl_backend_error {
 				<div class="row">
 					<div class="col-md-6">
 						<h2>What can I do?</h2>
-						<p class="lead">If you're a wiki visitor or owner</p>
-						<p>Try again in a few minutes. If the problem persists, please report this on <a href="https://phabricator.miraheze.org">phabricator.</a> We apologize for the inconvenience. Our sysadmins should be attempting to solve the issue ASAP!</p>
+						<p>Try again in a few minutes. If the problem persists, please report this on <a href="https://phabricator.miraheze.org">Phabricator</a>. If Phabricator is also down, you may join our <a href="https://discord.gg/TVAJTE4CUn">Discord server</a> or IRC (<a href="https://web.libera.chat/?channel=#miraheze-sre">#miraheze-sre</a>) for additional updates. We apologise for the inconvenience. Our system administrators should be attempting to resolve the issue ASAP!</p>
 					</div>
 					<div class="col-md-6">
-						<a class="twitter-timeline" data-width="500" data-height="350" text-align: center href="https://twitter.com/miraheze?ref_src=twsrc%5Etfw">Tweets by miraheze</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+						<a class="twitter-timeline" data-width="500" data-height="350" text-align: center href="https://twitter.com/miraheze?ref_src=twsrc%5Etfw">Tweets by Miraheze</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
* Remove "If you're a wiki visitor or owner" — since that's all-inclusive and unnecessary.
* Fix some wording and capitalisation.
* Mention alternatives if Phabricator is also down. Since if the cache proxies are the issue, Phabricator will likely also be down as it's now behind the cache proxies.