### PR TITLE
swiftobject111/2/3/4/5: increase swift::storage::object_server_default_workers to 12

### DIFF
--- a/hieradata/hosts/swiftobject111.yaml
+++ b/hieradata/hosts/swiftobject111.yaml
@@ -4,3 +4,4 @@ base::syslog::graylog_hostname: 'graylog121.miraheze.org'
 # Swift config
 
 swift_object_enable: true
+swift::storage::object_server_default_workers: 12

--- a/hieradata/hosts/swiftobject112.yaml
+++ b/hieradata/hosts/swiftobject112.yaml
@@ -4,3 +4,4 @@ base::syslog::graylog_hostname: 'graylog121.miraheze.org'
 # Swift config
 
 swift_object_enable: true
+swift::storage::object_server_default_workers: 12

--- a/hieradata/hosts/swiftobject113.yaml
+++ b/hieradata/hosts/swiftobject113.yaml
@@ -4,3 +4,4 @@ base::syslog::graylog_hostname: 'graylog121.miraheze.org'
 # Swift config
 
 swift_object_enable: true
+swift::storage::object_server_default_workers: 12

--- a/hieradata/hosts/swiftobject114.yaml
+++ b/hieradata/hosts/swiftobject114.yaml
@@ -4,3 +4,4 @@ base::syslog::graylog_hostname: 'graylog121.miraheze.org'
 # Swift config
 
 swift_object_enable: true
+swift::storage::object_server_default_workers: 12

--- a/hieradata/hosts/swiftobject115.yaml
+++ b/hieradata/hosts/swiftobject115.yaml
@@ -4,3 +4,4 @@ base::syslog::graylog_hostname: 'graylog121.miraheze.org'
 # Swift config
 
 swift_object_enable: true
+swift::storage::object_server_default_workers: 12


### PR DESCRIPTION
Whilst I'm not too sure which number would be best, I've seen Wikimedia set this to 12 for some of their servers which is a better starting off place. We can lower / increase this depending how things work when production traffic starts flowing in as then we'll have the data.