### PR TITLE
varnish: set proxy_buffering to off in nginx config

### DIFF
--- a/modules/varnish/templates/mediawiki.conf
+++ b/modules/varnish/templates/mediawiki.conf
@@ -10,6 +10,7 @@ server {
 		proxy_set_header X-Real-IP $remote_addr;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 		proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_buffering    off;
 		proxy_read_timeout 60s;
 		proxy_send_timeout 60s;
 		send_timeout       60s;
@@ -60,6 +61,7 @@ server {
 		# Remove duplicate headers that is already added on the frontend
 		proxy_hide_header     X-XSS-Protection;
 		proxy_hide_header     X-Frame-Options;
+		proxy_buffering    off;
 	}
 }
 
@@ -120,6 +122,7 @@ server {
 		# Remove duplicate headers that is already added on the frontend
 		proxy_hide_header     X-XSS-Protection;
 		proxy_hide_header     X-Frame-Options;
+		proxy_buffering    off;
 	}
 }
 
@@ -206,6 +209,7 @@ server {
 		# Remove duplicate headers that is already added on the frontend
 		proxy_hide_header     X-XSS-Protection;
 		proxy_hide_header     X-Frame-Options;
+		proxy_buffering    off;
 	}
 }
 


### PR DESCRIPTION
Lets have nginx synchronously deliver the response instantly.

See https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering