### PR TITLE
Return Varnish's default 200 response on all requests to static

### DIFF
--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -308,6 +308,11 @@ sub vcl_recv {
 		}
 	}
 
+	# Temporary: Return a 200 response on all static.miraheze.org requests without consulting the backends
+	if (req.http.Host == "static.miraheze.org") {
+		return(synth(200));
+	}
+
 	# Do not cache requests from this domain
 	if (req.http.Host == "icinga.miraheze.org" || req.http.Host == "grafana.miraheze.org") {
 		set req.backend_hint = mon141;


### PR DESCRIPTION
This should fix the NGINX error rate, and also avoid contacting the backends for static.miraheze.org, as no images will be returned anyway (https://phabricator.miraheze.org/T10717).