### PR TITLE
mediawiki-landing: include redirecting donate.php

### DIFF
--- a/modules/mediawiki/templates/mediawiki.conf.erb
+++ b/modules/mediawiki/templates/mediawiki.conf.erb
@@ -29,6 +29,10 @@ server {
 		deny all;
 	}
 
+	location ~ /donate {
+		return 301 https://donate.miraheze.org;
+	}
+
 	location ~ \.php {
 		include fastcgi_params;
 		fastcgi_index index.php;
@@ -42,10 +46,6 @@ server {
 
 	location /discord {
 		return 301 https://discord.gg/TVAJTE4CUn;
-	}
-
-	location /donate {
-		return 301 https://donate.miraheze.org;
 	}
 
 	location ~ ^/((?!(css|images)).)*$ {


### PR DESCRIPTION
So /donate.php also redirects to donate.miraheze.org. Currently the above regex matches donate.php, so this one does not. Move it above, and make it regex so that it also matches.