### PR TITLE
prevent mw-admins from using swift --delete all

### DIFF
--- a/modules/users/data/data.yaml
+++ b/modules/users/data/data.yaml
@@ -14,7 +14,8 @@ groups:
                  'ALL = (ALL) NOPASSWD: /usr/sbin/service jobrunner *',
                  'ALL = (ALL) NOPASSWD: /usr/sbin/service jobchron *',
                  'ALL = (ALL) NOPASSWD: /usr/bin/puppet *',
-                 'ALL = (ALL) NOPASSWD: /bin/journalctl *']
+                 'ALL = (ALL) NOPASSWD: /bin/journalctl *',
+                 'ALL = (ALL) !/etc/swift --delete all]
   mediawiki-roots:
     gid: 2002
     description: full root on MediaWiki servers


### PR DESCRIPTION
There would never be any need to use it, inherently dangerous command