### PR TITLE
miraheze-backup: use mysqldump to backup

### DIFF
--- a/modules/base/templates/backups/miraheze-backup.py.erb
+++ b/modules/base/templates/backups/miraheze-backup.py.erb
@@ -103,10 +103,7 @@ def backup_sql(dt: str, database: str):
         os.makedirs(f'/srv/backups/dbs')
 
     for db in dbs:
-        if database is None:
-            os.system(f'/usr/bin/mysqldump --quick --skip-lock-tables -C --ignore-table={db}.objectcache --ignore-table={db}.querycache --ignore-table={db}.querycachetwo --ignore-table={db}.recentchanges --ignore-table={db}.searchindex {db} | /usr/bin/nice /usr/bin/gzip > /srv/backups/dbs/{db}.sql.gz')
-        else:
-            os.system(f'/usr/bin/mysqldump --quick -C --ignore-table={db}.objectcache --ignore-table={db}.querycache --ignore-table={db}.querycachetwo --ignore-table={db}.recentchanges --ignore-table={db}.searchindex {db} | /usr/bin/nice /usr/bin/gzip > /srv/backups/dbs/{db}.sql.gz')
+        os.system(f'/usr/bin/mysqldump --quick --skip-lock-tables -C --ignore-table={db}.objectcache --ignore-table={db}.querycache --ignore-table={db}.querycachetwo --ignore-table={db}.recentchanges --ignore-table={db}.searchindex {db} | /usr/bin/nice /usr/bin/gzip > /srv/backups/dbs/{db}.sql.gz')
 
         pca_connection().put(f'/srv/backups/dbs/{db}.sql.gz', f'sql/{db}/{dt}.sql.gz', False)
         pca_web('POST', f'https://storage.bhs.cloud.ovh.net/v1/AUTH_76f9bc606a8044e08db7ebd118f6b19a/sql/{db}/{dt}.tar.gz', 5)

--- a/modules/base/templates/backups/miraheze-backup.py.erb
+++ b/modules/base/templates/backups/miraheze-backup.py.erb
@@ -212,7 +212,7 @@ def unfreeze_backup(source: str, dt: str, database: str):
     elif source in ['grafana']:
         file = f'sql/{source}/{dt}.tar.gz'
     elif source in ['sql', 'mediawiki-xml']:
-        file = f'{source}/{database}/{dt}.tar.gz'
+        file = f'{source}/{database}/{dt}.sql.gz'
 
     pca_web('GET', f'https://storage.bhs.cloud.ovh.net/v1/AUTH_76f9bc606a8044e08db7ebd118f6b19a/{file}', 0)
     available_in = pca_web('HEAD', f'https://storage.bhs.cloud.ovh.net/v1/AUTH_76f9bc606a8044e08db7ebd118f6b19a/{file}', 0).headers.get('X-Ovh-Retrieval-Delay')

--- a/modules/base/templates/backups/miraheze-backup.py.erb
+++ b/modules/base/templates/backups/miraheze-backup.py.erb
@@ -103,7 +103,7 @@ def backup_sql(dt: str, database: str):
         os.makedirs(f'/srv/backups/dbs')
 
     for db in dbs:
-        os.system(f'/usr/bin/mysqldump --quick --skip-lock-tables -C --ignore-table={db}.objectcache --ignore-table={db}.querycache --ignore-table={db}.querycachetwo --ignore-table={db}.recentchanges --ignore-table={db}.searchindex {db} | /usr/bin/nice /usr/bin/gzip > /srv/backups/dbs/{db}.sql.gz')
+        os.system(f'/usr/bin/mysqldump --quick --skip-lock-tables --single-transaction -C --ignore-table={db}.objectcache --ignore-table={db}.querycache --ignore-table={db}.querycachetwo --ignore-table={db}.recentchanges --ignore-table={db}.searchindex {db} | /usr/bin/nice /usr/bin/gzip > /srv/backups/dbs/{db}.sql.gz')
 
         pca_connection().put(f'/srv/backups/dbs/{db}.sql.gz', f'sql/{db}/{dt}.sql.gz', False)
         pca_web('POST', f'https://storage.bhs.cloud.ovh.net/v1/AUTH_76f9bc606a8044e08db7ebd118f6b19a/sql/{db}/{dt}.tar.gz', 5)

