### PR TITLE
Varnish: Update health checks

### DIFF
--- a/modules/mediawiki/files/healthcheck.php
+++ b/modules/mediawiki/files/healthcheck.php
@@ -1,6 +1,6 @@
 <?php
 
-// Return a 204 if all is good
-http_response_code(204);
+// Return a 200 if all is good
+http_response_code(200);
 
 // TODO: Implement any logic to fail while nginx is still up?

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -22,11 +22,12 @@ probe mwhealth {
 	.interval = <%= @interval_check %>;
 	# <%= @interval_timeout %> should be our upper limit for responding to a fair light web request
 	.timeout = <%= @interval_timeout %>;
-	# At least 4 out of 5 checks must be successful
+	# At least 3 out of 5 checks must be successful
 	# to mark the backend as healthy
 	.window = 5;
-	.threshold = 4;
-	.expected_response = 204;
+        .threshold = 3;
+        .initial = 3;
+	.expected_response = 200;
 }
 
 <%- @backends.each_pair do | name, property | -%>


### PR DESCRIPTION
* Change threshold so 3/5 checks to be successful
* Set initial to 3 to mark healthy initially
* Change expected_response to 200, as the health check request returns 200 in vcl_recv
* Update healthcheck.php status return to 200

This also should make this match gdnsd config threshholds and expected status as well.

I have no idea if this is right or if all (or even any) of it is actually needed, so feel free to close if not.