### PR TITLE
Remove acme-challenge from roundcubemail and icingaweb2

### DIFF
--- a/modules/icingaweb2/files/icinga2.conf
+++ b/modules/icingaweb2/files/icinga2.conf
@@ -13,11 +13,6 @@ server {
 		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 	}
 
-	location /.well-known/acme-challenge/ {
-		alias /var/www/challenges/;
-		try_files $uri =404;
-	}
-
 	location / {
 		return 301 https://icinga.miraheze.org/;
 	}

--- a/modules/roundcubemail/files/mail.miraheze.org.conf
+++ b/modules/roundcubemail/files/mail.miraheze.org.conf
@@ -13,11 +13,6 @@ server {
 		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 	}
 
-	location /.well-known/acme-challenge/ {
-		alias /var/www/challenges/;
-		try_files $uri =404;
-	}
-
 	location / {
 		return 301 https://webmail.miraheze.org/;
 	}

--- a/modules/roundcubemail/files/roundcubemail.conf
+++ b/modules/roundcubemail/files/roundcubemail.conf
@@ -13,11 +13,6 @@ server {
 		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 	}
 
-	location /.well-known/acme-challenge/ {
-		alias /var/www/challenges/;
-		try_files $uri =404;
-	}
-
 	location / {
 		return 301 https://webmail.miraheze.org/;
 	}


### PR DESCRIPTION
Only ensured on LetsEncrypt:
https://github.com/miraheze/puppet/blob/2228d4514b26c9821571d24fd1d547e8e60ed132/modules/letsencrypt/manifests/init.pp#L14-L21