### PR TITLE
mon141: lower MaxConcurrentChecks to 40

### DIFF
--- a/hieradata/hosts/mon141.yaml
+++ b/hieradata/hosts/mon141.yaml
@@ -49,7 +49,7 @@ icinga2::globals::constants:
   NodeName: 'mon141.miraheze.org'
   ZoneName: 'mon141.miraheze.org'
   TicketSalt: ''
-  MaxConcurrentChecks: 120
+  MaxConcurrentChecks: 40
 icinga2::globals::user: 'nagios'
 icinga2::globals::group: 'nagios'
 icinga2::globals::icinga2_bin: '/usr/sbin/icinga2'


### PR DESCRIPTION
When things get stuck it causes the load to sky rocket, lets lower this.