### PR TITLE
mariadb remove read-only on startup

### DIFF
--- a/modules/mariadb/templates/config/mw.cnf.erb
+++ b/modules/mariadb/templates/config/mw.cnf.erb
@@ -16,10 +16,6 @@ bind-address                   = ::
 key-buffer-size                = 16M
 myisam-recover-options         = FORCE,BACKUP
 
-# Default to read only on startup.
-# Unset it by doing `set global read_only = 0`
-read_only                      = 1
-
 max-allowed-packet             = 64M
 max-connect-errors             = 1000000
 sql-mode                       = STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_AUTO_VALUE_ON_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE


### PR DESCRIPTION
mysql should automatically handle error recovery. There's no sense making it read-only especially if we don't have a procedure in place to validate the database after it's started up.

The only use case I can think of for having read-only on startup is for doing maintenance where the server is expected to restart, but we don't want any changes after the restart.