### PR TITLE
Remove LetsEncrypt from mwtask111

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -77,7 +77,6 @@ node /^mw1[012][12]\.miraheze\.org$/ {
 node 'mwtask111.miraheze.org' {
     include base
     include role::mediawiki
-    include role::letsencrypt
 }
 
 node /^ns[12]\.miraheze\.org$/ {
@@ -102,7 +101,6 @@ node 'puppet111.miraheze.org' {
     include role::puppetserver
     include role::salt
     include role::letsencrypt
-    include letsencrypt::nginx
 }
 
 node 'test101.miraheze.org' {

--- a/modules/letsencrypt/manifests/web.pp
+++ b/modules/letsencrypt/manifests/web.pp
@@ -1,5 +1,7 @@
 # === Class letsencrypt::web
 class letsencrypt::web {
+    include letsencrypt::nginx
+
     ensure_packages(['python3-flask', 'python3-filelock'])
 
     file { '/usr/local/bin/mirahezerenewssl.py':

--- a/modules/phabricator/files/phab.miraheze.wiki.conf
+++ b/modules/phabricator/files/phab.miraheze.wiki.conf
@@ -4,10 +4,6 @@ server {
 
 	server_name phab.miraheze.wiki;
 
-	location /.well-known/acme-challenge/ {
-		rewrite ^/(.*)$ http://puppet111.miraheze.org/$1 redirect;
-	}
-
 	location /php_status {
 		access_log off;
 		allow 127.0.0.1;

--- a/modules/phabricator/files/phab.miraheze.wiki.conf
+++ b/modules/phabricator/files/phab.miraheze.wiki.conf
@@ -5,7 +5,7 @@ server {
 	server_name phab.miraheze.wiki;
 
 	location /.well-known/acme-challenge/ {
-		rewrite ^/(.*)$ http://mwtask.miraheze.org/$1 redirect;
+		rewrite ^/(.*)$ http://puppet111.miraheze.org/$1 redirect;
 	}
 
 	location /php_status {

--- a/modules/users/data/data.yaml
+++ b/modules/users/data/data.yaml
@@ -14,7 +14,6 @@ groups:
                  'ALL = (ALL) NOPASSWD: /usr/sbin/service jobrunner *',
                  'ALL = (ALL) NOPASSWD: /usr/sbin/service jobchron *',
                  'ALL = (ALL) NOPASSWD: /usr/bin/puppet *',
-                 'ALL = (ALL) NOPASSWD: /root/ssl-certificate',
                  'ALL = (ALL) NOPASSWD: /bin/journalctl *']
   mediawiki-roots:
     gid: 2002
@@ -32,7 +31,7 @@ groups:
                  'ALL = (ALL) NOPASSWD: /bin/journalctl *']
   puppet-users:
     gid: 2004
-    description: limited access on puppet111 to add SSL private keys
+    description: limited access on puppet111 to add SSL certificates
     members: [macfan]
     privileges: ['ALL = (ALL) NOPASSWD: /root/ssl-certificate']
   bastion:

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -160,14 +160,8 @@ sub mw_request {
 	call mobile_detection;
 	
 	# Assigning a backend
-	if (
-		req.url ~ "^/\.well-known" ||
-		req.http.Host == "sslrequest.miraheze.org"
-	) {
-		set req.backend_hint = puppet111;
-		return (pass);
 <%- @backends.each_pair do | name, property | -%>
-	} elseif (req.http.X-Miraheze-Debug == "<%= name %>.miraheze.org") {
+	if (req.http.X-Miraheze-Debug == "<%= name %>.miraheze.org") {
 		set req.backend_hint = <%= name %>;
 		return (pass);
 <%- end -%>
@@ -269,6 +263,14 @@ sub vcl_recv {
 			# We don't understand this
 			unset req.http.Accept-Encoding;
 		}
+	}
+
+	if (
+		req.url ~ "^/\.well-known" ||
+		req.http.Host == "sslrequest.miraheze.org"
+	) {
+		set req.backend_hint = puppet111;
+		return (pass);
 	}
 
         if (req.http.Host ~ "^(.*\.)?betaheze\.org") {


### PR DESCRIPTION
Note: removes this from phab.miraheze.wiki because it is theoretically unnecessary, to be there at all:
```nginx
location /.well-known/acme-challenge/ {
	rewrite ^/(.*)$ http://mwtask.miraheze.org/$1 redirect;
}
```
So I did not move it over, since I don't think it's necessary anymore. I could be wrong though. If so, we could always add it back next time the domain is attempted to be renewed I guess? If wanted I guess I can add it back.
