### PR TITLE
betawiki -> metawikibeta in deploy-mediawiki

### DIFF
--- a/modules/mediawiki/files/bin/deploy-mediawiki.py
+++ b/modules/mediawiki/files/bin/deploy-mediawiki.py
@@ -26,8 +26,8 @@ class EnvironmentList(TypedDict):
 
 
 beta: Environment = {
-    'wikidbname': 'betawiki',
-    'wikiurl': 'beta.betaheze.org',
+    'wikidbname': 'metawikibeta',
+    'wikiurl': 'meta.betaheze.org',
     'servers': ['test131'],
 }
 prod: Environment = {


### PR DESCRIPTION
betawiki has been replaced by metawikibeta in Betaheze. Replacing this will also fix https://phabricator.miraheze.org/T10715