### PR TITLE
Use SRI when fetching Bootstrap CSS

### DIFF
--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -603,7 +603,7 @@ sub vcl_backend_error {
 			<meta name="description" content="Backend Fetch Failed" />
 			<title>"} + beresp.status + " " + beresp.reason + {"</title>
 			<!-- Bootstrap core CSS -->
-			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" />
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" />
 			<style>
 				/* Error Page Inline Styles */
 				body {


### PR DESCRIPTION
This PR modifies the HTML shown on "Backend Fetch Failed" errors to use SRI when retrieving the Bootstrap CSS from jsdelivr. SubResource Integrity is a security measure to be used when retrieving content on CDNs to prevent a series of possible attacks. For an introduction on SRI, see https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity.

The hash is a SHA-384 hash created by me using OpenSSL 3.0.7. I generated it from both the Bootstrap GitHub 4.6.0 release (https://github.com/twbs/bootstrap/releases/tag/v4.6.0) and the file offered for download by jsdelivr, both returning the same hash.