### PR TITLE
allow ssl-admins to run puppet on ns* via Salt for T7582

### DIFF
--- a/hieradata/hosts/ns1.yaml
+++ b/hieradata/hosts/ns1.yaml
@@ -1,2 +1,3 @@
 puppetserver_hostname: 'puppet141.miraheze.org'
 dns: true
+ssl_admins::puppetns: true

--- a/hieradata/hosts/ns2.yaml
+++ b/hieradata/hosts/ns2.yaml
@@ -1,2 +1,3 @@
 puppetserver_hostname: 'puppet141.miraheze.org'
 dns: true
+ssl_admins::puppetns: true

--- a/modules/salt/manifests/ssl-admins.pp
+++ b/modules/salt/manifests/ssl-admins.pp
@@ -1,0 +1,18 @@
+class ssl_admins::puppetns {
+
+  file { '/usr/bin/puppet agent -tv':
+    ensure  => 'file',
+    owner   => 'root',
+    group   => 'ssl-admins',
+    mode    => '0440',
+    content => "puppet agent -t",
+  }
+
+  salt_cmd { 'run_puppet':
+    command  => '/usr/bin/puppet agent -tv',
+    user     => 'root',
+    group    => 'ssl-admins',
+    require  => File['/usr/bin/puppet agent -tv'],
+  }
+
+}


### PR DESCRIPTION
As a disclaimer this could either be completely wrong, not work or not be the correct way to do it but I thought I might as well give it a try.