### PR TITLE
jobrunner: set maxjobs to 1

### DIFF
--- a/modules/mediawiki/templates/jobrunner.json.erb
+++ b/modules/mediawiki/templates/jobrunner.json.erb
@@ -53,5 +53,5 @@
     },
 
     // Command used to launch a runner for a given job queue
-    "dispatcher": "nice -15 php /srv/mediawiki/w/maintenance/runJobs.php --wiki=%(db)x --type=%(type)x --maxtime=%(maxtime)x --memory-limit=%(maxmem)x --result=json"
+    "dispatcher": "nice -15 php /srv/mediawiki/w/maintenance/runJobs.php --wiki=%(db)x --type=%(type)x --maxtime=%(maxtime)x --maxjobs=1 --memory-limit=%(maxmem)x --result=json"
 }


### PR DESCRIPTION
stops a single type using up all resources, done upstream and advised by Krinkle yesterday