### PR TITLE
archive puppet-users, create letsencrypt-admins group

### DIFF
--- a/hieradata/hosts/puppet111.yaml
+++ b/hieradata/hosts/puppet111.yaml
@@ -1,5 +1,5 @@
 users::groups:
-  - puppet-users
+  - letsencrypt-admins
 puppetserver: true
 puppetserver_java_opts: '-Xms2000M -Xmx2000M'
 puppetdb_enable: true

--- a/modules/letsencrypt/files/ssl-certificate.py
+++ b/modules/letsencrypt/files/ssl-certificate.py
@@ -127,9 +127,9 @@ class SslCertificate:
         os.system(f'/bin/cat /etc/letsencrypt/live/{self.domain}/fullchain.pem')
 
         if self.private:
-            print('Private key is being copied and pushed to /home/puppet-users/ssl-keys')
-            os.system(f'cp /etc/letsencrypt/live/{self.domain}/privkey.pem /home/puppet-users/ssl-keys/{self.domain}.key')
-            os.system(f"cd /home/puppet-users/ssl-keys/ && git add . && git commit -m 'add {self.domain} key' && git push origin master")
+            print('Private key is being copied and pushed to /home/letsencrypt-admins/ssl-keys')
+            os.system(f'cp /etc/letsencrypt/live/{self.domain}/privkey.pem /home/letsencrypt-admins/ssl-keys/{self.domain}.key')
+            os.system(f"cd /home/letsencrypt-admins/ssl-keys/ && git add . && git commit -m 'add {self.domain} key' && git push origin master")
 
     def renew_letsencrypt_certificate(self):
         if self.wildcard:

--- a/modules/puppetserver/manifests/init.pp
+++ b/modules/puppetserver/manifests/init.pp
@@ -140,10 +140,10 @@ class puppetserver(
         ],
     }
 
-    file { '/home/puppet-users':
+    file { '/home/letsencrypt-admins':
         ensure  => directory,
         owner   => 'root',
-        group   => 'puppet-users',
+        group   => 'letsencrypt-admins',
         mode    => '0770',
     }
  

--- a/modules/users/data/data.yaml
+++ b/modules/users/data/data.yaml
@@ -34,6 +34,7 @@ groups:
     description: (archived group) limited access on puppet111 to manage SSL certificates
     members: []
     privileges: []
+
   bastion:
     gid: 2005
     description: users who require bastion access
@@ -43,7 +44,7 @@ groups:
   letsencrypt-admins:
     gid: 2006
     description: limited sudo access on puppet111 to manage SSL certificates
-    members: []
+    members: [macfan]
     privileges: ['ALL = (ALL) NOPASSWD: /root/ssl-certificate',
                  'ALL = (ALL) NOPASSWD: /var/lib/nagios/ssl-acme']
 

--- a/modules/users/data/data.yaml
+++ b/modules/users/data/data.yaml
@@ -31,7 +31,7 @@ groups:
                  'ALL = (ALL) NOPASSWD: /bin/journalctl *']
   puppet-users:
     gid: 2004
-    description: (archived group) limited access on puppet111 to manage SSL certificates
+    description: limited access on puppet servers
     members: []
     privileges: []
 
@@ -43,7 +43,7 @@ groups:
     
   letsencrypt-admins:
     gid: 2006
-    description: limited sudo access on puppet111 to manage SSL certificates
+    description: limited sudo access to manage SSL certificates
     members: [macfan]
     privileges: ['ALL = (ALL) NOPASSWD: /root/ssl-certificate',
                  'ALL = (ALL) NOPASSWD: /var/lib/nagios/ssl-acme']

--- a/modules/users/data/data.yaml
+++ b/modules/users/data/data.yaml
@@ -31,15 +31,21 @@ groups:
                  'ALL = (ALL) NOPASSWD: /bin/journalctl *']
   puppet-users:
     gid: 2004
-    description: limited access on puppet111 to manage SSL certificates
-    members: [macfan]
-    privileges: ['ALL = (ALL) NOPASSWD: /root/ssl-certificate',
-                 'ALL = (ALL) NOPASSWD: /var/lib/nagios/ssl-acme']
+    description: (archived group) limited access on puppet111 to manage SSL certificates
+    members: []
+    privileges: []
   bastion:
     gid: 2005
     description: users who require bastion access
     members: [macfan, rhinos, universalomega, agent]
     privileges: []
+    
+  letsencrypt-admins:
+    gid: 2006
+    description: limited sudo access on puppet111 to manage SSL certificates
+    members: []
+    privileges: ['ALL = (ALL) NOPASSWD: /root/ssl-certificate',
+                 'ALL = (ALL) NOPASSWD: /var/lib/nagios/ssl-acme']
 
 users:
   johnflewis:


### PR DESCRIPTION
Per T9290#188843, since the group now has sudo access and it doesn't make sense to use the word puppet considering it has nothing to do with puppet, this makes more sense