### PR TITLE
Change `backups-mediawiki-xml` to 3, 6, 9, 12

### DIFF
--- a/modules/mediawiki/manifests/jobqueue/runner.pp
+++ b/modules/mediawiki/manifests/jobqueue/runner.pp
@@ -113,7 +113,7 @@ class mediawiki::jobqueue::runner {
             minute   => '0',
             hour     => '1',
             monthday => ['27'],
-            month    => ['1', '3', '6', '9']
+            month    => ['3', '6', '9', '12']
         }
 
         monitoring::nrpe { 'Backups MediaWiki XML':


### PR DESCRIPTION
This was 0 before, which doesn't exist, so was made 1, this readjusts everything else for that.