### PR TITLE
nginx: set types_hash_max_size to 2048

### DIFF
--- a/modules/nginx/templates/nginx.conf.erb
+++ b/modules/nginx/templates/nginx.conf.erb
@@ -23,6 +23,7 @@ http {
 	client_max_body_size 250M;
 	server_names_hash_bucket_size 112;
 	http2_max_field_size 8k;
+	types_hash_max_size 2048;
 
 	keepalive_timeout <%= @keepalive_timeout %>;
 	keepalive_requests <%= @keepalive_requests %>;


### PR DESCRIPTION
This value is increased in the debian package but the default value in generally is 1024.