### PR TITLE
Revert "absent old letsencrypt nginx site"

### DIFF
--- a/modules/ssl/manifests/nginx.pp
+++ b/modules/ssl/manifests/nginx.pp
@@ -2,11 +2,6 @@
 #
 # Nginx config using hiera
 class ssl::nginx {
-    nginx::site { 'letsencrypt':
-        ensure  => absent,
-        monitor => false,
-    }
-
     nginx::site { 'ssl-acme':
         ensure  => present,
         source  => 'puppet:///modules/ssl/nginx.conf',


### PR DESCRIPTION
Reverts miraheze/puppet#2688

Now we can remove this.