### PR TITLE
Revert "Manage /home/ssl-admins recursively + ensure existence and permissions for /etc/puppetlabs/puppet/ssl-keys"

### DIFF
--- a/modules/ssl/manifests/init.pp
+++ b/modules/ssl/manifests/init.pp
@@ -31,15 +31,6 @@ class ssl {
         owner   => 'root',
         group   => 'ssl-admins',
         mode    => '0770',
-        recurse => true,
-    }
-    
-    file { '/etc/puppetlabs/puppet/ssl-keys':
-        ensure  => directory,
-        owner   => 'root',
-        group   => 'ssl-admins',
-        mode    => '0770',
-        recurse => true,
     }
 
     file { '/root/ssl':


### PR DESCRIPTION
Reverts miraheze/puppet#2691