### PR TITLE
mariadb: increase table cache size

### DIFF
--- a/modules/mariadb/templates/config/mw.cnf.erb
+++ b/modules/mariadb/templates/config/mw.cnf.erb
@@ -42,8 +42,8 @@ tmp-table-size                 = 64M
 max-heap-table-size            = 64M
 max-connections                = <%= @max_connections %>
 open-files-limit               = 200000
-table_open_cache               = 50000
-table_definition_cache         = 40000
+table_open_cache               = 80000
+table_definition_cache         = 50000
 
 # thread and connection handling
 thread_handling                = pool-of-threads


### PR DESCRIPTION
Increases definition cache size to 50k and open cache to 80k