### PR TITLE
prometheus::class: support define

### DIFF
--- a/modules/prometheus/manifests/class.pp
+++ b/modules/prometheus/manifests/class.pp
@@ -3,7 +3,7 @@ define prometheus::class (
     String $module,
     Integer $port,
 ) {
-    $servers = query_nodes("Class[${module}]")
+    $servers = query_nodes("Class[${module}] or Define[${module}]")
 
     file { $dest:
         ensure => present,


### PR DESCRIPTION
At some stage I think or rather guess maybe we should move to https://github.com/wikimedia/puppet/blob/production/modules/prometheus/manifests/class_config.pp

I'm not 100% sure on it hence why it's not being done now, but based on reading I guess it allows you to use anything define/class?