### PR TITLE
gluster101: unmount /mnt/mediawiki-static

### DIFF
--- a/hieradata/hosts/gluster101.yaml
+++ b/hieradata/hosts/gluster101.yaml
@@ -1,4 +1,3 @@
-gluster_client: true
 gluster_volume: gluster101.miraheze.org:/static
 
 base::syslog::graylog_hostname: 'graylog121.miraheze.org'


### PR DESCRIPTION
Not needed to mount, we have it on all the mw*