### PR TITLE
swift: add rsyslog rules

### DIFF
--- a/modules/swift/files/swift.logrotate.conf
+++ b/modules/swift/files/swift.logrotate.conf
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+/var/log/swift/*.log
+{
+    rotate 4
+    daily
+    missingok
+    notifempty
+    delaycompress
+    compress
+    sharedscripts
+    postrotate
+        invoke-rc.d rsyslog reload >/dev/null 2>&1 || true
+    endscript
+}

--- a/modules/swift/files/swift.rsyslog.conf
+++ b/modules/swift/files/swift.rsyslog.conf
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Filenames roughly match the ops_runbook, save for separate proxy-access.log
+# http://docs.openstack.org/developer/swift/ops_runbook/diagnose.html#diagnose-interpreting-messages-in-var-log-swift-files
+
+if ($syslogfacility-text == 'local1') and
+       ($programname == 'proxy-server') then {
+    action(type="omfile" file="/var/log/swift/proxy-access.log")
+    stop
+}
+
+if ($programname contains 'proxy-') or
+       ($programname contains 'account-') or
+       ($programname contains 'container-') or
+       ($programname contains 'object-') then {
+
+    if ($programname contains '-server') then {
+        action(type="omfile" file="/var/log/swift/server.log")
+        stop
+    }
+
+    action(type="omfile" file="/var/log/swift/background.log")
+    stop
+}

--- a/modules/swift/manifests/init.pp
+++ b/modules/swift/manifests/init.pp
@@ -66,4 +66,10 @@ class swift {
         content => template('swift/swift-env.sh.erb'),
         mode    => '0755',
     }
+
+    rsyslog::conf { 'swift':
+        source   => 'puppet:///modules/swift/swift.rsyslog.conf',
+        priority => 40,
+        require  => File['/var/log/swift'],
+    }
 }

--- a/modules/swift/manifests/init.pp
+++ b/modules/swift/manifests/init.pp
@@ -67,6 +67,11 @@ class swift {
         mode    => '0755',
     }
 
+    logrotate::conf { 'swift':
+        ensure => present,
+        source => 'puppet:///modules/swift/swift.logrotate.conf',
+    }
+
     rsyslog::conf { 'swift':
         source   => 'puppet:///modules/swift/swift.rsyslog.conf',
         priority => 40,


### PR DESCRIPTION
From:
- https://github.com/wikimedia/puppet/blob/production/modules/swift/files/swift.logrotate.conf
- https://github.com/wikimedia/puppet/blob/production/modules/swift/files/swift.rsyslog.conf