### PR TITLE
mediawiki: update static alias to just rewrite

### DIFF
--- a/modules/mediawiki/templates/mediawiki-includes.conf.erb
+++ b/modules/mediawiki/templates/mediawiki-includes.conf.erb
@@ -59,8 +59,8 @@ location /sitemaps/ {
 	rewrite ^/sitemaps/(.+)/sitemaps/(.+)$ https://static.miraheze.org/$1/sitemaps/$2 permanent;
 }
 
-location ~ ^/static/((?!(private))(.+))$ {
-	alias /mnt/mediawiki-static/$1;
+location /static/ {
+	rewrite ^/static/(.+)$ https://static.miraheze.org/$1 permanent;
 }
 
 # Redirect /entity/* to /wiki/Special:EntityData/*


### PR DESCRIPTION
Alias won't work with Swift.

Additional checks for private is no longer necessary here, since it is redirecting to the static subdomain, if access to it is denied there it would be denied, so a redirect even for private should be fine here.