### PR TITLE
Do not cache OAuth2 requests

### DIFF
--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -234,7 +234,7 @@ sub mw_request {
 	}
 
 	# A requet via OAuth should not be cached or use a cached response elsewhere
-	if (req.http.Authorization ~ "OAuth") {
+	if (req.http.Authorization ~ "OAuth" || req.http.Authorization ~ "Bearer") {
 		return (pass);
 	}
 


### PR DESCRIPTION
Currently, Varnish doesn't cache OAuth1 requests, via looking for the OAuth string in the Authorization header. This only matches OAuth1 requests, not OAuth2 requests.

This PR fixes that by looking for the "Bearer" string in the Authorization header, which is included in OAuth2 requests.

For reference, OAuth2's Authorization header looks like this: Authorization: Bearer (OAuth2 token)