### PR TITLE
Allow static access from same domain

### DIFF
--- a/modules/mediawiki/files/favicon.php
+++ b/modules/mediawiki/files/favicon.php
@@ -1,0 +1,45 @@
+<?php
+
+// Based on the version created by Wikimedia
+
+define( 'MW_NO_SESSION', 1 );
+require_once '/srv/mediawiki/w/includes/WebStart.php';
+
+use MediaWiki\MediaWikiServices;
+
+function streamFavicon() {
+	global $wgFavicon;
+	wfResetOutputBuffers();
+
+	$favicon = $wgFavicon;
+	if ( $favicon === '/favicon.ico' ) {
+		$favicon = '/default.ico';
+	}
+
+	$req = RequestContext::getMain()->getRequest();
+	if ( $req->getHeader( 'X-Favicon-Loop' ) !== false ) {
+		header( 'HTTP/1.1 500 Internal Server Error' );
+		return;
+	}
+
+	$url = wfExpandUrl( $favicon, PROTO_CANONICAL );
+	$client = MediaWikiServices::getInstance()
+		->getHttpRequestFactory()
+		->create( $url );
+	$client->setHeader( 'X-Favicon-Loop', '1' );
+
+	$status = $client->execute();
+	if ( !$status->isOK() ) {
+		header( 'HTTP/1.1 500 Internal Server Error' );
+		return;
+	}
+
+	$content = $client->getContent();
+	header( 'Content-Length: ' . strlen( $content ) );
+	header( 'Content-Type: ' . $client->getResponseHeader( 'Content-Type' ) );
+	header( 'Cache-Control: public' );
+	header( 'Expires: ' . gmdate( 'r', time() + 86400 ) );
+	echo $content;
+}
+
+streamFavicon();

