### PR TITLE
Move `mediawiki::jobqueue::chron` include to redis role

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -38,7 +38,6 @@ node 'graylog121.miraheze.org' {
 node 'jobchron121.miraheze.org' {
     include base
     include role::redis
-    include mediawiki::jobqueue::chron
 }
 
 node 'ldap111.miraheze.org' {
@@ -112,7 +111,6 @@ node 'test101.miraheze.org' {
     include base
     include role::mediawiki
     include role::redis
-    include mediawiki::jobqueue::chron
 }
 
 # ensures all servers have basic class if puppet runs

--- a/modules/role/manifests/redis.pp
+++ b/modules/role/manifests/redis.pp
@@ -1,6 +1,7 @@
 # role: redis
 class role::redis {
     include prometheus::exporter::redis
+    include mediawiki::jobqueue::chron
 
     $redis_heap = lookup('redis::heap', {'default_value' => '7000mb'})
     class { '::redis':
@@ -27,6 +28,6 @@ class role::redis {
     }
 
     motd::role { 'role::redis':
-        description => 'Redis caching server',
+        description => 'Redis jobchron server',
     }
 }


### PR DESCRIPTION
Also changes the redis role description since we don't use redis for caching anymore, only for jobchron.