### PR TITLE
prometheus: Use Miraheze rather then Main_Page

### DIFF
--- a/modules/role/manifests/prometheus.pp
+++ b/modules/role/manifests/prometheus.pp
@@ -3,7 +3,7 @@ class role::prometheus {
     include prometheus::exporter::blackbox
 
     $blackbox_mediawiki_urls = query_nodes('Class[Role::Varnish] or Class[Role::MediaWiki]').map |$host| {
-        [ 'Main_Page', 'Special:Version', 'Special:RecentChanges' ].map |$page| {
+        [ 'Miraheze', 'Special:Version', 'Special:RecentChanges' ].map |$page| {
             "https://${host}/wiki/${page}"
         }
     }


### PR DESCRIPTION
meta.miraheze.org main page is Miraheze not Main_Page.