### PR TITLE
varnish: dynamically set malloc based on the ram available

### DIFF
--- a/modules/varnish/manifests/init.pp
+++ b/modules/varnish/manifests/init.pp
@@ -57,6 +57,15 @@ class varnish (
         group  => 'varnish',
     }
 
+    $mem_gb = $facts['memorysize_mb'] / 1024.0
+    if ($mem_gb < 90.0) {
+        $fe_mem_gb = 1
+    } else {
+        $fe_mem_gb = ceiling(0.7 * ($mem_gb - 100.0))
+    }
+
+    $storage = "-s malloc,${fe_mem_gb}G -s file,${cache_file_name},${cache_file_size}",
+
     $max_threads = max(floor($::processorcount * 250), 500)
     systemd::service { 'varnish':
         ensure         => present,

--- a/modules/varnish/templates/initscripts/varnish.systemd.erb
+++ b/modules/varnish/templates/initscripts/varnish.systemd.erb
@@ -31,8 +31,7 @@ ExecStart=/usr/sbin/varnishd \
 -p vsl_reclen=2048 \
 -p workspace_backend=128k \
 -S /etc/varnish/secret \
--s malloc,256M \
--s file,<%= @cache_file_name %>,<%= @cache_file_size %> \
+<%= @storage %> \
 -p http_req_size=24576 \
 -p listen_depth=4096 -p vcc_err_unref=off \
 -p http_max_hdr=128 \

--- a/modules/varnish/templates/initscripts/varnish.systemd.erb
+++ b/modules/varnish/templates/initscripts/varnish.systemd.erb
@@ -31,6 +31,7 @@ ExecStart=/usr/sbin/varnishd \
 -p vsl_reclen=2048 \
 -p workspace_backend=128k \
 -S /etc/varnish/secret \
+-s malloc,256M \
 -s file,<%= @cache_file_name %>,<%= @cache_file_size %> \
 -p http_req_size=24576 \
 -p listen_depth=4096 -p vcc_err_unref=off \


### PR DESCRIPTION
According to the documentation [0], malloc is unlimited in varnish.

We change this to be dynamically set. Based on 2g on cp21/22/32/33, we'd set this to 1G.

[0] https://varnish-cache.org/docs/trunk/users-guide/storage-backends.html