### PR TITLE
switch SSL certificate generation to puppet111/automate private keys [DO NOT MERGE!]

### DIFF
--- a/hieradata/hosts/mwtask111.yaml
+++ b/hieradata/hosts/mwtask111.yaml
@@ -1,7 +1,6 @@
 users::groups:
   - mediawiki-admins
   - mediawiki-roots
-letsencrypt: true
 jobrunner: true
 jobrunner::intensive: true
 contactgroups: ['sre', 'mediawiki']

--- a/hieradata/hosts/puppet111.yaml
+++ b/hieradata/hosts/puppet111.yaml
@@ -1,6 +1,7 @@
 users::groups:
   - puppet-users
 puppetserver: true
+letsencrypt: true
 puppetserver_java_opts: '-Xms2000M -Xmx2000M'
 puppetdb_enable: true
 puppetdb_hostname: puppet111.miraheze.org

--- a/modules/letsencrypt/files/ssl-certificate.py
+++ b/modules/letsencrypt/files/ssl-certificate.py
@@ -124,7 +124,12 @@ class SslCertificate:
         os.system("/bin/cat /etc/letsencrypt/live/{0}/fullchain.pem".format(self.domain))
 
         if self.private:
-            os.system("/bin/cat /etc/letsencrypt/live/{0}/privkey.pem".format(self.domain))
+#            os.system("/bin/cat /etc/letsencrypt/live/{0}/privkey.pem".format(self.domain))
+             print("Private key is being copied to /etc/puppetlabs/puppet/ssl-keys")
+             os.system("cp /etc/letsencrypt/live/{0}/privkey.pem /etc/puppetlabs/puppet/ssl-keys")
+             os.system("mv /etc/puppetlabs/puppet/ssl-keys/privkey.pem /etc/puppetlabs/puppet/ssl-keys/{0}.key")
+             os.system("cd /etc/puppetlabs/puppet/ssl-keys && git add . && git commit -m "add {0} key" && git push")
+             
 
     def renew_letsencrypt_certificate(self):
         if self.wildcard:

--- a/modules/letsencrypt/files/ssl-certificate.py
+++ b/modules/letsencrypt/files/ssl-certificate.py
@@ -166,7 +166,11 @@ class SslCertificate:
         os.system("/bin/cat /etc/letsencrypt/live/{0}/fullchain.pem".format(self.domain))
 
         if self.private:
-            os.system("/bin/cat /etc/letsencrypt/live/{0}/privkey.pem".format(self.domain))
+#            os.system("/bin/cat /etc/letsencrypt/live/{0}/privkey.pem".format(self.domain))
+            print("Private key is being copied to /etc/puppetlabs/puppet/ssl-keys")
+            os.system("cp /etc/letsencrypt/live/{0}/privkey.pem /etc/puppetlabs/puppet/ssl-keys")
+            os.system("mv /etc/puppetlabs/puppet/ssl-keys/privkey.pem /etc/puppetlabs/puppet/ssl-keys/{0}.key")
+            os.system("cd /etc/puppetlabs/puppet/ssl-keys && git add . && git commit -m "add {0} key" && git push")
 
     def revoke_letsencrypt_certificate(self):
         if not self.quiet:

--- a/modules/monitoring/files/scripts/ssl-renew.sh
+++ b/modules/monitoring/files/scripts/ssl-renew.sh
@@ -21,4 +21,4 @@ curl -X POST -H 'Content-type: application/json' --data "{
   \"SERVICESTATE\": \"${SERVICESTATE}\",
   \"SERVICESTATETYPE\": \"${SERVICESTATETYPE}\",
   \"SERVICEDESC\": \"${SERVICEDESC}\"
-}" http://[2a10:6740::6:208]:5000/renew >> /var/log/icinga2/ssl-let.log 2>&1
+}" http://[2a10:6740::6:210]:5000/renew >> /var/log/icinga2/ssl-let.log 2>&1

--- a/modules/users/data/data.yaml
+++ b/modules/users/data/data.yaml
@@ -14,7 +14,6 @@ groups:
                  'ALL = (ALL) NOPASSWD: /usr/sbin/service jobrunner *',
                  'ALL = (ALL) NOPASSWD: /usr/sbin/service jobchron *',
                  'ALL = (ALL) NOPASSWD: /usr/bin/puppet *',
-                 'ALL = (ALL) NOPASSWD: /root/ssl-certificate',
                  'ALL = (ALL) NOPASSWD: /bin/journalctl *']
   mediawiki-roots:
     gid: 2002
@@ -34,7 +33,7 @@ groups:
     gid: 2004
     description: limited access on puppet111 to add SSL private keys
     members: [macfan]
-    privileges: []
+    privileges: ['ALL = (ALL) NOPASSWD: /root/ssl-certificate']
   bastion:
     gid: 2005
     description: users who require bastion access


### PR DESCRIPTION
As explained in T7582, since mw-admins are not actively generating certs and to make things easier for myself and MacFan4000 (as well as the later automation) it makes much more sense to move the entire generation process to puppet111 and automate the SSL key part rather than keep it on mwtask111.