### PR TITLE
Remove virtual_processor_count fact

### DIFF
--- a/modules/base/manifests/monitoring.pp
+++ b/modules/base/manifests/monitoring.pp
@@ -56,8 +56,8 @@ class base::monitoring {
         docs    => 'https://meta.miraheze.org/wiki/Tech:Icinga/Base_Monitoring#Disk_Space'
     }
 
-    $load_critical = $facts['virtual_processor_count'] * 2.0
-    $load_warning = $facts['virtual_processor_count'] * 1.7
+    $load_critical = $facts['processors']['count'] * 2.0
+    $load_warning = $facts['processors']['count'] * 1.7
     monitoring::nrpe { 'Current Load':
         command => "/usr/lib/nagios/plugins/check_load -w ${load_warning} -c ${load_critical}",
         docs    => 'https://meta.miraheze.org/wiki/Tech:Icinga/Base_Monitoring#Current_Load'


### PR DESCRIPTION
We haven't used openvz in a long while which required us to use a custom fact to correctly get the core count.

We can now remove this.