### PR TITLE
matomo: set bulk_requests_use_transaction to 0

### DIFF
--- a/modules/matomo/templates/config.ini.php.erb
+++ b/modules/matomo/templates/config.ini.php.erb
@@ -19,6 +19,10 @@ enable_load_data_infile = 0
 salt = "<%= @salt %>"
 trusted_hosts[] = "matomo.miraheze.org"
 
+[Tracker]
+;https://github.com/piwik/piwik/issues/6398#issuecomment-91093146
+bulk_requests_use_transaction = 0
+
 [mail]
 transport = "smtp"
 port = 25


### PR DESCRIPTION
To see if it helps with "Error in Matomo (tracker): Too many connections"