### PR TITLE
python: upgrade CI, support bookworm

### DIFF
--- a/.github/pythonchecks.txt
+++ b/.github/pythonchecks.txt
@@ -19,9 +19,11 @@ mypy==0.931
 types-requests==2.27.7
 pytest-xdist==2.5.0
 ## ACTUAL
-requests==2.27.1
+requests==2.27.1; python_version < '3.10'
+requests==2.28.1; python_version > '3.9'
 filelock==3.0.12; python_version < '3.10'
 types-filelock; python_version < '3.10'
-filelock==3.7.0; python_version > '3.9'
+filelock==3.9.0; python_version > '3.9'
 langcodes==3.3.0
-internetarchive==3.0.2
+internetarchive==3.0.2; python_version < '3.10'
+internetarchive==3.3.0; python_version > '3.9'

--- a/.github/pythonchecks.txt
+++ b/.github/pythonchecks.txt
@@ -7,7 +7,7 @@ flake8-sfs==0.0.4
 flake8-builtins==2.1.0
 flake8-commas==2.1.0
 flake8-comprehensions==3.11.1
-flake8-eradicate==1.4.0
+#flake8-eradicate==1.4.0 - doesn't support flake8 6
 flake8-fixme==1.1.1
 flake8-multiline-containers==0.0.19
 flake8-pytest-style==1.7.2

--- a/.github/pythonchecks.txt
+++ b/.github/pythonchecks.txt
@@ -1,23 +1,23 @@
 ## TESTING ONLY
-pytest==6.2.5
-wheel==0.37.1
-flake8==4.0.1
-flake8-unused-arguments==0.0.9
-flake8-sfs==0.0.3
-flake8-builtins==1.5.3
+pytest==7.2.2
+wheel==0.40.0
+flake8==6.0.0
+flake8-unused-arguments==0.0.13
+flake8-sfs==0.0.4
+flake8-builtins==2.1.0
 flake8-commas==2.1.0
-flake8-comprehensions==3.8.0
-flake8-eradicate==1.2.0
+flake8-comprehensions==3.11.1
+flake8-eradicate==1.4.0
 flake8-fixme==1.1.1
-flake8-multiline-containers==0.0.18
-flake8-pytest-style==1.6.0
-flake8-return==1.1.3
-flake8-quotes==3.3.1
-flake8-simplify==0.15.1
+flake8-multiline-containers==0.0.19
+flake8-pytest-style==1.7.2
+flake8-return==1.2.0
+flake8-quotes==3.3.2
+flake8-simplify==0.20.0
 flake8-pytest==1.3
-mypy==0.931
+mypy==1.1.1
 types-requests==2.27.7
-pytest-xdist==2.5.0
+pytest-xdist==3.2.1
 ## ACTUAL
 requests==2.27.1; python_version < '3.10'
 requests==2.28.1; python_version > '3.9'

--- a/.github/pythonchecks.txt
+++ b/.github/pythonchecks.txt
@@ -14,7 +14,7 @@ flake8-pytest-style==1.7.2
 flake8-return==1.2.0
 flake8-quotes==3.3.2
 flake8-simplify==0.20.0
-flake8-pytest==1.3
+flake8-pytest==1.4
 mypy==1.1.1
 types-requests==2.27.7
 pytest-xdist==3.2.1

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.9', '3.10']
+        python: ['3.9', '3.11']
     steps:
       - uses: actions/checkout@v3
       - name: Python ${{ matrix.python }}

--- a/modules/mediawiki/files/bin/deploy-mediawiki.py
+++ b/modules/mediawiki/files/bin/deploy-mediawiki.py
@@ -1,7 +1,7 @@
 #! /usr/bin/python3
 
 import argparse
-from typing import Optional, Union, TypedDict
+from typing import Optional, TypedDict
 import os
 import time
 import requests

--- a/modules/mediawiki/files/bin/deploy-mediawiki.py
+++ b/modules/mediawiki/files/bin/deploy-mediawiki.py
@@ -139,7 +139,7 @@ def _get_deployed_path(repo: str) -> str:
     return f'/srv/mediawiki/{repos[repo]}/'
 
 
-def _construct_rsync_command(time: str, dest: str, recursive: bool = True, local: bool = True, location: Union[None, str] = None, server: Union[None, str] = None) -> str:
+def _construct_rsync_command(time: str, dest: str, recursive: bool = True, local: bool = True, location: Optional[str] = None, server: Optional[str] = None) -> str:
     if time:
         params = '--inplace'
     else:


### PR DESCRIPTION
Check python 3.11 instead to match likely next debian version