### PR TITLE
unattended-upgrades: replace MailOnlyOnError with MailReport

### DIFF
--- a/modules/base/files/apt/50unattended-upgrades
+++ b/modules/base/files/apt/50unattended-upgrades
@@ -20,7 +20,7 @@ Unattended-Upgrade::Package-Blacklist {
 };
 
 Unattended-Upgrade::Mail "sre-infrastructure@miraheze.org";
-Unattended-Upgrade::MailOnlyOnError "true";
+Unattended-Upgrade::MailReport "only-on-error";
 
 Unattended-Upgrade::Remove-Unused-Dependencies "true";
 


### PR DESCRIPTION
It seems `Unattended-Upgrade::MailOnlyOnError` is legacy, and deprecated on Debian Bullseye. Replace it with `Unattended-Upgrade::MailReport`