### PR TITLE
jobQueueCollector: add z-claimed and z-delayed jobs

### DIFF
--- a/modules/prometheus/files/redis/jobQueueCollector.lua
+++ b/modules/prometheus/files/redis/jobQueueCollector.lua
@@ -2,7 +2,12 @@
 -- Author: John Lewis, Miraheze
 
 local result = {}
-local queues = { 'l-unclaimed', 'z-abandoned' }
+local queues = {
+	'l-unclaimed',
+	'z-abandoned',
+	'z-claimed',
+	'z-delayed'
+}
 
 -- Below is a list of jobs we want to monitor specifically
 local jobs = {


### PR DESCRIPTION
So we can collect all jobs, and calculate the abandoned jobs to total jobs ratio, and there could be some other uses as well.