### PR TITLE
monitoring: switch from using manage_repo to manage_repos param

### DIFF
--- a/modules/monitoring/manifests/init.pp
+++ b/modules/monitoring/manifests/init.pp
@@ -59,8 +59,8 @@ class monitoring (
     )
 
     class { '::icinga2':
-        manage_repo => true,
-        constants   => {
+        manage_repos => true,
+        constants    => {
             'TicketSalt' => $ticket_salt
         }
     }


### PR DESCRIPTION
manage_repo is deprecated and recommends using manage_repos.