### PR TITLE
varnish: fix address (should be `::6`)

### DIFF
--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -54,7 +54,7 @@ sub vcl_init {
 acl purge {
 	"localhost";
 	# IPv6
-	"2a10:6740::/64";
+	"2a10:6740::6/64";
 	# IPv4
 	"31.24.105.128/28";
 }


### PR DESCRIPTION
`2a10:6740::6/64` is what it should be here if I am not mistaken.