### PR TITLE
mirahezerenewssl.py: raise logging level to info

### DIFF
--- a/modules/ssl/files/mirahezerenewssl.py
+++ b/modules/ssl/files/mirahezerenewssl.py
@@ -8,7 +8,7 @@ import os
 
 app = Flask(__name__)
 
-logging.basicConfig(filename='/var/log/ssl/miraheze-renewal.log', format='%(asctime)s - %(message)s', level=logging.DEBUG, force=True)
+logging.basicConfig(filename='/var/log/ssl/miraheze-renewal.log', format='%(asctime)s - %(message)s', level=logging.INFO, force=True)
 
 
 @app.route('/renew', methods=['POST'])


### PR DESCRIPTION
the filelock library generates debug level logging statements for every lock interaction. This may not seem like much, but every process waiting for the lock will attempt to acquire it every 0.05 seconds, meaning a log line will be generated for every process every 0.05 seconds. ssl-acme can take over 8 minutes to run in some cases (based on current puppet141 logs). This means that 450 processes (equivalent to the number of certs that need to be renewed) would generate over 300MB of logs in 8 minutes. This would seem to be the cause of T10458