### PR TITLE
mariadb: set open table cache to 150k

### DIFF
--- a/modules/mariadb/templates/config/mw.cnf.erb
+++ b/modules/mariadb/templates/config/mw.cnf.erb
@@ -42,8 +42,8 @@ tmp-table-size                 = 64M
 max-heap-table-size            = 64M
 max-connections                = <%= @max_connections %>
 open-files-limit               = 200000
-table_open_cache               = 500000
-table_definition_cache         = 250400
+table_open_cache               = 100000
+table_definition_cache         = 50400
 
 # thread and connection handling
 thread_handling                = pool-of-threads

--- a/modules/mariadb/templates/config/mw.cnf.erb
+++ b/modules/mariadb/templates/config/mw.cnf.erb
@@ -42,8 +42,8 @@ tmp-table-size                 = 64M
 max-heap-table-size            = 64M
 max-connections                = <%= @max_connections %>
 open-files-limit               = 200000
-table_open_cache               = 100000
-table_definition_cache         = 50400
+table_open_cache               = 150000
+table_definition_cache         = 75400
 
 # thread and connection handling
 thread_handling                = pool-of-threads

--- a/modules/mariadb/templates/mariadb-systemd-override.conf.erb
+++ b/modules/mariadb/templates/mariadb-systemd-override.conf.erb
@@ -3,4 +3,4 @@
 TimeoutStartSec=0
 Restart=always
 # Default is 32768 in mariadb systemd service
-LimitNOFILE=8000540
+LimitNOFILE=2400540


### PR DESCRIPTION
Definition cache is set to 75k (half).

We had originally set this to 500k but because it used a lot of ram, lets lower this.