### PR TITLE
swift: set reclaim_age to 6 hours

### DIFF
--- a/modules/swift/templates/account-server.conf.erb
+++ b/modules/swift/templates/account-server.conf.erb
@@ -22,6 +22,8 @@ use = egg:swift#recon
 
 [account-replicator]
 concurrency = 1
+# default is 7 days
+reclaim_age = 21600 # 6 hours in seconds
 
 [account-auditor]
 concurrency = 1

--- a/modules/swift/templates/account-server.conf.erb
+++ b/modules/swift/templates/account-server.conf.erb
@@ -23,7 +23,8 @@ use = egg:swift#recon
 [account-replicator]
 concurrency = 1
 # default is 7 days
-reclaim_age = 21600 # 6 hours in seconds
+# 6 hours in seconds
+reclaim_age = 21600
 
 [account-auditor]
 concurrency = 1

--- a/modules/swift/templates/container-server.conf.erb
+++ b/modules/swift/templates/container-server.conf.erb
@@ -23,6 +23,8 @@ recon_cache_path = /var/cache/swift
 
 [container-replicator]
 concurrency = 1
+# default is 7 days
+reclaim_age = 21600 # 6 hours in seconds
 
 [container-updater]
 concurrency = 1

--- a/modules/swift/templates/container-server.conf.erb
+++ b/modules/swift/templates/container-server.conf.erb
@@ -24,7 +24,8 @@ recon_cache_path = /var/cache/swift
 [container-replicator]
 concurrency = 1
 # default is 7 days
-reclaim_age = 21600 # 6 hours in seconds
+# 6 hours in seconds
+reclaim_age = 21600
 
 [container-updater]
 concurrency = 1

--- a/modules/swift/templates/object-server.conf.erb
+++ b/modules/swift/templates/object-server.conf.erb
@@ -17,6 +17,9 @@ mount_check = false
 # fallocate_reserve = 1%
 disable_fallocate = false
 fallocate_reserve = 2%
+# default is 7 days
+# 6 hours in seconds
+reclaim_age = 21600
 
 [pipeline:main]
 pipeline = recon object-server
@@ -40,9 +43,6 @@ recon_cache_path = /var/cache/swift
 
 [object-replicator]
 concurrency = 1
-# default is 7 days
-# 6 hours in seconds
-reclaim_age = 21600
 # Don't let replication rsyncs starve other processes of CPU or I/O.
 nice_priority = 1
 # ionice_class and ionice_priority must be specified together.

--- a/modules/swift/templates/object-server.conf.erb
+++ b/modules/swift/templates/object-server.conf.erb
@@ -40,6 +40,8 @@ recon_cache_path = /var/cache/swift
 
 [object-replicator]
 concurrency = 1
+# default is 7 days
+reclaim_age = 21600 # 6 hours in seconds
 # Don't let replication rsyncs starve other processes of CPU or I/O.
 nice_priority = 1
 # ionice_class and ionice_priority must be specified together.

--- a/modules/swift/templates/object-server.conf.erb
+++ b/modules/swift/templates/object-server.conf.erb
@@ -41,7 +41,8 @@ recon_cache_path = /var/cache/swift
 [object-replicator]
 concurrency = 1
 # default is 7 days
-reclaim_age = 21600 # 6 hours in seconds
+# 6 hours in seconds
+reclaim_age = 21600
 # Don't let replication rsyncs starve other processes of CPU or I/O.
 nice_priority = 1
 # ionice_class and ionice_priority must be specified together.


### PR DESCRIPTION
We don't want to wait 7 days for swift to delete accounts/objects/containers on the disk.