### PR TITLE
MariaDB: always restart

### DIFF
--- a/modules/mariadb/templates/mariadb-systemd-override.conf.erb
+++ b/modules/mariadb/templates/mariadb-systemd-override.conf.erb
@@ -1,3 +1,4 @@
 # now that we host alot of dbs the timeout keeps getting hit
 [Service]
 TimeoutStartSec=0
+Restart=always


### PR DESCRIPTION
We default to read only on start-up, there is no risk to data and it means wikis become available after an OOM much faster. It’s far better to have wikis read only than down.