### PR TITLE
mariadb: set table_open_cache to 50k

### DIFF
--- a/modules/mariadb/templates/config/mw.cnf.erb
+++ b/modules/mariadb/templates/config/mw.cnf.erb
@@ -42,7 +42,7 @@ tmp-table-size                 = 64M
 max-heap-table-size            = 64M
 max-connections                = <%= @max_connections %>
 open-files-limit               = 200000
-table_open_cache               = 100000
+table_open_cache               = 50000
 table_definition_cache         = 100000
 
 # thread and connection handling


### PR DESCRIPTION
We fixed the open files limit so can now set table_open_cache to 50k. Which in conjunction with table_open_cache_instances will equal 800k. (50k x 8 x 2 = 800).

We will keep table_open_cache at 100k on the dbs as the open file limit hasn't been applied as it requires a restart of service.
https://dba.stackexchange.com/questions/283064/server-with-mariadb-sometimes-dies-under-high-load