### PR TITLE
ssl-acme: skip checking the host key

### DIFF
--- a/modules/letsencrypt/files/ssl-acme
+++ b/modules/letsencrypt/files/ssl-acme
@@ -58,7 +58,7 @@ WARNING)
         ;;
         HARD)
                 # Lets Renew here
-                git config --global core.sshCommand "ssh -i /var/lib/nagios/id_rsa -F /dev/null -o ProxyCommand='nc -6 -X connect -x bast.miraheze.org:8080 %h %p'"
+                git config --global core.sshCommand "ssh -i /var/lib/nagios/id_rsa -F /dev/null -o ProxyCommand='nc -o StrictHostKeyChecking=no -6 -X connect -x bast.miraheze.org:8080 %h %p'"
                 if [ ! -d /srv/ssl/ssl/ ]; then
                     cd /srv/ssl/ && git clone git@github.com:miraheze/ssl.git
                 else


### PR DESCRIPTION
if we don't skip it then the auto-renewal script fails