### PR TITLE
Revert "cp32/cp33 lower storage size to 45g (#3358)"

### DIFF
--- a/hieradata/hosts/cp32.yaml
+++ b/hieradata/hosts/cp32.yaml
@@ -1,5 +1,5 @@
 users::groups: 'cache-admins'
-varnish::cache_file_size: '45G'
+varnish::cache_file_size: '55G'
 nginx::worker_processes: 4
 puppetserver_hostname: 'puppet141.miraheze.org'
 


### PR DESCRIPTION
This reverts commit 7f71521b4208baa65720c52cdf67e3e761f32782.