### PR TITLE
Raise `request_terminate_timeout` to 60 instead of 59

### DIFF
--- a/modules/php/manifests/php_fpm.pp
+++ b/modules/php/manifests/php_fpm.pp
@@ -182,7 +182,7 @@ class php::php_fpm(
         $base_fpm_pool_config = {
             'pm'                        => 'static',
             'pm.max_children'           => $num_workers,
-            'request_terminate_timeout' => 59,
+            'request_terminate_timeout' => 60,
         }
 
         php::fpm::pool { 'www':


### PR DESCRIPTION
To match `max_execution_time`