### PR TITLE
Use IPv6 address for sslhost

### DIFF
--- a/modules/monitoring/files/hosts.conf
+++ b/modules/monitoring/files/hosts.conf
@@ -1,6 +1,6 @@
 object Host "sslhost" {
     import "virtual-host"
-    address = "127.0.0.1"
+    address6 = "::1"
 
     vars.notification["mail"] = {
       /* The user groups `icingaadmins`, `sre`, and `ssladmins` are defined in `users.conf`. */

--- a/modules/monitoring/files/services.conf
+++ b/modules/monitoring/files/services.conf
@@ -1,7 +1,7 @@
 /*
  * Service apply rules.
  *
- * The CheckCommand objects `ping4`, `ping6`, etc
+ * The CheckCommand objects `ping6`, `ssh`, `http`, etc.
  * are provided by the plugin check command templates.
  * Check the documentation for details.
  *
@@ -18,19 +18,10 @@
  */
 
 /*
- * These are generic `ping4` and `ping6`
- * checks applied to all hosts having the
- * `address` resp. `address6` attribute
- * defined.
+ * These are generic `ping6` checks applied
+ * to all hosts having the `address6`
+ * attribute defined.
  */
-apply Service "ping4" {
-  import "generic-service"
-
-  check_command = "ping4"
-
-  assign where host.address
-}
-
 apply Service "ping6" {
   import "generic-service"
 

--- a/modules/monitoring/files/services.conf
+++ b/modules/monitoring/files/services.conf
@@ -37,7 +37,7 @@ apply Service "ping6" {
 
 /*
  * Apply the `ssh` service to all hosts
- * with the `address` attribute defined and
+ * with the `address6` attribute defined and
  * the custom variable `os` set to `Linux`.
  */
 apply Service "ssh" {
@@ -45,7 +45,7 @@ apply Service "ssh" {
 
   check_command = "ssh"
 
-  assign where (host.address || host.address6) && host.vars.os == "Linux"
+  assign where host.address6 && host.vars.os == "Linux"
 }
 
 


### PR DESCRIPTION
Also removes the `ping4` CheckCommand, and IPv4 address attribute from `ssh` since this was the only one using IPv4 address for monitoring.