### PR TITLE
explicitly configure phabricator favicon

### DIFF
--- a/modules/phabricator/data/config.yaml
+++ b/modules/phabricator/data/config.yaml
@@ -3,6 +3,12 @@ ui.logo:
   'logoImagePHID': 'PHID-FILE-gtm67dpburyr56ogaqay'
   'wordmarkText': 'Miraheze'
 
+# favicon
+ui.favicons:
+  'source': 'PHID-FILE-gtm67dpburyr56ogaqay'
+  'width': 80
+  'height': 80
+
 # MySQL
 mysql.port: 3306
 mysql.user: 'phabricator'


### PR DESCRIPTION
Config documentation is limited to https://secure.phabricator.com/T13103#237103