### PR TITLE
Remove unused jobchron from hiera

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1,4 +1,3 @@
-jobchron: false
 jobrunner: false
 jobrunner::intensive: false
 mailserver: false

--- a/modules/mediawiki/manifests/init.pp
+++ b/modules/mediawiki/manifests/init.pp
@@ -22,10 +22,6 @@ class mediawiki(
         include mediawiki::jobqueue::runner
     }
 
-    if lookup(jobchron) {
-        include mediawiki::jobqueue::chron
-    }
-
     if lookup(mediawiki::use_shellbox) {
         include mediawiki::shellbox
     }


### PR DESCRIPTION
The class is included via site instead.