### PR TITLE
db: don't allow access to testglobal from non test servers

### DIFF
--- a/modules/mariadb/templates/grants/mediawiki-grants.sql.erb
+++ b/modules/mariadb/templates/grants/mediawiki-grants.sql.erb
@@ -45,6 +45,12 @@ GRANT USAGE
     IDENTIFIED BY '<%= @wikiadmin_password %>'
     REQUIRE SSL;
 
+-- test101 - only allow test to reach beta
+GRANT USAGE
+    ON *.* TO 'wikiadmin'@'2a10:6740::6:109'
+    IDENTIFIED BY '<%= @mediawiki_password %>'
+    REQUIRE SSL;
+
 GRANT SELECT, INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, INDEX, CREATE VIEW, LOCK TABLES
     ON `%wiki%`.* TO 'wikiadmin'@'%';
 

--- a/modules/mariadb/templates/grants/mediawiki-grants.sql.erb
+++ b/modules/mariadb/templates/grants/mediawiki-grants.sql.erb
@@ -18,7 +18,7 @@ GRANT SELECT, INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, INDEX, CREATE VIEW, L
     ON `mhglobal`.* TO 'mediawiki'@'%';
 
 GRANT SELECT, INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, INDEX, CREATE VIEW, LOCK TABLES
-    ON `testglobal`.* TO 'mediawiki'@'%';
+    ON `testglobal`.* TO 'mediawiki'@'2a10:6740::6:109';
 
 GRANT SELECT, INSERT, UPDATE, DELETE, DROP, ALTER
     ON `incidents`.* TO 'mediawiki'@'%';
@@ -52,7 +52,7 @@ GRANT SELECT, INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, INDEX, CREATE VIEW, L
     ON `mhglobal`.* TO 'wikiadmin'@'%';
 
 GRANT SELECT, INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, INDEX, CREATE VIEW, LOCK TABLES
-    ON `testglobal`.* TO 'wikiadmin'@'%';
+    ON `testglobal`.* TO 'wikiadmin'@'2a10:6740::6:109';
 
 GRANT SELECT, INSERT, UPDATE, DELETE, DROP, ALTER
     ON `incidents`.* TO 'wikiadmin'@'%';

--- a/modules/mariadb/templates/grants/mediawiki-grants.sql.erb
+++ b/modules/mariadb/templates/grants/mediawiki-grants.sql.erb
@@ -5,6 +5,12 @@ GRANT USAGE
     IDENTIFIED BY '<%= @mediawiki_password %>'
     REQUIRE SSL;
 
+-- test101 - only allow test to reach beta
+GRANT USAGE
+    ON *.* TO 'mediawiki'@'2a10:6740::6:109'
+    IDENTIFIED BY '<%= @mediawiki_password %>'
+    REQUIRE SSL;
+
 GRANT SELECT, INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, INDEX, CREATE VIEW, LOCK TABLES
     ON `%wiki%`.* TO 'mediawiki'@'%';
 


### PR DESCRIPTION
This should make it impossible to generate cache for beta on production as there will not be the cw_wikis table.

I can only find that some LoginNotifyJobs were trigged for beta. I'm not quite sure how yet.