### PR TITLE
Patch-LimitCargoDB

### DIFF
--- a/modules/mariadb/templates/grants/mediawiki-grants.sql.erb
+++ b/modules/mariadb/templates/grants/mediawiki-grants.sql.erb
@@ -32,9 +32,14 @@ GRANT SELECT, INSERT, UPDATE, DELETE, DROP, ALTER
 
 -- Grants for 'cargouser'@''
 
+GRANT USAGE
+    ON *.* TO 'cargouser'@'%'
+    IDENTIFIED BY '<%= @mediawiki_password %>'
+    REQUIRE SSL
+    WITH MAX_STATEMENT_TIME 600;
+
 GRANT SELECT, INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, INDEX, CREATE VIEW, LOCK TABLES
-    on `%wiki`.* TO 'cargouser'@'%'
-    IDENTIFIED BY '<%= @mediawiki_password %>';
+    on `%wikicargo`.* TO 'cargouser'@'%';
 
 -- Grants for 'wikiadmin'@''
 

--- a/modules/mariadb/templates/grants/mediawiki-grants.sql.erb
+++ b/modules/mariadb/templates/grants/mediawiki-grants.sql.erb
@@ -35,11 +35,10 @@ GRANT SELECT, INSERT, UPDATE, DELETE, DROP, ALTER
 GRANT USAGE
     ON *.* TO 'cargouser'@'%'
     IDENTIFIED BY '<%= @mediawiki_password %>'
-    REQUIRE SSL
     WITH MAX_STATEMENT_TIME 600;
 
 GRANT SELECT, INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, INDEX, CREATE VIEW, LOCK TABLES
-    on `%wikicargo`.* TO 'cargouser'@'%';
+    on `%cargo`.* TO 'cargouser'@'%';
 
 -- Grants for 'wikiadmin'@''
 


### PR DESCRIPTION
SSL is apparently not compatible with cargo
%wikicargo does not support beta, and there shouldn't be any other %cargo databases