### PR TITLE
mediawiki: remove acme-challenge

### DIFF
--- a/modules/mediawiki/templates/mediawiki-includes.conf.erb
+++ b/modules/mediawiki/templates/mediawiki-includes.conf.erb
@@ -3,11 +3,6 @@ index index.php index.html;
 fastcgi_read_timeout 140;
 send_timeout 140;
 
-location /.well-known/acme-challenge/ {
-	alias /var/www/challenges/;
-	try_files $uri =404;
-}
-
 location ~ ^/(\.git|config|landing|cache) {
         deny all;
 }

--- a/modules/mediawiki/templates/mediawiki.conf.erb
+++ b/modules/mediawiki/templates/mediawiki.conf.erb
@@ -31,11 +31,6 @@ server {
 
 	add_header X-Frame-Options "ALLOW-FROM static.miraheze.org";
 
-	location /.well-known/acme-challenge/ {
-		alias /var/www/challenges/;
-		try_files $uri =404;
-	}
-
 	location ~ ^/(\.git|config) {
 		deny all;
 	}


### PR DESCRIPTION
Only ensured on LetsEncrypt:
https://github.com/miraheze/puppet/blob/2228d4514b26c9821571d24fd1d547e8e60ed132/modules/letsencrypt/manifests/init.pp#L14-L21