### PR TITLE
miraheze-backup: add some logs for backing up db

### DIFF
--- a/modules/base/templates/backups/miraheze-backup.py.erb
+++ b/modules/base/templates/backups/miraheze-backup.py.erb
@@ -115,6 +115,8 @@ def backup_sql(dt: str, database: str):
         os.makedirs(f'/srv/backups/dbs')
 
     for db in dbs:
+        print(f'Backing up database \'{db}\'...')
+
         os.system(f'/usr/bin/ionice -c2 -n7 /usr/bin/mysqldump --quick --skip-lock-tables --single-transaction -C --ignore-table={db}.objectcache --ignore-table={db}.querycache --ignore-table={db}.querycachetwo --ignore-table={db}.recentchanges --ignore-table={db}.searchindex {db} | /usr/bin/nice /usr/bin/pigz > /srv/backups/dbs/{db}.sql.gz')
 
         pca_connection('PUT', f'/srv/backups/dbs/{db}.sql.gz', f'sql/{db}/{dt}.sql.gz', False)


### PR DESCRIPTION
This is to find out which db it fails on.