### PR TITLE
remove /etc/cron.daily/apt

### DIFF
--- a/modules/base/manifests/upgrades.pp
+++ b/modules/base/manifests/upgrades.pp
@@ -15,10 +15,4 @@ class base::upgrades {
         source  => 'puppet:///modules/base/apt/20auto-upgrades',
         require => Package['unattended-upgrades'],
     }
-
-    # http://askubuntu.com/a/556169
-    file { '/etc/cron.daily/apt':
-        ensure => 'link',
-        target => '/etc/cron.daily/apt.disabled',
-    }
 }


### PR DESCRIPTION
the link target doesn't seem to exist on new servers, and /etc/cron.daily/apt seems to have been replaced with /etc/cron.daily/apt-compat (there may also be something in systemd that supersedes that)