### PR TITLE
users: update display_name for sre and mediawiki

### DIFF
--- a/modules/monitoring/files/users.conf
+++ b/modules/monitoring/files/users.conf
@@ -94,11 +94,11 @@ object User "void" {
 /* User groups */
 
 object UserGroup "sre" {
-  display_name = "SRE"
+  display_name = "Site Reliability Engineers"
 }
 
 object UserGroup "mediawiki" {
-  display_name = "MediaWiki System Administrators"
+  display_name = "MediaWiki Engineers"
 }
 
 object UserGroup "ssladmins" {


### PR DESCRIPTION
To update to full names as to match the [organisation](https://meta.miraheze.org/wiki/Tech:Organisation#Department:_Site_Reliability_Engineering) names, and since ssladmins and mediawiki does use an expanded full name, but for mediawiki just correct it to be "MediaWiki Engineers".