### PR TITLE
varnish: increase default_ttl to an hour from 2 minutes

### DIFF
--- a/modules/varnish/templates/initscripts/varnish.systemd.erb
+++ b/modules/varnish/templates/initscripts/varnish.systemd.erb
@@ -35,6 +35,7 @@ ExecStart=/usr/sbin/varnishd \
 -p http_req_size=24576 \
 -p listen_depth=4096 -p vcc_err_unref=off \
 -p http_max_hdr=128
+-p default_ttl=3600
 -p nuke_limit=1000
 ExecReload=/usr/share/varnish/varnishreload
 ExecStopPost=/usr/bin/rm -rf /var/lib/varnish/*


### PR DESCRIPTION
From the documentation:
- The TTL assigned to objects if neither the backend nor the VCL code assigns one.

The WMF set this at 24h but I don't think we should do 24h yet so instead the best value is 1 hour.