### PR TITLE
graylog: set ignore_migration_failures

### DIFF
--- a/modules/role/manifests/graylog.pp
+++ b/modules/role/manifests/graylog.pp
@@ -30,6 +30,7 @@ class role::graylog {
             'password_secret'     => lookup('passwords::graylog::password_secret'),
             'root_password_sha2'  => lookup('passwords::graylog::root_password_sha2'),
             'elasticsearch_hosts' => $elasticsearch_host,
+            'ignore_migration_failures' => true,
         }
     }
 


### PR DESCRIPTION
For some reason migrating from graylog121 to 131 is causing issues with the index (migration).

https://github.com/Graylog2/graylog2-server/issues/12963