### PR TITLE
es_exporter: improve accuracy of nginx metrics query

### DIFF
--- a/modules/prometheus/files/es_exporter/20-nginx.cfg
+++ b/modules/prometheus/files/es_exporter/20-nginx.cfg
@@ -8,7 +8,7 @@ QueryJson = {
 			"bool": {
 				"must": [
 					{
-						"match": {
+						"match_phrase": {
 							"application_name": "nginx"
 						}
 					}
@@ -23,14 +23,21 @@ QueryJson = {
 			}
 		},
 		"aggs": {
-			"request_time": {
-				"terms": {
-					"field": "nginx_request_time"
+			"request_time_range": {
+				"range": {
+					"field": "nginx_request_time",
+					"ranges": [
+						{ "to": 100 },
+						{ "from": 100, "to": 250 },
+						{ "from": 250 }
+					]
 				}
 			},
 			"status_code": {
 				"terms": {
-					"field": "nginx_status"
+					"field": "nginx_status",
+					"min_doc_count": 10,
+					"size": 5
 				}
 			}
 		}


### PR DESCRIPTION
This modifies the nginx metrics query to improve its accuracy and focus on relevant data. The query now uses the match_phrase query type instead of the match query type for the application_name field, to ensure that only documents with an exact match are returned. The query also includes a filter for a specific time range, to narrow the results to a specific period.

In addition, the query includes min_doc_count and size parameters in the terms aggregations, to limit the results to HTTP status codes that have at least 10 documents and a maximum of 5 values. This helps to eliminate noise and focus on significant trends.

Finally, the query includes a new range aggregation for the request time field, which allows us to group documents by request time ranges rather than individual request times. This provides a more granular view of the data and allows us to identify patterns and trends in the request times.

Overall, these changes should help to make the nginx metrics query more accurate and useful for monitoring and analysis.