### PR TITLE
jobrunner: allow mw* to manage RecordLint

### DIFF
--- a/modules/mediawiki/templates/jobrunner.json.erb
+++ b/modules/mediawiki/templates/jobrunner.json.erb
@@ -14,8 +14,7 @@
                 "DataDumpGenerateJob",
                 "RequestWikiAIJob",
                 "webVideoTranscode",
-                "webVideoTranscodePrioritized",
-                "RecordLintJob"
+                "webVideoTranscodePrioritized"
             ]
         }
     },


### PR DESCRIPTION
It only was noticed on test101 and it's growing a huge backlog due to refreshLinks being on mwtask.

We should see if we can cope to avoid disaster.