### PR TITLE
monitoring: fix nrpe_timeout to use new timeout syntax

### DIFF
--- a/modules/monitoring/manifests/nrpe.pp
+++ b/modules/monitoring/manifests/nrpe.pp
@@ -22,7 +22,7 @@ define monitoring::nrpe (
             critical      => $critical,
             vars          => {
                 nrpe_command => "check_${title}",
-                nrpe_timeout => '60',
+                nrpe_timeout => '60:CRITICAL',
             },
         }
     }


### PR DESCRIPTION
According to the help guide, the timeout syntax has a new format:

```
 -t, --timeout=INTERVAL:STATE
                              INTERVAL  Number of seconds before connection times out (default=10)
                              STATE     Check state to exit with in the event of a timeout (default=CRITICAL)
                              Timeout STATE must be a valid state name (case-insensitive) or integer:
                              (OK, WARNING, CRITICAL, UNKNOWN) or integer (0-3)
```