### PR TITLE
base::puppet: force the puppet repo to use bullseye

### DIFF
--- a/modules/base/manifests/puppet.pp
+++ b/modules/base/manifests/puppet.pp
@@ -13,6 +13,9 @@ class base::puppet (
 
     apt::source { 'puppetlabs':
         location => 'http://apt.puppetlabs.com',
+        # TODO: Once a bookworm repo is available,
+        # emove this hack.
+        release => 'bullseye',
         repos    => "puppet${puppet_major_version}",
         require  => File['/etc/apt/trusted.gpg.d/puppetlabs.gpg'],
         notify   => Exec['apt_update_puppetlabs'],


### PR DESCRIPTION
This is until a bookworm repo is available.