### PR TITLE
mediawiki: fix running the cron on beta

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -12,6 +12,7 @@ mediawiki::is_canary: false
 mediawiki::default_sync: 'all'
 mediawiki::use_shellbox: false
 mediawiki::jobqueue::wiki: 'loginwiki'
+mediawiki::jobqueue::runner::beta: false
 mediawiki::monitoring::host: 'login.miraheze.org'
 memcached_servers_1:
   - 2a10:6740::6:510:11211:1

--- a/hieradata/hosts/test131.yaml
+++ b/hieradata/hosts/test131.yaml
@@ -8,7 +8,7 @@ jobrunner: true
 mediawiki::jobqueue::runner::beta: true
 mediawiki::jobqueue::runner::cron: true
 mediawiki::jobqueue::runner::redis_ip: '[2a10:6740::6:406]:6379'
-mediawiki::jobqueue::wiki: 'metawikibeta'
+mediawiki::jobqueue::wiki: 'loginwikibeta'
 
 role::mediawiki::use_strict_firewall: true
 vpncloud::server_ip: 10.0.1.7

--- a/hieradata/hosts/test131.yaml
+++ b/hieradata/hosts/test131.yaml
@@ -5,6 +5,7 @@ users::groups:
 contactgroups: ['sre', 'mediawiki']
 
 jobrunner: true
+mediawiki::jobqueue::runner::beta: true
 mediawiki::jobqueue::runner::cron: true
 mediawiki::jobqueue::runner::redis_ip: '[2a10:6740::6:406]:6379'
 mediawiki::jobqueue::wiki: 'metawikibeta'