--- a/modules/base/templates/backups/miraheze-backup.py.erb
+++ b/modules/base/templates/backups/miraheze-backup.py.erb
@@ -95,23 +95,23 @@ def backup_phabricator(dt: str):
 
 def backup_sql(dt: str, database: str):
     if database is None:
-        os.system('/usr/bin/mydumper -N -W -k --less-locking -t 4 -c -x \'^(.*wiki(?!.*(objectcache|querycache|querycachetwo|recentchanges|searchindex)))\' --trx-consistency-only -o \'/srv/backups/dbs\'')
         dbs = [file for file in os.listdir('/srv/mariadb') if os.path.isdir(f'/srv/mariadb/{file}') and file[-4:] == 'wiki']
     else:
-        os.system(f'/usr/bin/mysqldump -C --ignore-table={database}.objectcache --ignore-table={database}.querycache --ignore-table={database}.querycachetwo --ignore-table={database}.searchindex --ignore-table={database}.recentchanges {database} > /srv/backups/dbs/{database}.backup')
         dbs = [database]
 
-    for db in dbs:
-        tar = tarfile.open(f'{db}.tar.gz', 'w:gz')
-        for dbfile in glob.glob(f'/srv/backups/dbs/{db}.*'):
-            tar.add(dbfile, arcname=db)
-            os.remove(dbfile)
-        tar.close()
+    if not os.path.isdir(f'/srv/backups/dbs'):
+        os.makedirs(f'/srv/backups/dbs')
 
-        pca_connection().put(f'{db}.tar.gz', f'sql/{db}/{dt}.tar.gz', False)
+    for db in dbs:
+        if database is None:
+            os.system(f'/usr/bin/mysqldump --quick --skip-lock-tables -C --ignore-table={db}.objectcache --ignore-table={db}.querycache --ignore-table={db}.querycachetwo --ignore-table={db}.recentchanges --ignore-table={db}.searchindex {db} | /usr/bin/nice /usr/bin/gzip > /srv/backups/dbs/{db}.sql.gz')
+        else:
+            os.system(f'/usr/bin/mysqldump --quick -C --ignore-table={db}.objectcache --ignore-table={db}.querycache --ignore-table={db}.querycachetwo --ignore-table={db}.recentchanges --ignore-table={db}.searchindex {db} | /usr/bin/nice /usr/bin/gzip > /srv/backups/dbs/{db}.sql.gz')
+
+        pca_connection().put(f'/srv/backups/dbs/{db}.sql.gz', f'sql/{db}/{dt}.sql.gz', False)
         pca_web('POST', f'https://storage.bhs.cloud.ovh.net/v1/AUTH_76f9bc606a8044e08db7ebd118f6b19a/sql/{db}/{dt}.tar.gz', 5)
 
-        os.remove(f'{db}.tar.gz')
+        os.remove(f'/srv/backups/dbs/{db}.sql.gz')
 
 
 def backup_grafana_db(dt: str):
@@ -124,6 +124,7 @@ def backup_grafana_db(dt: str):
     pca_web('POST', f'https://storage.bhs.cloud.ovh.net/v1/AUTH_76f9bc606a8044e08db7ebd118f6b19a/sql/grafana/{dt}.tar.gz', 4)
 
     os.remove('grafana.tar.gz')
+    os.remove('/var/lib/grafana/grafana_backup.db')
 
 
 def backup_mediawiki_xml(dt: str, database: str):
@@ -190,7 +191,7 @@ def download(source: str, dt: str, database: str):
     elif source in ['grafana']:
         download_pca(f'sql/{source}/{dt}.tar.gz')
     elif source in ['sql']:
-        download_pca(f'{source}/{database}/{dt}.tar.gz')
+        download_pca(f'{source}/{database}/{dt}.sql.gz')
 
     print(f'Completed! This took {time.time() - ts}s')
 


### PR DESCRIPTION
mydumper uses too much ram for us to use. Although this means dumping will be longer and will also mean file sizes are larger.