### PR TITLE
Monitor parsoid warming jobs

### DIFF
--- a/modules/prometheus/files/redis/jobQueueCollector.lua
+++ b/modules/prometheus/files/redis/jobQueueCollector.lua
@@ -47,6 +47,7 @@ local jobs = {
 	'MoveTranslatableBundleJob',
 	'NamespaceMigrationJob',
 	'PageProperties',
+	'parsoidCachePrewarm',
 	'PublishStashedFile',
 	'PurgeEntityData',
 	'RecordLintJob',


### PR DESCRIPTION
Per https://grafana.wikimedia.org/d/CbmStnlGk/jobqueue-job?orgId=1&var-dc=eqiad%20prometheus%2Fk8s&var-job=parsoidCachePrewarm&from=now-12h&to=now for https://github.com/miraheze/mw-config/pull/5245