### PR TITLE
varnish: lower large_objects_cutoff to 8388608 (8mb) for static.miraheze.org

### DIFF
--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -403,8 +403,8 @@ sub vcl_backend_response {
 		}
 	}
 
-	// hit-for-pass objects >= 67108864 size. Do cache if Content-Length is missing.
-	if (std.integer(beresp.http.Content-Length, 0) >= 67108864) {
+	// hit-for-pass objects >= 8388608 size. Do cache if Content-Length is missing.
+	if (std.integer(beresp.http.Content-Length, 0) >= 8388608) {
 		// HFP
 		return(pass(beresp.ttl));
 	}

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -403,8 +403,12 @@ sub vcl_backend_response {
 		}
 	}
 
-	// hit-for-pass objects >= 8388608 size. Do cache if Content-Length is missing.
-	if (std.integer(beresp.http.Content-Length, 0) >= 8388608) {
+	// hit-for-pass objects >= 8388608 size and if domain == static.miraheze.org or
+	// hit-for-pass objects >= 67108864 size and if domain != static.miraheze.org.
+	// Do cache if Content-Length is missing.
+	if (std.integer(beresp.http.Content-Length, 0) >= 8388608 && bereq.http.Host == "static.miraheze.org" ||
+		std.integer(beresp.http.Content-Length, 0) >= 67108864 && bereq.http.Host != "static.miraheze.org"
+	) {
 		// HFP
 		return(pass(beresp.ttl));
 	}


### PR DESCRIPTION
Whilst increasing nuke_limit helped a bit, we still had the problem sometimes.

Setting the large_objects_cutoff to 8mb means objects over this won't get cached (and thus won't hit this problem), this is only for static.miraheze.org.

We could set nuke_limit to a big number but based on our little storage space we're giving to varnish + we have over 5k wikis, I think it's better to just lower the large object cut off.

I was reading https://phabricator.wikimedia.org/T266373#6630349 which also went over increasing nuke_limit to something like 9999999 but went onto explain it could cause other issues.

I also think it makes sense not to cache large objects so we save space to cache more objects.

Bug: T8908