### PR TITLE
mediawiki: fix `updateExternalLinks.php` cron

### DIFF
--- a/modules/mediawiki/manifests/jobqueue/runner.pp
+++ b/modules/mediawiki/manifests/jobqueue/runner.pp
@@ -41,7 +41,7 @@ class mediawiki::jobqueue::runner {
 
         cron { 'update rottenlinks on all wikis':
             ensure   => present,
-            command  => '/usr/local/bin/fileLockScript.sh /tmp/rotten_links_file_lock "/usr/bin/nice 15 /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/databases.json /srv/mediawiki/w/extensions/RottenLinks/maintenance/updateExternalLinks.php"',
+            command  => '/usr/local/bin/fileLockScript.sh /tmp/rotten_links_file_lock "/usr/bin/nice -n 15 /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/databases.json /srv/mediawiki/w/extensions/RottenLinks/maintenance/updateExternalLinks.php"',
             user     => 'www-data',
             minute   => '0',
             hour     => '0',


### PR DESCRIPTION
Seems to have been broken over a year ago with dbe96ca. Using `-number` works (before it was -19), but using a positive number, it has to define `-n` for `nice` to work. As now it just returns: `/usr/bin/nice: ‘15’: No such file or directory`