--- a/modules/mediawiki/manifests/jobqueue/runner.pp
+++ b/modules/mediawiki/manifests/jobqueue/runner.pp
@@ -69,7 +69,7 @@ class mediawiki::jobqueue::runner {
 
         cron { 'generate sitemaps for all wikis':
             ensure  => present,
-            command => "/usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/${database} /srv/mediawiki/w/extensions/MirahezeMagic/maintenance/generateMirahezeSitemap.php",
+            command => "/usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/${database}.json /srv/mediawiki/w/extensions/MirahezeMagic/maintenance/generateMirahezeSitemap.php",
             user    => 'www-data',
             minute  => '0',
             hour    => '0',

--- a/modules/mediawiki/manifests/jobqueue/runner.pp
+++ b/modules/mediawiki/manifests/jobqueue/runner.pp
@@ -8,8 +8,8 @@ class mediawiki::jobqueue::runner {
 
     $beta = lookup('mediawiki::jobqueue::runner::beta')
     $database = $beta ? {
-      true    => 'databases',
-      default => 'beta',
+      true    => 'beta',
+      default => 'databases',
     }
     $sf_wiki = $beta ? {
         true => 'metawikibeta',

--- a/modules/mediawiki/manifests/jobqueue/runner.pp
+++ b/modules/mediawiki/manifests/jobqueue/runner.pp
@@ -59,7 +59,7 @@ class mediawiki::jobqueue::runner {
 
         cron { 'update rottenlinks on all wikis':
             ensure   => present,
-            command  => \"/usr/local/bin/fileLockScript.sh /tmp/rotten_links_file_lock \"/usr/bin/nice -n 15 /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/${database}.json /srv/mediawiki/w/extensions/RottenLinks/maintenance/updateExternalLinks.php\"\",
+            command  => "/usr/local/bin/fileLockScript.sh /tmp/rotten_links_file_lock '/usr/bin/nice -n 15 /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/${database}.json /srv/mediawiki/w/extensions/RottenLinks/maintenance/updateExternalLinks.php'",
             user     => 'www-data',
             minute   => '0',
             hour     => '0',

--- a/modules/mediawiki/manifests/jobqueue/runner.pp
+++ b/modules/mediawiki/manifests/jobqueue/runner.pp
@@ -58,7 +58,7 @@ class mediawiki::jobqueue::runner {
 
         cron { 'update rottenlinks on all wikis':
             ensure   => present,
-            command  => "/usr/local/bin/fileLockScript.sh /tmp/rotten_links_file_lock '/usr/bin/nice -n 15 /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/${database}.json /srv/mediawiki/w/extensions/RottenLinks/maintenance/updateExternalLinks.php'",
+            command  => "/usr/local/bin/fileLockScript.sh /tmp/rotten_links_file_lock \'/usr/bin/nice -n 15 /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/${database}.json /srv/mediawiki/w/extensions/RottenLinks/maintenance/updateExternalLinks.php\'",
             user     => 'www-data',
             minute   => '0',
             hour     => '0',

--- a/modules/mediawiki/manifests/jobqueue/runner.pp
+++ b/modules/mediawiki/manifests/jobqueue/runner.pp
@@ -59,7 +59,7 @@ class mediawiki::jobqueue::runner {
 
         cron { 'update rottenlinks on all wikis':
             ensure   => present,
-            command  => \"/usr/local/bin/fileLockScript.sh /tmp/rotten_links_file_lock "/usr/bin/nice -n 15 /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/${database}.json /srv/mediawiki/w/extensions/RottenLinks/maintenance/updateExternalLinks.php"\",
+            command  => \"/usr/local/bin/fileLockScript.sh /tmp/rotten_links_file_lock \"/usr/bin/nice -n 15 /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/${database}.json /srv/mediawiki/w/extensions/RottenLinks/maintenance/updateExternalLinks.php\"\",
             user     => 'www-data',
             minute   => '0',
             hour     => '0',

--- a/modules/mediawiki/manifests/jobqueue/runner.pp
+++ b/modules/mediawiki/manifests/jobqueue/runner.pp
@@ -4,7 +4,6 @@
 class mediawiki::jobqueue::runner {
     include mediawiki::jobqueue::shared
     $wiki = lookup('mediawiki::jobqueue::wiki')
-    $wiki = lookup('mediawiki::jobqueue::runner::beta')
     ensure_packages('python3-xmltodict')
 
     $beta = lookup('mediawiki::jobqueue::runner::beta')

--- a/modules/mediawiki/manifests/jobqueue/runner.pp
+++ b/modules/mediawiki/manifests/jobqueue/runner.pp
@@ -112,9 +112,19 @@ class mediawiki::jobqueue::runner {
             }
         }
 
+
+        if $wiki == 'loginwikibeta' {
+            cron { 'purge_parsercache':
+                ensure  => present,
+                command => '/usr/bin/php /srv/mediawiki/w/maintenance/purgeParserCache.php --age 864000 --msleep 200 --wiki loginwikibeta',
+                user    => 'www-data',
+                special => 'daily',
+            }
+        }
+
         cron { 'update_statistics':
             ensure   => present,
-            command  => '/usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/databases.json /srv/mediawiki/w/maintenance/initSiteStats.php --update --active > /dev/null',
+            command  => "/usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/${database}.json /srv/mediawiki/w/maintenance/initSiteStats.php --update --active > /dev/null",
             user     => 'www-data',
             minute   => '0',
             hour     => '5',
@@ -123,7 +133,7 @@ class mediawiki::jobqueue::runner {
 
         cron { 'update_sites':
             ensure   => present,
-            command  => '/usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/databases.json /srv/mediawiki/w/extensions/MirahezeMagic/maintenance/populateWikibaseSitesTable.php > /dev/null',
+            command  => "/usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/${database}.json /srv/mediawiki/w/extensions/MirahezeMagic/maintenance/populateWikibaseSitesTable.php > /dev/null",
             user     => 'www-data',
             minute   => '0',
             hour     => '5',
@@ -132,7 +142,7 @@ class mediawiki::jobqueue::runner {
 
         cron { 'clean_gu_cache':
             ensure   => present,
-            command  => '/usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/databases.json /srv/mediawiki/w/extensions/GlobalUsage/maintenance/refreshGlobalimagelinks.php --pages=existing,nonexisting > /dev/null',
+            command  => "/usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/${database}.json /srv/mediawiki/w/extensions/GlobalUsage/maintenance/refreshGlobalimagelinks.php --pages=existing,nonexisting > /dev/null",
             user     => 'www-data',
             minute   => '0',
             hour     => '5',


### PR DESCRIPTION
We don't want to run over all wikis as it'll conflict with it running on mwtask. We only want it to run on beta wikis, lets use the beta.json file for this.