### PR TITLE
varnish: always use case-insensitive redirects for `path_redirects`

### DIFF
--- a/modules/varnish/templates/mediawiki.conf
+++ b/modules/varnish/templates/mediawiki.conf
@@ -158,7 +158,7 @@ server {
 
 	<%- if property['path_redirects'] -%>
 	<%- property['path_redirects'].each_pair do | path, redirect | -%>
-	location <%= path %> {
+	location ~* <%= path %> {
 		return 301 https://<%= redirect %>;
 	}
 	<%- end -%>


### PR DESCRIPTION
Should only be merged with miraheze/ssl#541, at the same time.