### PR TITLE
all_certs.pp assume nginx service exists

### DIFF
--- a/modules/ssl/manifests/all_certs.pp
+++ b/modules/ssl/manifests/all_certs.pp
@@ -1,10 +1,12 @@
 # Class for loading all certificates.
 class ssl::all_certs {
-    if defined(Service['nginx']) {
-        $restart_nginx = Service['nginx']
-    } else {
-        $restart_nginx = undef
-    }
+    # For now, assume nginx service is always defined; the function seems to be always returning false
+    # We only load this class from nginx definitions anyway
+    #if defined(Service['nginx']) {
+    $restart_nginx = Service['nginx']
+    #} else {
+    #    $restart_nginx = undef
+    #}
 
     file { '/etc/ssl/localcerts':
         ensure  => directory,


### PR DESCRIPTION
Puppet is currently not creating the proper notify relationship between `/etc/ssl/localcerts` and `Service['nginx']`. I'm assuming this is because `defined(Service['nginx'])` is returning false for some reason (possibly evaluation order?). For now, we can always assume we can reach it, given that all_certs is always called inside an nginx definition file.

Maybe we need a requires?