### PR TITLE
ferm: remove os_version check

### DIFF
--- a/modules/ferm/manifests/init.pp
+++ b/modules/ferm/manifests/init.pp
@@ -89,14 +89,12 @@ class ferm {
 
     # Starting with Bullseye iptables default to the nft backend, but for ferm
     # we need the legacy backend
-    if os_version('debian >= bullseye') {
-        alternatives::select { 'iptables':
-            path => '/usr/sbin/iptables-legacy',
-        }
+    alternatives::select { 'iptables':
+        path => '/usr/sbin/iptables-legacy',
+    }
 
-        alternatives::select { 'ip6tables':
-            path => '/usr/sbin/ip6tables-legacy',
-        }
+    alternatives::select { 'ip6tables':
+        path => '/usr/sbin/ip6tables-legacy',
     }
 
     # the rules are virtual resources for cases where they are defined in a


### PR DESCRIPTION
All servers are on bullseye. No longer need this check.