--- a/modules/mediawiki/files/favicon.php
+++ b/modules/mediawiki/files/favicon.php
@@ -13,7 +13,7 @@ function streamFavicon() {
 
 	$favicon = $wgFavicon;
 	if ( $favicon === '/favicon.ico' ) {
-		$favicon = '/default.ico';
+		$favicon = '/favicons/default.ico';
 	}
 
 	$req = RequestContext::getMain()->getRequest();

--- a/modules/mediawiki/files/robots.php
+++ b/modules/mediawiki/files/robots.php
@@ -1,7 +1,6 @@
 <?php
 
 define( 'MW_NO_SESSION', 1 );
-
 require_once '/srv/mediawiki/w/includes/WebStart.php';
 
 use MediaWiki\MediaWikiServices;
@@ -10,10 +9,6 @@ $wikiPageFactory = MediaWikiServices::getInstance()->getWikiPageFactory();
 $titleFactory = MediaWikiServices::getInstance()->getTitleFactory();
 
 $page = $wikiPageFactory->newFromTitle( $titleFactory->newFromText( 'Robots.txt', NS_MEDIAWIKI ) );
-
-$databaseJsonFileName = '/srv/mediawiki/cache/databases.json';
-$databasesArray = file_exists( $databaseJsonFileName ) ?
-	json_decode( file_get_contents( $databaseJsonFileName ), true ) : [ 'combi' => [] ];
 
 header( 'Content-Type: text/plain; charset=utf-8' );
 header( 'X-Miraheze-Robots: Default' );
@@ -37,47 +32,9 @@ echo "# Throttle MJ12Bot" . "\r\n";
 echo "User-agent: MJ12bot" . "\r\n";
 echo "Crawl-Delay: 10" . "\r\n\n";
 
-if ( $databasesArray['combi'] ) {
-	if ( preg_match( '/^(.+)\.miraheze\.org$/', $_SERVER['HTTP_HOST'], $matches ) ) {
-		$wiki = "{$matches[1]}wiki";
-
-		if ( !isset( $databasesArray['combi']["{$wiki}"] ) ) {
-			return;
-		}
-
-		# Dynamic sitemap url
-		echo "# Dynamic sitemap url" . "\r\n";
-		echo "Sitemap: https://static.miraheze.org/{$wiki}/sitemaps/sitemap.xml" . "\r\n\n";
-	} else {
-		$customDomainFound = false;
-		$suffixes = [ 'wiki' ];
-		$suffixMatch = array_flip( [ 'miraheze.org' => 'wiki' ] );
-
-		foreach ( $databasesArray['combi'] as $db => $data ) {
-			foreach ( $suffixes as $suffix ) {
-				if ( substr( $db, -strlen( $suffix ) == $suffix ) ) {
-					$url = $data['u'] ?? 'https://' . substr( $db, 0, -strlen( $suffix ) ) . '.' . $suffixMatch[$suffix];
-
-					if ( !$url ) {
-						continue;
-					}
-
-					if ( $url === "https://{$_SERVER['HTTP_HOST']}" ) {
-						$customDomainFound = $db;
-					}
-				}
-			}
-
-			continue;
-		}
-
-		if ( $customDomainFound ) {
-			# Dynamic sitemap url
-			echo "# Dynamic sitemap url" . "\r\n";
-			echo "Sitemap: https://static.miraheze.org/{$customDomainFound}/sitemaps/sitemap.xml" . "\r\n\n";
-		}
-	}
-}
+# Dynamic sitemap url
+echo "# Dynamic sitemap url" . "\r\n";
+echo "Sitemap: https://static.miraheze.org/{$wgDBname}/sitemaps/sitemap.xml" . "\r\n\n";
 
 if ( $page->exists() ) {
 	header( 'X-Miraheze-Robots: Custom' );

--- a/modules/mediawiki/files/sitemap.php
+++ b/modules/mediawiki/files/sitemap.php
@@ -1,43 +1,37 @@
 <?php
 
-$databaseJsonFileName = '/srv/mediawiki/cache/databases.json';
-$databasesArray = file_exists( $databaseJsonFileName ) ?
-	json_decode( file_get_contents( $databaseJsonFileName ), true ) : [ 'combi' => [] ];
+define( 'MW_NO_SESSION', 1 );
+require_once '/srv/mediawiki/w/includes/WebStart.php';
 
-if ( $databasesArray['combi'] ) {
-	if ( preg_match( '/^(.+)\.miraheze\.org$/', $_SERVER['HTTP_HOST'], $matches ) ) {
-		$wiki = "{$matches[1]}wiki";
-		if ( !isset( $databasesArray['combi']["{$wiki}"] ) ) {
-			return;
-		}
+use MediaWiki\MediaWikiServices;
 
-		header( "Location: https://static.miraheze.org/{$wiki}/sitemaps/sitemap.xml", true, 302 );
-	} else {
-		$customDomainFound = false;
-		$suffixes = [ 'wiki' ];
-		$suffixMatch = array_flip( [ 'miraheze.org' => 'wiki' ] );
-		foreach ( $databasesArray['combi'] as $db => $data ) {
-			foreach ( $suffixes as $suffix ) {
-				if ( substr( $db, -strlen( $suffix ) == $suffix ) ) {
-					$url = $data['u'] ?? 'https://' . substr( $db, 0, -strlen( $suffix ) ) . '.' . $suffixMatch[$suffix];
+function streamSitemapIndex() {
+	global $wgDBname;
+	wfResetOutputBuffers();
 
-					if ( !$url ) {
-						continue;
-					}
+	$url = "https://static.miraheze.org/{$wgDBname}/sitemaps/sitemap.xml";
 
-					if ( $url === "https://{$_SERVER['HTTP_HOST']}" ) {
-						$customDomainFound = $db;
-					}
-				}
-			}
-
-			continue;
-		}
-
-		if ( $customDomainFound ) {
-			header( "Location: https://static.miraheze.org/{$customDomainFound}/sitemaps/sitemap.xml", true, 302 );
-		}
+	$req = RequestContext::getMain()->getRequest();
+	if ( $req->getHeader( 'X-Sitemap-Loop' ) !== false ) {
+		header( 'HTTP/1.1 500 Internal Server Error' );
+		return;
 	}
+
+	$client = MediaWikiServices::getInstance()
+		->getHttpRequestFactory()
+		->create( $url );
+	$client->setHeader( 'X-Sitemap-Loop', '1' );
+
+	$status = $client->execute();
+	if ( !$status->isOK() ) {
+		header( 'HTTP/1.1 500 Internal Server Error' );
+		return;
+	}
+
+	$content = $client->getContent();
+	header( 'Content-Length: ' . strlen( $content ) );
+	header( 'Content-Type: ' . $client->getResponseHeader( 'Content-Type' ) );
+	echo $content;
 }
 
-exit();
+streamSitemapIndex();

--- a/modules/mediawiki/files/touch.php
+++ b/modules/mediawiki/files/touch.php
@@ -1,0 +1,45 @@
+<?php
+
+// Based on the version created by Wikimedia
+
+define( 'MW_NO_SESSION', 1 );
+require_once '/srv/mediawiki/w/includes/WebStart.php';
+
+use MediaWiki\MediaWikiServices;
+
+function streamAppleTouch() {
+	global $wgAppleTouchIcon;
+	wfResetOutputBuffers();
+
+	$touch = $wgAppleTouchIcon;
+	if ( $touch === '/apple-touch-icon.png' || $touch === false ) {
+		$touch = '/favicons/apple-touch-icon-default.png';
+	}
+
+	$req = RequestContext::getMain()->getRequest();
+	if ( $req->getHeader( 'X-Favicon-Loop' ) !== false ) {
+		header( 'HTTP/1.1 500 Internal Server Error' );
+		return;
+	}
+
+	$url = wfExpandUrl( $touch, PROTO_CANONICAL );
+	$client = MediaWikiServices::getInstance()
+		->getHttpRequestFactory()
+		->create( $url );
+	$client->setHeader( 'X-Favicon-Loop', '1' );
+
+	$status = $client->execute();
+	if ( !$status->isOK() ) {
+		header( 'HTTP/1.1 500 Internal Server Error' );
+		return;
+	}
+
+	$content = $client->getContent();
+	header( 'Content-Length: ' . strlen( $content ) );
+	header( 'Content-Type: ' . $client->getResponseHeader( 'Content-Type' ) );
+	header( 'Cache-Control: public' );
+	header( 'Expires: ' . gmdate( 'r', time() + 86400 ) );
+	echo $content;
+}
+
+streamAppleTouch();

--- a/modules/mediawiki/manifests/favicons.pp
+++ b/modules/mediawiki/manifests/favicons.pp
@@ -1,22 +1,22 @@
 # === Class mediawiki::favicons
 class mediawiki::favicons {
-    file { [
-        '/usr/share/nginx',
-        '/usr/share/nginx/favicons',
-    ]:
+    file { '/srv/mediawiki/favicons':
         ensure => directory,
         owner  => 'www-data',
         group  => 'www-data',
         mode   => '0755',
+        require => File['/srv/mediawiki'],
     }
 
-    file { '/usr/share/nginx/favicons/default.ico':
+    file { '/srv/mediawiki/favicons/default.ico':
         ensure => present,
         source => 'puppet:///modules/mediawiki/favicons/default.ico',
+        require => File['/srv/mediawiki/favicons'],
     }
 
-    file { '/usr/share/nginx/favicons/apple-touch-icon-default.png':
+    file { '/srv/mediawiki/favicons/apple-touch-icon-default.png':
         ensure => present,
         source => 'puppet:///modules/mediawiki/favicons/apple-touch-icon-default.png',
+        require => File['/srv/mediawiki/favicons'],
     }
 }

--- a/modules/mediawiki/manifests/init.pp
+++ b/modules/mediawiki/manifests/init.pp
@@ -82,6 +82,18 @@ class mediawiki(
         require => File['/srv/mediawiki'],
     }
 
+    file { '/srv/mediawiki/favicon.php':
+        ensure  => 'present',
+        source  => 'puppet:///modules/mediawiki/favicon.php',
+        require => File['/srv/mediawiki'],
+    }
+
+    file { '/srv/mediawiki/touch.php':
+        ensure  => 'present',
+        source  => 'puppet:///modules/mediawiki/touch.php',
+        require => File['/srv/mediawiki'],
+    }
+
     file { '/srv/mediawiki/healthcheck.php':
         ensure  => 'present',
         source  => 'puppet:///modules/mediawiki/healthcheck.php',

--- a/modules/mediawiki/templates/mediawiki-includes.conf.erb
+++ b/modules/mediawiki/templates/mediawiki-includes.conf.erb
@@ -42,11 +42,11 @@ location = / {
 }
 
 location = /favicon.ico {
-	try_files /../../usr/share/nginx/favicons/$host.ico /../../usr/share/nginx/favicons/default.ico;
+	rewrite ^(.*)$ /favicon.php;
 }
 
 location = /apple-touch-icon.png {
-	try_files /../../usr/share/nginx/favicons/apple-touch-icon-$host.png /../../usr/share/nginx/favicons/apple-touch-icon-default.png;
+	rewrite ^(.*)$ /touch.php;
 }
 
 location = /wiki {

--- a/modules/mediawiki/templates/mediawiki.conf.erb
+++ b/modules/mediawiki/templates/mediawiki.conf.erb
@@ -173,11 +173,11 @@ server {
  	}
 
 	location = /favicon.ico {
-		try_files /../../usr/share/nginx/favicons/$host.ico /../../usr/share/nginx/favicons/default.ico;
+		try_files /../../srv/mediawiki/favicons/$host.ico /../../srv/mediawiki/favicons/default.ico;
 	}
 
 	location = /apple-touch-icon.png {
-		try_files /../../usr/share/nginx/favicons/apple-touch-icon-$host.png /../../usr/share/nginx/favicons/apple-touch-icon-default.png;
+		try_files /../../srv/mediawiki/favicons/apple-touch-icon-$host.png /../../srv/mediawiki/favicons/apple-touch-icon-default.png;
 	}
 
 	location /private/ {

--- a/modules/mediawiki/templates/mediawiki.conf.erb
+++ b/modules/mediawiki/templates/mediawiki.conf.erb
@@ -129,6 +129,10 @@ server {
 	location /.well-known/change-password {
 		return 301 /wiki/Special:ChangePassword;
 	}
+
+	location ~ ^/static/((?!(private))(.+))$ {
+		alias /mnt/mediawiki-static/$1;
+	}
 }
 
 server {

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -177,7 +177,7 @@ sub mw_request {
 
 	# Rewrite hostname to static.miraheze.org for caching
 	if (req.url ~ "^/static/") {
-		set req.http.host = "static.miraheze.org";
+		set req.http.Host = "static.miraheze.org";
 	}
 
 	# Numerous static.miraheze.org specific code
@@ -245,7 +245,7 @@ sub vcl_recv {
 	unset req.http.Proxy; # https://httpoxy.org/
 
 	# Health checks, do not send request any further, if we're up, we can handle it
-	if (req.http.host == "health.miraheze.org" && req.url == "/check") {
+	if (req.http.Host == "health.miraheze.org" && req.url == "/check") {
 		if (std.healthy(mediawiki.backend())) {
 			return (synth(200));
 		} else {

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -175,6 +175,11 @@ sub mw_request {
 		set req.backend_hint = mediawiki.backend();
 	}
 
+	# Rewrite hostname to static.miraheze.org for caching
+	if (req.url ~ "^/static/") {
+		set req.http.host = "static.miraheze.org";
+	}
+
 	# Numerous static.miraheze.org specific code
 	if (req.http.Host == "static.miraheze.org") {
 		# We can do this because static.mh.o should not be capable of serving such requests anyway


### PR DESCRIPTION
* Allows static files to be accessed directly from the wiki subdomain or custom domain using /static.
  * Should exclude private access, but this should be verified.
* Allows access to favicon/apple touch icon directly from /favicon.ico or /apple-touch-icon.png.
* Rewrites sitemap.php to use MediaWiki's HttpRequestFactory in order to retrieve the sitemap directly from static, rather than redirecting to it. This is designed to fix support for the sitemap index usage within Google, etc...
  * Also provides better code standards rather than again decoding the database file, it uses WebStart, and then `$wgDBname` directly.
* Simplifies robots.php to use `$wgDBname` directly, rather than decoding the database file again. This should be accessible since we use WebStart.
* The use of WebStart for robots.php and sitemap.php should also add support for the beta realm, which uses a different suffix.

Meant to fix issues like https://phabricator.miraheze.org/T8744

I have no idea if this will work, or if my regex for static access is correct at all. This should be verified.