### PR TITLE
mariadb: read my.cnf from /root/ in logrotate file

### DIFF
--- a/modules/mariadb/files/mysql-server.logrotate.conf
+++ b/modules/mariadb/files/mysql-server.logrotate.conf
@@ -13,7 +13,7 @@
           test -x /usr/bin/mysqladmin || exit 0
           # check if server is running
           if mysqladmin ping > /dev/null 2>&1; then
-            mysqladmin --local flush-error-log flush-engine-log flush-general-log flush-slow-log
+            env HOME=/root/ mysqladmin --local flush-error-log flush-engine-log flush-general-log flush-slow-log
           fi
           /usr/lib/rsyslog/rsyslog-rotate
         endscript

--- a/modules/mariadb/files/mysql-server.logrotate.conf
+++ b/modules/mariadb/files/mysql-server.logrotate.conf
@@ -12,8 +12,8 @@
         postrotate
           test -x /usr/bin/mysqladmin || exit 0
           # check if server is running
-          if mysqladmin ping > /dev/null 2>&1; then
-            env HOME=/root/ mysqladmin --local flush-error-log flush-engine-log flush-general-log flush-slow-log
+          if mysqladmin --defaults-file="/root/.my.cnf" ping > /dev/null 2>&1; then
+            mysqladmin --defaults-file="/root/.my.cnf" --local flush-error-log flush-engine-log flush-general-log flush-slow-log
           fi
           /usr/lib/rsyslog/rsyslog-rotate
         endscript


### PR DESCRIPTION
See https://serverfault.com/questions/375004/logrotate-not-rotating-the-logs