### PR TITLE
Remove `puppetmaster` from hieradata

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -2,7 +2,6 @@ jobchron: false
 jobrunner: false
 jobrunner::intensive: false
 mailserver: false
-puppetmaster: false
 puppetserver: false
 mediawiki::branch: 'REL1_37'
 mediawiki::branch_mw_config: 'master'

--- a/modules/base/manifests/monitoring.pp
+++ b/modules/base/manifests/monitoring.pp
@@ -14,7 +14,6 @@ class base::monitoring {
         notify  => Service['nagios-nrpe-server'],
     }
 
-    $puppetmaster_version = lookup('puppetmaster_version', {'default_value' => 6})
     file { '/usr/lib/nagios/plugins/check_puppet_run':
         ensure  => present,
         content => template('base/icinga/check_puppet_run.erb'),


### PR DESCRIPTION
Seems to be unused and the puppetmaster module was removed with e694825.