### PR TITLE
mariadb: fix logrotate config

### DIFF
--- a/modules/mariadb/files/mysql-server.logrotate.conf
+++ b/modules/mariadb/files/mysql-server.logrotate.conf
@@ -1,0 +1,19 @@
+# - I put everything in one block and added sharedscripts, so that mysql gets
+#   flush-logs'd only once.                                      
+#   Else the binary logs would automatically increase by n times every day.
+# - The error log is obsolete, messages go to syslog now.
+/var/log/mysql/mysql.log /var/log/mysql/mysql-slow.log /var/log/mysql/mariadb-slow.log /var/log/mysql/error.log {
+        daily
+        rotate 7
+        missingok
+        create 640 mysql adm
+        compress
+        sharedscripts
+        postrotate
+          test -x /usr/bin/mysqladmin || exit 0
+          # check if server is running
+          if mysqladmin ping > /dev/null 2>&1; then
+            mysqladmin --local flush-error-log flush-engine-log flush-general-log flush-slow-log
+          fi
+        endscript
+}

--- a/modules/mariadb/manifests/config.pp
+++ b/modules/mariadb/manifests/config.pp
@@ -90,6 +90,12 @@ class mariadb::config(
         require => Package["mariadb-server-${version}"],
     }
 
+    logrotate::conf { 'mysql-server':
+        ensure => present,
+        source => 'puppet:///modules/mariadb/mysql-server.logrotate.conf',
+        require => Package["mariadb-server-${version}"],
+    }
+
     systemd::unit { 'mariadb.service':
         ensure   => present,
         content  => template('mariadb/mariadb-systemd-override.conf.erb'),


### PR DESCRIPTION
By default in the mariadb packaging it sets within the logrotate file to use mysqladm with --defaults-file set for debian.cnf. We fix this by removing this param.