### PR TITLE
stunnel: always listen through ipv6

### DIFF
--- a/modules/varnish/templates/stunnel.conf
+++ b/modules/varnish/templates/stunnel.conf
@@ -9,6 +9,6 @@ delay = yes
 
 <%- @backends.each_pair do | name, property | -%>
 [<%= name %>]
-accept = <%= property['port'] %>
+accept = :::<%= property['port'] %>
 connect = <%= name %>.miraheze.org:443
 <%- end -%>


### PR DESCRIPTION
This seems to successfully fix issues like:

```ps
2022.09.15 20:54:04 LOG3[317696]: s_connect: s_poll_wait 2a10:6740::6:403:443: TIMEOUTconnect exceeded
2022.09.15 20:54:04 LOG3[317696]: No more addresses to connect
```