### PR TITLE
varnish: Remove duplicate ExecReload from systemd unit

### DIFF
--- a/modules/varnish/templates/initscripts/varnish.systemd.erb
+++ b/modules/varnish/templates/initscripts/varnish.systemd.erb
@@ -40,8 +40,6 @@ ExecStart=/usr/sbin/varnishd \
 -p http_max_hdr=128 \
 -p default_ttl=3600 \
 -p nuke_limit=1000
-ExecReload=/usr/share/varnish/varnishreload
-ExecStopPost=/usr/bin/rm -rf /var/lib/varnish/*
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
We use reload-vcl and don't need varnishreload.