### PR TITLE
T10285: Set Content-Disposition header on static.miraheze.org requests containing ?download

### DIFF
--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -197,6 +197,14 @@ sub mw_request {
 		if (req.method == "OPTIONS" && req.http.Origin) {
 			return (synth(200, "CORS Preflight"));
 		}
+		# From Wikimedia: https://gerrit.wikimedia.org/r/c/operations/puppet/+/120617/7/templates/varnish/upload-frontend.inc.vcl.erb
+		# required for Extension:MultiMediaViewer: T10285
+		if (req.url ~ "(?i)(\?|&)download(=|&|$)") {
+			/* Pretend that the parameter wasn't there for caching purposes */
+			set req.url = regsub(req.url, "(?i)(\?|&)download(=[^&]+)?$", "");
+			set req.url = regsub(req.url, "(?i)(\?|&)download(=[^&]+)?&", "\1");
+			set req.http.X-Content-Disposition = "attachment";
+		}
 	}
 
 	# Don't cache a non-GET or HEAD request

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -203,7 +203,7 @@ sub mw_request {
 			/* Pretend that the parameter wasn't there for caching purposes */
 			set req.url = regsub(req.url, "(?i)(\?|&)download(=[^&]+)?$", "");
 			set req.url = regsub(req.url, "(?i)(\?|&)download(=[^&]+)?&", "\1");
-			set req.http.X-Content-Disposition = "attachment";
+			set req.http.Content-Disposition = "attachment";
 		}
 	}
 

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -203,7 +203,7 @@ sub mw_request {
 			/* Pretend that the parameter wasn't there for caching purposes */
 			set req.url = regsub(req.url, "(?i)(\?|&)download(=[^&]+)?$", "");
 			set req.url = regsub(req.url, "(?i)(\?|&)download(=[^&]+)?&", "\1");
-			set req.http.Content-Disposition = "attachment";
+			set req.http.X-Content-Disposition = "attachment";
 		}
 	}
 
@@ -553,6 +553,10 @@ sub vcl_deliver {
 	# Identify uncacheable content
 	if (obj.uncacheable) {
 		set resp.http.X-Cache = resp.http.X-Cache + " UNCACHEABLE";
+	}
+
+	if (req.http.X-Content-Disposition == "attachment") {
+		set resp.http.Content-Disposition = "attachment";
 	}
 
 	return (deliver);


### PR DESCRIPTION
This pull request sets Content-Disposition: attachment on requests at static.miraheze.org that contain ?download.

This is required by Extension:MultiMediaViewer in order to actually download the file: see https://phabricator.miraheze.org/T10285.

The code is from Gilles <gdubuc@wikimedia.org> (https://gerrit.wikimedia.org/r/c/operations/puppet/+/120617), I just ported it to Miraheze.