### PR TITLE
jobrunner-high: allow running refreshLinks with higher memory

### DIFF
--- a/modules/mediawiki/templates/jobrunner-hi.json.erb
+++ b/modules/mediawiki/templates/jobrunner-hi.json.erb
@@ -11,7 +11,8 @@
                 "RequestWikiAIJob",
                 "webVideoTranscode",
                 "webVideoTranscodePrioritized",
-                "RecordLintJob"
+                "RecordLintJob",
+                "refreshLinks"
             ]
         }
     },
@@ -38,7 +39,8 @@
             "*": "192M",
             "DataDumpGenerateJob": "300M",
             "RequestWikiAIJob": "1750M",
-            "webVideoTranscode": "300M"
+            "webVideoTranscode": "300M",
+            "refreshLinks": "500M"
         }
     },
 


### PR DESCRIPTION
Some jobs are struggling to finish on the standard mw* servers and being killed due to high memory