### PR TITLE
mediawiki: reduce mediawiki::php::fpm::fpm_min_child to 20

### DIFF
--- a/hieradata/hosts/mw121.yaml
+++ b/hieradata/hosts/mw121.yaml
@@ -6,7 +6,7 @@ contactgroups: ['sre', 'mediawiki']
 
 role::mediawiki::use_strict_firewall: true
 
-mediawiki::php::fpm::fpm_min_child: 32
+mediawiki::php::fpm::fpm_min_child: 20
 mediawiki::php::fpm::fpm_workers_multiplier: 1.0
 mediawiki::php::fpm_config:
   post_max_size: '250M'

--- a/hieradata/hosts/mw122.yaml
+++ b/hieradata/hosts/mw122.yaml
@@ -6,7 +6,7 @@ contactgroups: ['sre', 'mediawiki']
 
 role::mediawiki::use_strict_firewall: true
 
-mediawiki::php::fpm::fpm_min_child: 32
+mediawiki::php::fpm::fpm_min_child: 20
 mediawiki::php::fpm::fpm_workers_multiplier: 1.0
 mediawiki::php::fpm_config:
   post_max_size: '250M'

--- a/hieradata/hosts/mw131.yaml
+++ b/hieradata/hosts/mw131.yaml
@@ -9,7 +9,7 @@ mediawiki::jobqueue::runner::redis_ip: '[2a10:6740::6:306]:6379'
 
 role::mediawiki::use_strict_firewall: true
 
-mediawiki::php::fpm::fpm_min_child: 32
+mediawiki::php::fpm::fpm_min_child: 20
 mediawiki::php::fpm::fpm_workers_multiplier: 1.0
 mediawiki::php::fpm_config:
   post_max_size: '250M'

--- a/hieradata/hosts/mw132.yaml
+++ b/hieradata/hosts/mw132.yaml
@@ -9,7 +9,7 @@ mediawiki::jobqueue::runner::redis_ip: '[2a10:6740::6:306]:6379'
 
 role::mediawiki::use_strict_firewall: true
 
-mediawiki::php::fpm::fpm_min_child: 32
+mediawiki::php::fpm::fpm_min_child: 20
 mediawiki::php::fpm::fpm_workers_multiplier: 1.0
 mediawiki::php::fpm_config:
   post_max_size: '250M'

--- a/hieradata/hosts/mw141.yaml
+++ b/hieradata/hosts/mw141.yaml
@@ -9,7 +9,7 @@ mediawiki::jobqueue::runner::redis_ip: '[2a10:6740::6:306]:6379'
 
 role::mediawiki::use_strict_firewall: true
 
-mediawiki::php::fpm::fpm_min_child: 32
+mediawiki::php::fpm::fpm_min_child: 20
 mediawiki::php::fpm::fpm_workers_multiplier: 1.0
 mediawiki::php::fpm_config:
   post_max_size: '250M'

--- a/hieradata/hosts/mw142.yaml
+++ b/hieradata/hosts/mw142.yaml
@@ -9,7 +9,7 @@ mediawiki::jobqueue::runner::redis_ip: '[2a10:6740::6:306]:6379'
 
 role::mediawiki::use_strict_firewall: true
 
-mediawiki::php::fpm::fpm_min_child: 32
+mediawiki::php::fpm::fpm_min_child: 20
 mediawiki::php::fpm::fpm_workers_multiplier: 1.0
 mediawiki::php::fpm_config:
   post_max_size: '250M'


### PR DESCRIPTION
using 32 is OOm'g, lets go to a smaller number.