### PR TITLE
varnish: do gziping in varnish rather than varnish

### DIFF
--- a/modules/nginx/templates/nginx.conf.erb
+++ b/modules/nginx/templates/nginx.conf.erb
@@ -43,7 +43,7 @@ http {
 	ssl_session_timeout 60m;
 
 	# GZIP Settings
-	gzip on;
+	gzip off;
 	gzip_disable "msie6";
 	gzip_comp_level 6;
 	gzip_min_length 500;

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -355,7 +355,6 @@ sub vcl_backend_response {
 		unset bereq.http.Cookie;
 	}
 
-
 	# Distribute caching re-calls where possible
 	if (beresp.ttl >= 60s) {
 		set beresp.ttl = beresp.ttl * std.random( 0.95, 1.00 );

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -436,14 +436,11 @@ sub vcl_backend_response {
 	}
 
 	// set a 601s hit-for-pass object based on response conditions in vcl_backend_response:
-	//    Calculated TTL <= 0 + Status < 500 + No underlying cache hit:
+	//    Calculated TTL <= 0 + Status < 500:
 	//    These are generally uncacheable responses.  The 5xx exception
 	//    avoids us accidentally replacing a good stale/grace object with
 	//    an hfp (and then repeatedly passing on potentially-cacheable
-	//    content) due to an isolated 5xx response, and the exception for
-	//    underlying cache hits (detected from X-Cache-Int) is to avoid
-	//    creating a persist HFP object when a lower-level varnish
-	//    returned an expired object under grace-mode rules.
+	//    content) due to an isolated 5xx response.
 	if (beresp.ttl <= 0s && beresp.status < 500) {
 		set beresp.grace = 31s;
 		set beresp.keep = 0s;

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -355,12 +355,7 @@ sub vcl_backend_response {
 		unset bereq.http.Cookie;
 	}
 
-	# A hit-for-pass action
-	if (beresp.ttl <= 0s) {
-		set beresp.ttl = 1800s;
-		set beresp.uncacheable = true;
-	}
-	
+
 	# Distribute caching re-calls where possible
 	if (beresp.ttl >= 60s) {
 		set beresp.ttl = beresp.ttl * std.random( 0.95, 1.00 );
@@ -407,6 +402,52 @@ sub vcl_backend_response {
 		} else {
 			set beresp.ttl = 43200s;
 		}
+	}
+
+	// Compress compressible things if the backend didn't already, but
+	// avoid explicitly-defined CL < 860 bytes.  We've seen varnish do
+	// gzipping on CL:0 302 responses, resulting in output that has CE:gzip
+	// and CL:20 and sends a pointless gzip header.
+	// Very small content may actually inflate from gzipping, and
+	// sub-one-packet content isn't saving a lot of latency for the gzip
+	// costs (to the server and the client, who must also decompress it).
+	// The magic 860 number comes from Akamai, Google recommends anywhere
+	// from 150-1000.  See also:
+	// https://webmasters.stackexchange.com/questions/31750/what-is-recommended-minimum-object-size-for-gzip-performance-benefits
+	if (beresp.http.content-type ~ "json|text|html|script|xml|icon|ms-fontobject|ms-opentype|x-font|sla"
+		&& (!beresp.http.Content-Length || std.integer(beresp.http.Content-Length, 0) >= 860)) {
+			set beresp.do_gzip = true;
+	}
+	// SVGs served by MediaWiki are part of the interface. That makes them
+	// very hot objects, as a result the compression time overhead is a
+	// non-issue. Several of them tend to be requested at the same time,
+	// as the browser finds out about them when parsing stylesheets that
+	// contain multiple. This means that the "less than 1 packet" rationale
+	// for not compressing very small objects doesn't apply either. Lastly,
+	// since they're XML, they contain a fair amount of repetitive content
+	// even when small, which means that gzipped SVGs tend to be
+	// consistantly smaller than their uncompressed version, even when tiny.
+	// For all these reasons, it makes sense to have a lower threshold for
+	// SVG. Applying it to XML in general is a more unknown tradeoff, as it
+	// would affect small API responses that are more likely to be cold
+	// objects due to low traffic to specific API URLs.
+	if (beresp.http.content-type ~ "svg" && (!beresp.http.Content-Length || std.integer(beresp.http.Content-Length, 0) >= 150)) {
+		set beresp.do_gzip = true;
+	}
+
+	// set a 601s hit-for-pass object based on response conditions in vcl_backend_response:
+	//    Calculated TTL <= 0 + Status < 500 + No underlying cache hit:
+	//    These are generally uncacheable responses.  The 5xx exception
+	//    avoids us accidentally replacing a good stale/grace object with
+	//    an hfp (and then repeatedly passing on potentially-cacheable
+	//    content) due to an isolated 5xx response, and the exception for
+	//    underlying cache hits (detected from X-Cache-Int) is to avoid
+	//    creating a persist HFP object when a lower-level varnish
+	//    returned an expired object under grace-mode rules.
+	if (beresp.ttl <= 0s && beresp.status < 500) {
+		set beresp.grace = 31s;
+		set beresp.keep = 0s;
+		return(pass(601s));
 	}
 
 	// hit-for-pass objects >= 8388608 size and if domain == static.miraheze.org or


### PR DESCRIPTION
It's recommended here [0] to do it in varnish rather than the web server as it'll use less cpu resources.

[0] https://varnish-cache.org/docs/trunk/users-guide/compression.html#compressing-content-if-backends-don-t