### PR TITLE
swift: re enable swift*replicator

### DIFF
--- a/modules/swift/manifests/ac.pp
+++ b/modules/swift/manifests/ac.pp
@@ -51,8 +51,10 @@ class swift::ac {
         'swift-account',
         'swift-account-auditor',
         'swift-account-reaper',
+        'swift-account-replicator',
         'swift-container',
         'swift-container-auditor',
+        'swift-container-replicator',
         'swift-container-updater',
     ]:
         ensure => running,

--- a/modules/swift/manifests/ac.pp
+++ b/modules/swift/manifests/ac.pp
@@ -58,19 +58,6 @@ class swift::ac {
         ensure => running,
     }
 
-    service { [
-        'swift-account-replicator',
-        'swift-container-replicator',
-    ]:
-        ensure   => 'stopped',
-        enable   => 'mask',
-        provider => 'systemd',
-        require  => [
-            Package['swift-account'],
-            Package['swift-container'],
-        ],
-    }
-
     # object-reconstructor and container-sharder are not used.
     # Remove their unit so 'systemctl <action> swift*' exits zero.
     # If one of the units matching the wildcard is masked then systemctl

--- a/modules/swift/manifests/storage.pp
+++ b/modules/swift/manifests/storage.pp
@@ -40,13 +40,6 @@ class swift::storage (
         ensure => running,
     }
 
-    service { 'swift-object-replicator':
-        ensure   => 'stopped',
-        enable   => 'mask',
-        provider => 'systemd',
-        require  => Package['swift-object'],
-    }
-
     # object-reconstructor and container-sharder are not used in WMF deployment, yet are enabled
     # by the Debian package.
     # Remove their unit so 'systemctl <action> swift*' exits zero.


### PR DESCRIPTION
With the replication set at one it means that there won't be copies, but we need this service to delete tombstones otherwise we'll run out of inodes.