### PR TITLE
varnish: Set large_objects_cutoff and nuke_limit

### DIFF
--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -403,6 +403,12 @@ sub vcl_backend_response {
 		}
 	}
 
+	// hit-for-pass objects >= 67108864 size. Do cache if Content-Length is missing.
+	if (std.integer(beresp.http.Content-Length, 0) >= 67108864) {
+		// HFP
+		return(pass(beresp.ttl));
+	}
+
 	return (deliver);
 }
 

--- a/modules/varnish/templates/initscripts/varnish.systemd.erb
+++ b/modules/varnish/templates/initscripts/varnish.systemd.erb
@@ -32,6 +32,7 @@ ExecStart=/usr/sbin/varnishd \
 -s file,<%= @cache_file_name %>,<%= @cache_file_size %> \
 -p vcc_err_unref=off \
 -p http_max_hdr=128
+-p nuke_limit=1000
 ExecReload=/usr/share/varnish/varnishreload
 ExecStopPost=/usr/bin/rm -rf /var/lib/varnish/*
 


### PR DESCRIPTION
Limited testing showed that this at least fixed T8908.

Upstream had a similar issue [0] and was fixed with [1].

[0] https://phabricator.wikimedia.org/T266373
[1] https://gerrit.wikimedia.org/r/c/operations/puppet/+/641724/

Bug: T8908