### PR TITLE
imagemagick: remove use of domain=path, rights=none

### DIFF
--- a/modules/imagemagick/files/policy.xml
+++ b/modules/imagemagick/files/policy.xml
@@ -73,5 +73,4 @@
   <policy domain="coder" rights="none" pattern="EPS" />
   <policy domain="coder" rights="none" pattern="PDF" />
   <policy domain="coder" rights="none" pattern="XPS" />
-  <policy domain="path" rights="none" pattern="@*" />
 </policymap>


### PR DESCRIPTION
We already restrict using firejail. Lets remove this.