### PR TITLE
Allow mediawiki-admins to restart Nutcracker

### DIFF
--- a/modules/users/data/data.yaml
+++ b/modules/users/data/data.yaml
@@ -10,6 +10,7 @@ groups:
     members: [agent, macfan]
     privileges: ['ALL = (www-data) NOPASSWD: ALL',
                  'ALL = (ALL) NOPASSWD: /usr/sbin/service nginx *',
+                 'ALL = (ALL) NOPASSWD: /usr/sbin/service nutcracker *',
                  'ALL = (ALL) NOPASSWD: /usr/sbin/service php7.4-fpm *',
                  'ALL = (ALL) NOPASSWD: /usr/sbin/service jobrunner *',
                  'ALL = (ALL) NOPASSWD: /usr/sbin/service jobchron *',


### PR DESCRIPTION
mw-admins already have the ability to restart PHP and Nginx so this shouldn't be a huge escalation.