### PR TITLE
varnish: support redirecting paths in SSL redirects.yaml

### DIFF
--- a/modules/varnish/templates/mediawiki.conf
+++ b/modules/varnish/templates/mediawiki.conf
@@ -133,11 +133,13 @@ server {
 server {
 	listen 443 ssl http2;
 	listen [::]:443 ssl http2;
-<%- if property['additional_domain'] -%>
+
+	<%- if property['additional_domain'] -%>
 	server_name <%= property['url'] %> <%= property['additional_domain'] %>;
-<%- else -%>
+	<%- else -%>
 	server_name <%= property['url'] %>;
-<%- end -%>
+	<%- end -%>
+
 	root /var/www/html;
 	
 	# no way you are legit - rhinosf1 T8832
@@ -154,7 +156,18 @@ server {
 	add_header Strict-Transport-Security "max-age=604800";
 	<%- end -%>
 
+	<%- if property['redirect_paths'] -%>
+	<%- property['redirect_paths'].each_pair do | path, target | -%>
+	location <%= path %> {
+		return 301 https://<%= target %>$request_uri;
+	}
+	<%- end -%>
+	location / {
+		return 301 https://<%= property['redirect'] %>$request_uri;
+	}
+	<%- else -%>
 	return 301 https://<%= property['redirect'] %>$request_uri;
+	<%- end -%>
 }
 
 <%- end -%>

--- a/modules/varnish/templates/mediawiki.conf
+++ b/modules/varnish/templates/mediawiki.conf
@@ -156,16 +156,25 @@ server {
 	add_header Strict-Transport-Security "max-age=604800";
 	<%- end -%>
 
-	<%- if property['redirect_paths'] -%>
-	<%- property['redirect_paths'].each_pair do | path, target | -%>
+	<%- if property['path_redirects'] -%>
+	<%- property['path_redirects'].each_pair do | path, redirect | -%>
 	location <%= path %> {
-		return 301 https://<%= target %>$request_uri;
+		return 301 https://<%= redirect %>$request_uri;
 	}
 	<%- end -%>
+	# If we are using path_redirects, make the main
+	# redirect property optional.
+	<%- if property['redirect'] -%>
+	# Only redirect if there are no other matches found.
+	# This prevents this from conflicting with
+	# redirects specified in path_redirects.
 	location / {
 		return 301 https://<%= property['redirect'] %>$request_uri;
 	}
+	<%- end -%>
 	<%- else -%>
+	# If we aren't using path_redirects, always
+	# redirect using the main redirect property.
 	return 301 https://<%= property['redirect'] %>$request_uri;
 	<%- end -%>
 }


### PR DESCRIPTION
This is per discussion in the Miraheze meeting yesterday for [T9213](https://phabricator.miraheze.org/T9213), so that we can create a short URL from miraheze.wiki/br to redirect to the Phabricator bug report form, so we can link the short URL in the exception message.

There are other uses for this as well though.