### PR TITLE
php: increase max requests by 50%

### DIFF
--- a/modules/php/manifests/fpm/pool.pp
+++ b/modules/php/manifests/fpm/pool.pp
@@ -57,7 +57,7 @@ define php::fpm::pool(
         'listen.backlog' => 256,
         'pm'     => 'static',
         'pm.max_children' => $facts['processors']['count'],
-        'pm.max_requests' => 1000,
+        'pm.max_requests' => 5000,
         'pm.status_path' => '/php_status',
         'access.format'  => '%{%Y-%m-%dT%H:%M:%S}t [%p] %{microseconds}d %{HTTP_HOST}e/%r %m/%s %{mega}M',
         'process.dumpable' => yes,


### PR DESCRIPTION
We have discovered what caused the memory leaks and it wasn't php-fpm. Let's increase this by 50%.