### PR TITLE
Stop installing ruby-safe-yaml

### DIFF
--- a/modules/base/manifests/packages.pp
+++ b/modules/base/manifests/packages.pp
@@ -26,7 +26,6 @@ class base::packages {
         'python-is-python3',
         'python3-distro',
         'ruby',
-        'ruby-safe-yaml',
         'screen',
         'strace',
         'tcpdump',


### PR DESCRIPTION
This package isn't available under bookworm and we no longer use the functions from this package.