### PR TITLE
Raise varnish::interval-check to 60 seconds again

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -18,7 +18,7 @@ memcached_servers_1:
   - 2a10:6740::6:105:11211:1
 memcached_servers_3:
   - 2a10:6740::6:405:11211:1
-varnish::interval-check: '20s'
+varnish::interval-check: '60s'
 varnish::interval-timeout: '60s'
 varnish::backends:
   mw121:


### PR DESCRIPTION
With it low (at 20 seconds), 503s would be even more common, I think. So this reverts it back to 60 seconds now that gluster migration is done.