### PR TITLE
varnish: add index.php to vcl_hash

### DIFF
--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -322,7 +322,7 @@ sub vcl_recv {
 # Defines the uniqueness of a request
 sub vcl_hash {
 	# FIXME: try if we can make this ^/wiki/ only?
-	if (req.url ~ "^/wiki/" || req.url ~ "^/w/load.php") {
+	if (req.url ~ "^/wiki/" || req.url ~ "^/w/(index|load)\.php") {
 		hash_data(req.http.X-Device);
 	}
 }


### PR DESCRIPTION
`/w/index.php?title=Main_Page`
> Age 0
> X-Cache cp30 PASS UNCACHEABLE

`/wiki/Main_Page`
> Age 7785
> X-Cache cp30 HIT (6)

And this was the only thing I could really see as differing here. So I thought it may have something to do with the cache splitting here.