### PR TITLE
nginx: increase LimitNOFILE to 16192

### DIFF
--- a/modules/nginx/templates/nginx-systemd-override.conf.erb
+++ b/modules/nginx/templates/nginx-systemd-override.conf.erb
@@ -1,5 +1,5 @@
 [Service]
+LimitNOFILE=16192
 ExecReload=
 ExecReload=/usr/sbin/nginx -t
 ExecReload=/usr/sbin/nginx -g 'daemon on; master_process on;' -s reload
-LimitNOFILE=16192

--- a/modules/nginx/templates/nginx-systemd-override.conf.erb
+++ b/modules/nginx/templates/nginx-systemd-override.conf.erb
@@ -2,3 +2,4 @@
 ExecReload=
 ExecReload=/usr/sbin/nginx -t
 ExecReload=/usr/sbin/nginx -g 'daemon on; master_process on;' -s reload
+LimitNOFILE=16192


### PR DESCRIPTION
Matches what we have set in nginx.conf and also the default is based on the system which is 1024.