### PR TITLE
redis: disable lua-time-limit

### DIFF
--- a/modules/redis/templates/redis.conf.erb
+++ b/modules/redis/templates/redis.conf.erb
@@ -38,7 +38,7 @@ maxmemory-samples <%= @maxmemory_samples %>
 #appendonly yes
 #appendfsync everysec
 
-lua-time-limit 5000
+# lua-time-limit 5000
 
 slowlog-log-slower-than 10000
 slowlog-max-len 128


### PR DESCRIPTION
Either it's a coincidence that issues with the job queue stopped after changing this or this fixed the issue.

Either way I don't see why we need this set at 5s. It was imported 8 years ago.

This defaults it to the default in redis which is 500ms.