### PR TITLE
mediawiki: move monitoring host to to hiera

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -17,6 +17,7 @@ mediawiki::is_canary: false
 mediawiki::default_sync: 'all'
 mediawiki::use_shellbox: false
 mediawiki::jobqueue::wiki: 'loginwiki'
+mediawiki::monitoring::host: 'login.miraheze.org'
 memcached_servers_1:
   - 2a10:6740::6:105:11211:1
 memcached_servers_2:

--- a/hieradata/hosts/test101.yaml
+++ b/hieradata/hosts/test101.yaml
@@ -14,6 +14,7 @@ puppetserver_hostname: 'puppet111.miraheze.org'
 mediawiki::php::fpm::childs: 12
 mediawiki::php::fpm::fpm_max_memory: 256
 mediawiki::use_staging: true
+mediawiki::monitoring::host: 'beta.betaheze.org'
 
 http_proxy: 'http://bast.miraheze.org:8080'
 gluster_volume: gluster101.miraheze.org:/static

--- a/modules/mediawiki/manifests/monitoring.pp
+++ b/modules/mediawiki/manifests/monitoring.pp
@@ -3,7 +3,7 @@ class mediawiki::monitoring {
     monitoring::services { 'MediaWiki Rendering':
         check_command => 'check_mediawiki',
         vars          => {
-            host    => 'login.miraheze.org',
+            host    => lookup('mediawiki::monitoring::host'),
             address => $facts['ipaddress'],
         },
     }


### PR DESCRIPTION
this is needed because currently the check fails for test101 because in all cases we are trying to check loginwiki, and test101 only serves the beta cluster, and thus cannot serve loginwiki causing the check to fail with 404. This makes it configurable per server. We default to loginwiki, and explicitly set betawiki for test101.