### PR TITLE
nginx: remove use of ipv6only

### DIFF
--- a/modules/matomo/files/nginx.conf
+++ b/modules/matomo/files/nginx.conf
@@ -1,6 +1,6 @@
 server {
 	listen 80;
-	listen [::]:80 ipv6only=on;
+	listen [::]:80;
 
 	server_name ~.;
 
@@ -19,7 +19,7 @@ server {
 
 server {
 	listen 443 ssl http2;
-	listen [::]:443 ssl http2 ipv6only=on;
+	listen [::]:443 ssl http2;
 
 	server_name matomo.miraheze.org;
 

--- a/modules/mediawiki/templates/mediawiki.conf.erb
+++ b/modules/mediawiki/templates/mediawiki.conf.erb
@@ -1,9 +1,9 @@
 server {
 	# We can only set backlog once per port (so this will be applied to the others below)
 	listen 80 deferred backlog=4096;
-	listen [::]:80 deferred ipv6only=on backlog=4096;
+	listen [::]:80 deferred backlog=4096;
 	listen 443 ssl deferred http2 backlog=4096;
-	listen [::]:443 deferred ssl http2 ipv6only=on backlog=4096;
+	listen [::]:443 deferred ssl http2 backlog=4096;
 
 	server_name miraheze.org;
 	root /srv/mediawiki/landing;

--- a/modules/mediawiki/templates/shellbox.internal.erb
+++ b/modules/mediawiki/templates/shellbox.internal.erb
@@ -1,6 +1,6 @@
 server {
 	listen *:8080;
-	listen [::]:8080 ipv6only=on;
+	listen [::]:8080;
 
 	server_name shellbox.internal;
 	root /srv/shellbox/public_html;

--- a/modules/reports/files/nginx.conf
+++ b/modules/reports/files/nginx.conf
@@ -1,6 +1,6 @@
 server {
 	listen 80;
-	listen [::]:80 ipv6only=on;
+	listen [::]:80;
 
 	server_name ~.;
 
@@ -19,7 +19,7 @@ server {
 
 server {
 	listen 443 ssl http2;
-	listen [::]:443 ssl http2 ipv6only=on;
+	listen [::]:443 ssl http2;
 
 	server_name reports.miraheze.org;
 

--- a/modules/role/files/elasticsearch/nginx.conf
+++ b/modules/role/files/elasticsearch/nginx.conf
@@ -1,5 +1,5 @@
 server {
-	listen [::]:443 ssl http2 deferred ipv6only=on;
+	listen [::]:443 ssl http2 deferred;
 
 	server_name elasticsearch.miraheze.org;
 

--- a/modules/role/files/opensearch/nginx.conf
+++ b/modules/role/files/opensearch/nginx.conf
@@ -1,5 +1,5 @@
 server {
-	listen [::]:443 ssl http2 deferred ipv6only=on;
+	listen [::]:443 ssl http2 deferred;
 
 	server_name opensearch.miraheze.org;
 

--- a/modules/ssl/files/nginx.conf
+++ b/modules/ssl/files/nginx.conf
@@ -1,8 +1,8 @@
 server {
 	listen 80;
-	listen [::]:80 ipv6only=on;
+	listen [::]:80;
 	listen 443 ssl http2;
-	listen [::]:443 ssl http2 ipv6only=on;
+	listen [::]:443 ssl http2;
 
 	server_name miraheze.org;
 	root /var/www/html;

--- a/modules/swift/files/nginx/swift.conf
+++ b/modules/swift/files/nginx/swift.conf
@@ -1,6 +1,6 @@
 server {
 	listen 443 default_server deferred backlog=4096 reuseport ssl;
-	listen [::]:443 default_server deferred backlog=4096 reuseport ipv6only=on ssl;
+	listen [::]:443 default_server deferred backlog=4096 reuseport ssl;
 
 	server_name swift-lb.miraheze.org;
 

--- a/modules/varnish/templates/mediawiki.conf
+++ b/modules/varnish/templates/mediawiki.conf
@@ -5,7 +5,7 @@ map $http_upgrade $connection_upgrade {
 
 server {
 	listen 80 deferred;
-	listen [::]:80 deferred ipv6only=on;
+	listen [::]:80 deferred;
 
 	server_name ~.;
 
@@ -38,7 +38,7 @@ server {
 server {
 	# We can only set backlog once per port (so this will be applied to the others below)
 	listen 443 ssl http2 deferred backlog=16384;
-	listen [::]:443 ssl http2 deferred  backlog=16384 ipv6only=on;
+	listen [::]:443 ssl http2 deferred  backlog=16384;
 
 	server_name miraheze.org *.miraheze.org;
 	root /var/www/html;


### PR DESCRIPTION
this option is enabled by default on all sockets and seems to cause nginx to panic when declaired multiple times