### PR TITLE
nginx: turn off multi_accept

### DIFF
--- a/modules/nginx/templates/nginx.conf.erb
+++ b/modules/nginx/templates/nginx.conf.erb
@@ -11,8 +11,7 @@ worker_rlimit_nofile 16192; # Twice the number of worker_connections
 
 events {
 	worker_connections 8096;
-	use epoll;
-	multi_accept on;
+	multi_accept off;
 }
 
 http {


### PR DESCRIPTION
Also remove use epoll as it'll use epoll by default.