### PR TITLE
varnish: experiment with using both malloc and file storage

### DIFF
--- a/modules/varnish/manifests/init.pp
+++ b/modules/varnish/manifests/init.pp
@@ -39,7 +39,7 @@ class varnish (
     }
 
     # TODO: On bigger memory hosts increase Transient size
-    $storage = "-s file,${cache_file_name},${cache_file_size} -s Transient=malloc,500M"
+    $storage = "-s file,${cache_file_name},${cache_file_size} -s malloc,1G -s Transient=malloc,1G"
 
     # Default is 5000 in varnish
     $max_threads = max(floor($::processorcount * 250), 5000)

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -360,6 +360,14 @@ sub vcl_backend_fetch {
 
 # Backend response, defines cacheability
 sub vcl_backend_response {
+	if (std.integer(beresp.http.content-length, 0) > 1000) {
+		# most responses go into on-disk storage
+		set beresp.storage = storage.s0;
+	} else {
+		# tiny ones go into malloc
+		set beresp.storage = storage.s1;
+	}
+
 	# T9808: Assign restrictive Cache-Control if one is missing
 	if (!beresp.http.Cache-Control) {
 		set beresp.http.Cache-Control = "private, s-maxage=0, max-age=0, must-revalidate";


### PR DESCRIPTION
Tiny objects go into memory whereas the bigger ones go into the storage.