### PR TITLE
mariadb: innodb_flush_neighbors set to 0

### DIFF
--- a/modules/mariadb/templates/config/mw.cnf.erb
+++ b/modules/mariadb/templates/config/mw.cnf.erb
@@ -62,6 +62,7 @@ wait_timeout                   = 3600
 
 innodb-flush-method            = O_DIRECT
 innodb_thread_concurrency      = 0
+innodb_flush_neighbors         = 0
 innodb_io_capacity             = 1000
 innodb_stats_method            = nulls_unequal
 innodb-log-file-size           = 256M


### PR DESCRIPTION
We use SSDs so can set this to 0.