### PR TITLE
varnish: match listen_depth and net.core.somaxconn

### DIFF
--- a/modules/varnish/templates/initscripts/varnish.systemd.erb
+++ b/modules/varnish/templates/initscripts/varnish.systemd.erb
@@ -31,7 +31,7 @@ ExecStart=/usr/sbin/varnishd \
 -S /etc/varnish/secret \
 -s file,<%= @cache_file_name %>,<%= @cache_file_size %> \
 -p http_req_size=24576 \
--p vcc_err_unref=off \
+-p listen_depth=4096 -p vcc_err_unref=off \
 -p http_max_hdr=128
 -p nuke_limit=1000
 ExecReload=/usr/share/varnish/varnishreload


### PR DESCRIPTION
listen_depth default is 1024 but we have net.core.somaxconn set to 4096. Lets set varnish to 4096 as well.