### PR TITLE
Set higher ping threshold for cp32/cp33

### DIFF
--- a/modules/monitoring/files/services.conf
+++ b/modules/monitoring/files/services.conf
@@ -28,11 +28,6 @@ apply Service "ping4" {
 
   check_command = "ping4"
 
-  if ( host.name == "ns1" ) {
-    vars.ping_wrta = 120
-    vars.ping_crta = 2000
-  }
-
   assign where host.address
 }
 
@@ -40,10 +35,10 @@ apply Service "ping6" {
   import "generic-service"
 
   check_command = "ping6"
-  
-  if ( host.name == "ns1" ) {
+
+  if ( regex("^((cp3[23])|ns1)$", host.name) ) {
     vars.ping_wrta = 120
-    vars.ping_crta = 2000
+    vars.ping_crta = 180
   }
 
   assign where host.address6


### PR DESCRIPTION
Also changes ns1, since icinga indicates it isn't that high, we don't need it that high here. Additionally, removes ns1 from ping4, since it is not ever checking ping4 as only address6 is used when defining hosts.