### PR TITLE
mariadb: remove innodb_stats_sample_pages from config file

### DIFF
--- a/modules/mariadb/templates/config/mw.cnf.erb
+++ b/modules/mariadb/templates/config/mw.cnf.erb
@@ -67,7 +67,6 @@ wait_timeout                   = 3600
 innodb-flush-method            = O_DIRECT
 innodb_thread_concurrency      = 0
 innodb_io_capacity             = 1000
-innodb_stats_sample_pages      = 16
 innodb_stats_method            = nulls_unequal
 innodb-log-file-size           = 256M
 innodb-flush-log-at-trx-commit = 1


### PR DESCRIPTION
The config was deprecated and now shows:

> 2022-11-26 19:50:03 0 [Warning] 'innodb-stats-sample-pages' was removed. It does nothing now and exists only for compatibility with old my.cnf files.

in the logs