### PR TITLE
jobrunner: don't set server twice in redis.queues

### DIFF
--- a/modules/mediawiki/templates/jobrunner.json.erb
+++ b/modules/mediawiki/templates/jobrunner.json.erb
@@ -46,7 +46,6 @@
         ],
         // Main queue servers
         "queues": [
-            "<%= @redis_server_ip %>",
             "<%= @redis_server_ip %>"
         ],
         "password": "<%= @redis_password %>"


### PR DESCRIPTION
It would just be running the same thing twice: https://github.com/miraheze/jobrunner-service/blob/58a49a34c11f2fdddb701f1d296928779c1c0e7a/redisJobChronService#L92 I don't think we want to do that.