### PR TITLE
Manage /home/ssl-admins recursively + ensure existence and permissions for /etc/puppetlabs/puppet/ssl-keys

### DIFF
--- a/modules/ssl/manifests/init.pp
+++ b/modules/ssl/manifests/init.pp
@@ -33,6 +33,14 @@ class ssl {
         mode    => '0770',
         recurse => true,
     }
+    
+    file { '/etc/puppetlabs/puppet/ssl-keys':
+        ensure  => directory,
+        owner   => 'root',
+        group   => 'ssl-admins',
+        mode    => '0770',
+        recurse => true,
+    }
 
     file { '/root/ssl':
         ensure => directory,

--- a/modules/ssl/manifests/init.pp
+++ b/modules/ssl/manifests/init.pp
@@ -31,6 +31,7 @@ class ssl {
         owner   => 'root',
         group   => 'ssl-admins',
         mode    => '0770',
+        recurse => true,
     }
 
     file { '/root/ssl':


### PR DESCRIPTION
This will ensure that everything in /home/ssl-admins has the correct permissions (writable by ssl-admins) and that /etc/puppetlabs/puppet/ssl-keys exists and has the correct permissions (writable by ssl-admins).