### PR TITLE
check_reverse_dns: format exceptions, suppressing tracebacks

### DIFF
--- a/modules/monitoring/files/check_reverse_dns.py
+++ b/modules/monitoring/files/check_reverse_dns.py
@@ -53,6 +53,9 @@ def get_args():
     return parser.parse_args()
 
 
+sys.excepthook = lambda type, value, traceback: print(f'{type.__name__}: {value}')
+
+
 def check_records(hostname):
     """Check NS and CNAME records for given hostname."""
     extra_known_tlds = ('eu.org','for.uz')

--- a/modules/monitoring/files/check_reverse_dns.py
+++ b/modules/monitoring/files/check_reverse_dns.py
@@ -25,7 +25,6 @@ import re
 import sys
 import tldextract
 
-
 sys.excepthook = lambda type, value, traceback: print(f'{type.__name__}: {value}')
 
 

--- a/modules/monitoring/files/check_reverse_dns.py
+++ b/modules/monitoring/files/check_reverse_dns.py
@@ -26,6 +26,9 @@ import sys
 import tldextract
 
 
+sys.excepthook = lambda type, value, traceback: print(f'{type.__name__}: {value}')
+
+
 def get_args():
     """Return specified arguments.
 
@@ -51,9 +54,6 @@ def get_args():
     )
 
     return parser.parse_args()
-
-
-sys.excepthook = lambda type, value, traceback: print(f'{type.__name__}: {value}')
 
 
 def check_records(hostname):


### PR DESCRIPTION
We could probably use `sys.tracebacklimit`, but doing it this way, formatting it just seemed nicer.