### PR TITLE
ssl::nginx: stop loading ssl::hiera

### DIFF
--- a/modules/ssl/manifests/nginx.pp
+++ b/modules/ssl/manifests/nginx.pp
@@ -9,6 +9,4 @@ class ssl::nginx {
     }
 
     ssl::wildcard { 'ssl-acme nginx wildcard': }
-
-    include ssl::hiera
 }


### PR DESCRIPTION
We don't need it. We already load the certificate we need with ssl::wildcard.