### PR TITLE
mariadb: increase innodb_ft_cache_size to 150MB

### DIFF
--- a/modules/mariadb/templates/config/mw.cnf.erb
+++ b/modules/mariadb/templates/config/mw.cnf.erb
@@ -74,7 +74,7 @@ innodb-stats-on-metadata       = OFF
 # Defaults to 8000000 (8MB)
 # We set this to 150000000 (150MB)
 innodb_ft_cache_size           = 150000000
-innodb_ft_total_cache_size     = 200000000
+innodb_ft_total_cache_size     = 640000000
 innodb_adaptive_hash_index     = OFF
 # From 10.5.7+ the default has been changed to 90%.
 # Change this back to 75%.

--- a/modules/mariadb/templates/config/mw.cnf.erb
+++ b/modules/mariadb/templates/config/mw.cnf.erb
@@ -71,7 +71,10 @@ innodb-file-per-table          = 1
 innodb-buffer-pool-size        = <%= @innodb_buffer_pool_size %>
 innodb_lock_wait_timeout       = 120
 innodb-stats-on-metadata       = OFF
-innodb_ft_total_cache_size     = 150000000
+# Defaults to 8000000 (8MB)
+# We set this to 150000000 (150MB)
+innodb_ft_cache_size           = 150000000
+innodb_ft_total_cache_size     = 200000000
 innodb_adaptive_hash_index     = OFF
 # From 10.5.7+ the default has been changed to 90%.
 # Change this back to 75%.


### PR DESCRIPTION
Some wikis (larger ones) are hitting the limit and thus we need to increase it.