### PR TITLE
Only run MediaWiki XML backups on mwtask141, not test131 also

### DIFF
--- a/modules/mediawiki/manifests/jobqueue/runner.pp
+++ b/modules/mediawiki/manifests/jobqueue/runner.pp
@@ -77,6 +77,22 @@ class mediawiki::jobqueue::runner {
                 user    => 'www-data',
                 special => 'daily',
             }
+
+            cron { 'backups-mediawiki-xml':
+                ensure   => present,
+                command  => '/usr/local/bin/miraheze-backup backup mediawiki-xml > /var/log/mediawiki-xml-backup.log 2>&1',
+                user     => 'root',
+                minute   => '0',
+                hour     => '1',
+                monthday => ['27'],
+                month    => ['3', '6', '9', '12']
+            }
+
+            monitoring::nrpe { 'Backups MediaWiki XML':
+                command  => '/usr/lib/nagios/plugins/check_file_age -w 8640000 -c 11232000 -f /var/log/mediawiki-xml-backup.log',
+                docs     => 'https://meta.miraheze.org/wiki/Backups#General_backup_Schedules',
+                critical => true
+            }
         }
 
         cron { 'update_statistics':
@@ -104,22 +120,6 @@ class mediawiki::jobqueue::runner {
             minute   => '0',
             hour     => '5',
             monthday => [ '6', '21' ],
-        }
-
-        cron { 'backups-mediawiki-xml':
-            ensure   => present,
-            command  => '/usr/local/bin/miraheze-backup backup mediawiki-xml > /var/log/mediawiki-xml-backup.log 2>&1',
-            user     => 'root',
-            minute   => '0',
-            hour     => '1',
-            monthday => ['27'],
-            month    => ['3', '6', '9', '12']
-        }
-
-        monitoring::nrpe { 'Backups MediaWiki XML':
-            command  => '/usr/lib/nagios/plugins/check_file_age -w 8640000 -c 11232000 -f /var/log/mediawiki-xml-backup.log',
-            docs     => 'https://meta.miraheze.org/wiki/Backups#General_backup_Schedules',
-            critical => true
         }
     }
 

--- a/modules/mediawiki/manifests/jobqueue/runner.pp
+++ b/modules/mediawiki/manifests/jobqueue/runner.pp
@@ -58,7 +58,7 @@ class mediawiki::jobqueue::runner {
             month   => '*',
             weekday => [ '6' ],
         }
-        
+
         if $wiki == 'loginwiki' {
             $swift_password = lookup('mediawiki::swift_password')
             cron { 'generate sitemap index':


### PR DESCRIPTION
No need to run on test131, when wiki is set to betawiki, move the backups (and monitoring) up, so they are not on test131, and icinga does not alert `FILE_AGE CRITICAL: File not found - /var/log/mediawiki-xml-backup.log` for test131