### PR TITLE
prometheus-es-exporter: use elasticsearch master only

### DIFF
--- a/modules/prometheus/templates/initscripts/prometheus-es-exporter.systemd_override.erb
+++ b/modules/prometheus/templates/initscripts/prometheus-es-exporter.systemd_override.erb
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=/usr/bin/prometheus-es-exporter --config-dir /etc/prometheus-es-exporter --es-cluster https://es131.miraheze.org:9200 --ca-certs /etc/ssl/certs/Sectigo.crt --ipv6 --cluster-health-disable --nodes-stats-disable --indices-aliases-disable --indices-mappings-disable --indices-stats-disable
+ExecStart=/usr/bin/prometheus-es-exporter --config-dir /etc/prometheus-es-exporter --es-cluster https://elasticsearch.miraheze.org --ca-certs /etc/ssl/certs/Sectigo.crt --ipv6 --cluster-health-disable --nodes-stats-disable --indices-aliases-disable --indices-mappings-disable --indices-stats-disable


### PR DESCRIPTION
Using this uses es131 (or whatever the elasticsearch master is), we don't need to define it with the server.