### PR TITLE
mediawiki-landing: redirect `/en` to `/`

### DIFF
--- a/modules/mediawiki/templates/mediawiki.conf.erb
+++ b/modules/mediawiki/templates/mediawiki.conf.erb
@@ -48,19 +48,18 @@ server {
 		return 301 https://discord.gg/TVAJTE4CUn;
 	}
 
-	location /en {
-		return 301 /;
-	}
-
-	location ~ ^/((?!(css|discord|en|images)).)*$ {
+	location ~ ^/((?!(css|discord|images)).)*$ {
 		# redirect query parameter to path
 		if ($arg_lang != '' && $arg_lang != 'en') {
 			return 301 /$arg_lang;
 		}
 
+		# redirect en (default) to /
 		if ($arg_lang == 'en') {
 			return 301 /;
 		}
+
+		rewrite ^/en(/.*)?$ / permanent;
 
 		# rewrite path to lang, so that, for example, /en will act the
 		# same as ?lang=en, but without the ?lang being needed 
@@ -273,19 +272,18 @@ server {
 		send_timeout 140;
 	}
 
-	location /en {
-		return 301 /;
-	}
-
-	location ~ ^/((?!(css|en|images)).)*$ {
+	location ~ ^/((?!(css|images)).)*$ {
 		# redirect query parameter to path
 		if ($arg_lang != '' && $arg_lang != 'en') {
 			return 301 /$arg_lang;
 		}
 
+		# redirect en (default) to /
 		if ($arg_lang == 'en') {
 			return 301 /;
 		}
+
+		rewrite ^/en(/.*)?$ / permanent;
 
 		# rewrite path to lang, so that, for example, /en will act the
 		# same as ?lang=en, but without the ?lang being needed 

--- a/modules/mediawiki/templates/mediawiki.conf.erb
+++ b/modules/mediawiki/templates/mediawiki.conf.erb
@@ -48,10 +48,18 @@ server {
 		return 301 https://discord.gg/TVAJTE4CUn;
 	}
 
-	location ~ ^/((?!(css|discord|images)).)*$ {
+	location /en {
+		return 301 /;
+	}
+
+	location ~ ^/((?!(css|discord|en|images)).)*$ {
 		# redirect query parameter to path
-		if ($arg_lang != '') {
+		if ($arg_lang != '' && $arg_lang != 'en') {
 			return 301 /$arg_lang;
+		}
+
+		if ($arg_lang == 'en') {
+			return 301 /;
 		}
 
 		# rewrite path to lang, so that, for example, /en will act the
@@ -265,10 +273,18 @@ server {
 		send_timeout 140;
 	}
 
-	location ~ ^/((?!(css|images)).)*$ {
+	location /en {
+		return 301 /;
+	}
+
+	location ~ ^/((?!(css|en|images)).)*$ {
 		# redirect query parameter to path
-		if ($arg_lang != '') {
+		if ($arg_lang != '' && $arg_lang != 'en') {
 			return 301 /$arg_lang;
+		}
+
+		if ($arg_lang == 'en') {
+			return 301 /;
 		}
 
 		# rewrite path to lang, so that, for example, /en will act the


### PR DESCRIPTION
To normalise the default so that multiple versions aren't the exact same content.