### PR TITLE
salt: Set ssh_max_procs to how many cpu cores that the host has

### DIFF
--- a/modules/salt/templates/roster.erb
+++ b/modules/salt/templates/roster.erb
@@ -13,4 +13,6 @@
   user: salt-user
   priv: /home/salt-user/.ssh/id_ed25519
   sudo: True         # Whether to sudo to root, not enabled by default
+  ssh_max_procs: <%= scope.lookupvar('::processorcount') %>
+  ssh_wipe: True
 <%- end -%>

--- a/modules/salt/templates/roster.erb
+++ b/modules/salt/templates/roster.erb
@@ -13,6 +13,6 @@
   user: salt-user
   priv: /home/salt-user/.ssh/id_ed25519
   sudo: True         # Whether to sudo to root, not enabled by default
-  ssh_max_procs: <%= scope.lookupvar('::processorcount') %>
+  ssh_max_procs: <%= @facts['processors']['count'] %>
   ssh_wipe: True
 <%- end -%>


### PR DESCRIPTION
Also sets ssh_wipe to true so on each run, after all commands are finished, it'll remove the salt files.