### PR TITLE
monitoring: fix nrpe_timeout

### DIFF
--- a/modules/monitoring/manifests/nrpe.pp
+++ b/modules/monitoring/manifests/nrpe.pp
@@ -22,7 +22,7 @@ define monitoring::nrpe (
             critical      => $critical,
             vars          => {
                 nrpe_command => "check_${title}",
-                nrpe_timeout => '60s',
+                nrpe_timeout => '60',
             },
         }
     }


### PR DESCRIPTION
Drop the s as the number is in seconds, it does not need the s.