### PR TITLE
varnish: Improve static.miraheze.org

### DIFF
--- a/modules/varnish/manifests/init.pp
+++ b/modules/varnish/manifests/init.pp
@@ -39,8 +39,7 @@ class varnish (
         group  => 'varnish',
     }
 
-    $facts['memory']['system']['total_bytes']
-    $mem_gb = $facts['memorysize_mb'] / 1024.0
+    $mem_gb = $facts['memory']['system']['total_bytes'] / 1024.0
     if ($mem_gb < 90.0) {
         $v_mem_gb = 1
     } else {

--- a/modules/varnish/manifests/init.pp
+++ b/modules/varnish/manifests/init.pp
@@ -26,6 +26,14 @@ class varnish (
     $interval_check = lookup('varnish::interval-check')
     $interval_timeout = lookup('varnish::interval-timeout')
 
+    # (1024.0 * 1024.0) converts to megabytes.
+    $mem_gb = $facts['memory']['system']['total_bytes'] / (1024.0 * 1024.0) / 1024.0
+    if ($mem_gb < 90.0) {
+        $v_mem_gb = 1
+    } else {
+        $v_mem_gb = ceiling(0.7 * ($mem_gb - 100.0))
+    }
+
     file { '/etc/varnish/default.vcl':
         ensure  => present,
         content => template('varnish/default.vcl'),
@@ -37,14 +45,6 @@ class varnish (
         ensure => directory,
         owner  => 'varnish',
         group  => 'varnish',
-    }
-
-    # (1024.0 * 1024.0) converts to megabytes.
-    $mem_gb = $facts['memory']['system']['total_bytes'] / (1024.0 * 1024.0) / 1024.0
-    if ($mem_gb < 90.0) {
-        $v_mem_gb = 1
-    } else {
-        $v_mem_gb = ceiling(0.7 * ($mem_gb - 100.0))
     }
 
     # TODO: On bigger memory hosts increase Transient size

--- a/modules/varnish/manifests/init.pp
+++ b/modules/varnish/manifests/init.pp
@@ -39,8 +39,15 @@ class varnish (
         group  => 'varnish',
     }
 
+    $mem_gb = $facts['memorysize_mb'] / 1024.0
+    if ($mem_gb < 90.0) {
+        $v_mem_gb = 1
+    } else {
+        $v_mem_gb = ceiling(0.7 * ($mem_gb - 100.0))
+    }
+
     # TODO: On bigger memory hosts increase Transient size
-    $storage = "-s file,${cache_file_name},${cache_file_size} -s Transient=malloc,1G"
+    $storage = "-s file,${cache_file_name},${cache_file_size} -s Transient=malloc,${v_mem_gb}G"
 
     systemd::service { 'varnish':
         ensure         => present,

--- a/modules/varnish/manifests/init.pp
+++ b/modules/varnish/manifests/init.pp
@@ -39,7 +39,8 @@ class varnish (
         group  => 'varnish',
     }
 
-    $mem_gb = $facts['memory']['system']['total_bytes'] / 1024.0
+    # (1024.0 * 1024.0) converts to megabytes.
+    $mem_gb = $facts['memory']['system']['total_bytes'] / (1024.0 * 1024.0) / 1024.0
     if ($mem_gb < 90.0) {
         $v_mem_gb = 1
     } else {

--- a/modules/varnish/manifests/init.pp
+++ b/modules/varnish/manifests/init.pp
@@ -39,6 +39,7 @@ class varnish (
         group  => 'varnish',
     }
 
+    $facts['memory']['system']['total_bytes']
     $mem_gb = $facts['memorysize_mb'] / 1024.0
     if ($mem_gb < 90.0) {
         $v_mem_gb = 1

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -436,7 +436,14 @@ sub vcl_backend_fetch {
 
 sub mf_admission_policies {
     // hit-for-pass objects >= 8388608 size. Do cache if Content-Length is missing.
-    if (std.integer(beresp.http.Content-Length, 0) >= 8388608) {
+    if (bereq.http.Host == "static.miraheze.org" && std.integer(beresp.http.Content-Length, 0) >= 8388608) {
+        // HFP
+        set beresp.http.X-CDIS = "pass";
+        return(pass(beresp.ttl));
+    }
+
+    // hit-for-pass objects >= 67108864 size. Do cache if Content-Length is missing.
+    if (bereq.http.Host != "static.miraheze.org" && std.integer(beresp.http.Content-Length, 0) >= 67108864) {
         // HFP
         set beresp.http.X-CDIS = "pass";
         return(pass(beresp.ttl));

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -16,7 +16,7 @@ C{
 
    #define RATE 0.2
    #define BASE -20.3
-   #define MEMORY 1/1024.0 %>
+   #define MEMORY 1/1024.0
    const double adm_param = pow(MEMORY, RATE) / pow(2.0, BASE);
 }C
 

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -26,7 +26,7 @@ probe mwhealth {
 	# to mark the backend as healthy
 	.window = 5;
 	.threshold = 4;
-        .initial = 4;
+	.initial = 4;
 	.expected_response = 204;
 }
 
@@ -118,13 +118,13 @@ sub rate_limit {
 			(req.http.X-Real-IP != "185.15.56.22" && req.http.User-Agent !~ "^IABot/2")
 		) {
 			if (req.url ~ "^/(w/api.php|w/rest.php|wiki/Special:EntityData)") {
-			    if (vsthrottle.is_denied("rest:" + req.http.X-Real-IP, 1000, 10s)) {
-				return (synth(429, "Too Many Requests"));
-			    }
+				if (vsthrottle.is_denied("rest:" + req.http.X-Real-IP, 1000, 10s)) {
+					return (synth(429, "Too Many Requests"));
+				}
 			} else {
-			    if (vsthrottle.is_denied("mwrtl:" + req.http.X-Real-IP, 1000, 50s)) {
-				return (synth(429, "Too Many Requests"));
-			    }
+				if (vsthrottle.is_denied("mwrtl:" + req.http.X-Real-IP, 1000, 50s)) {
+					return (synth(429, "Too Many Requests"));
+				}
 			}
 		}
 	}
@@ -198,9 +198,9 @@ sub mw_request {
 	if (req.http.Host == "static.miraheze.org") {
 		unset req.http.X-Range;
 
-	    if (req.http.Range) {
-	        set req.hash_ignore_busy = true;
-	    }
+		if (req.http.Range) {
+			set req.hash_ignore_busy = true;
+		}
 
 		# We can do this because static.miraheze.org should not be capable of serving such requests anyway
 		# This could also increase cache hit rates as Cookies will be stripped entirely
@@ -254,10 +254,10 @@ sub mw_request {
 			}
 		}
 
-	    // Fixup borked client Range: headers
-	    if (req.http.Range ~ "(?i)bytes:") {
-	        set req.http.Range = regsub(req.http.Range, "(?i)bytes:\s*", "bytes=");
-	    }
+		// Fixup borked client Range: headers
+		if (req.http.Range ~ "(?i)bytes:") {
+			set req.http.Range = regsub(req.http.Range, "(?i)bytes:\s*", "bytes=");
+		}
 	}
 
 	# Don't cache a non-GET or HEAD request
@@ -343,10 +343,10 @@ sub vcl_recv {
 		return (pass);
 	}
 
-        if (req.http.Host ~ "^(.*\.)?betaheze\.org") {
-                set req.backend_hint = test131;
-                return (pass);
-        }
+		if (req.http.Host ~ "^(.*\.)?betaheze\.org") {
+				set req.backend_hint = test131;
+				return (pass);
+		}
 
 	# Only cache js files from Matomo
 	if (req.http.Host == "matomo.miraheze.org") {
@@ -373,7 +373,7 @@ sub vcl_recv {
 
 	# Do not cache requests from this domain
 	if (req.http.Host == "phabricator.miraheze.org" || req.http.Host == "phab.miraheze.wiki" ||
-            req.http.Host == "blog.miraheze.org") {
+		req.http.Host == "blog.miraheze.org") {
 		set req.backend_hint = phab121;
 		return (pass);
 	}
@@ -405,11 +405,11 @@ sub vcl_hash {
 }
 
 sub vcl_pipe {
-    // for websockets over pipe
-    if (req.http.upgrade) {
-        set bereq.http.upgrade = req.http.upgrade;
-        set bereq.http.connection = req.http.connection;
-    }
+	// for websockets over pipe
+	if (req.http.upgrade) {
+		set bereq.http.upgrade = req.http.upgrade;
+		set bereq.http.connection = req.http.connection;
+	}
 }
 
 # Initiate a backend fetch
@@ -429,19 +429,19 @@ sub vcl_backend_fetch {
 		unset bereq.http.X-Orig-Cookie;
 	}
 
-    if (bereq.http.X-Range) {
-        set bereq.http.Range = bereq.http.X-Range;
-        unset bereq.http.X-Range;
-    }
+	if (bereq.http.X-Range) {
+		set bereq.http.Range = bereq.http.X-Range;
+		unset bereq.http.X-Range;
+	}
 }
 
 # Backend response, defines cacheability
 sub vcl_backend_response {
-    if (beresp.http.Content-Range) {
-        // Varnish itself doesn't ask for ranges, so this must have been
-        // a passed range request
-        set beresp.http.X-Content-Range = beresp.http.Content-Range;
-    }
+	if (beresp.http.Content-Range) {
+		// Varnish itself doesn't ask for ranges, so this must have been
+		// a passed range request
+		set beresp.http.X-Content-Range = beresp.http.Content-Range;
+	}
 
 	# T9808: Assign restrictive Cache-Control if one is missing
 	if (!beresp.http.Cache-Control) {
@@ -569,26 +569,26 @@ sub vcl_backend_response {
 
 # Last sub route activated, clean up of HTTP headers etc.
 sub vcl_deliver {
-    if (resp.http.X-Content-Range) {
-        set resp.http.Content-Range = resp.http.X-Content-Range;
-        unset resp.http.X-Content-Range;
-    }
+	if (resp.http.X-Content-Range) {
+		set resp.http.Content-Range = resp.http.X-Content-Range;
+		unset resp.http.X-Content-Range;
+	}
 
 	if ( req.http.Host == "static.miraheze.org" ) {
 		unset resp.http.Set-Cookie;
 		unset resp.http.Cache-Control;
 
-	    if (req.http.X-Content-Disposition == "attachment") {
-	        set resp.http.Content-Disposition = "attachment";
-	    }
+		if (req.http.X-Content-Disposition == "attachment") {
+			set resp.http.Content-Disposition = "attachment";
+		}
 
-	    // Prevent browsers from content sniffing.
-	    set resp.http.X-Content-Type-Options = "nosniff";
+		// Prevent browsers from content sniffing.
+		set resp.http.X-Content-Type-Options = "nosniff";
 
 		call add_upload_cors_headers;
 	}
 
-    if ( req.url ~ "^(?i)\/w\/img_auth\.php\/(.+)" ) {
+	if ( req.url ~ "^(?i)\/w\/img_auth\.php\/(.+)" ) {
 		call add_upload_cors_headers;
 	}
 
@@ -636,20 +636,20 @@ sub vcl_deliver {
 }
 
 sub add_upload_cors_headers {
-    set resp.http.Access-Control-Allow-Origin = "*";
+	set resp.http.Access-Control-Allow-Origin = "*";
 
-    // Headers exposed for CORS:
-    // - Age, Content-Length, Date, X-Cache
-    //
-    // - X-Content-Duration: used for OGG audio and video files.
-    //   Firefox 41 dropped support for this header, but OGV.js still supports it.
-    //   See <https://bugzilla.mozilla.org/show_bug.cgi?id=1160695#c27> and
-    //   <https://github.com/brion/ogv.js/issues/88>.
-    //
-    // - Content-Range: indicates total file and actual range returned for RANGE
-    //   requests. Used by ogv.js to eliminate an extra HEAD request
-    //   to get the total file size.
-    set resp.http.Access-Control-Expose-Headers = "Age, Date, Content-Length, Content-Range, X-Content-Duration, X-Cache";
+	// Headers exposed for CORS:
+	// - Age, Content-Length, Date, X-Cache
+	//
+	// - X-Content-Duration: used for OGG audio and video files.
+	//   Firefox 41 dropped support for this header, but OGV.js still supports it.
+	//   See <https://bugzilla.mozilla.org/show_bug.cgi?id=1160695#c27> and
+	//   <https://github.com/brion/ogv.js/issues/88>.
+	//
+	// - Content-Range: indicates total file and actual range returned for RANGE
+	//   requests. Used by ogv.js to eliminate an extra HEAD request
+	//   to get the total file size.
+	set resp.http.Access-Control-Expose-Headers = "Age, Date, Content-Length, Content-Range, X-Content-Duration, X-Cache";
 }
 
 # Hit code, default logic is appended

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -146,6 +146,8 @@ sub rate_limit {
 # Artificial error handling/redirects within Varnish
 sub vcl_synth {
 	if (req.method != "PURGE") {
+		set resp.http.X-CDIS = "int";
+
 		if (resp.status == 752) {
 			set resp.http.Location = resp.reason;
 			set resp.status = 302;

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -16,7 +16,7 @@ C{
 
    #define RATE 0.2
    #define BASE -20.3
-   #define MEMORY 1/1024.0
+   #define MEMORY <%= @v_mem_gb.to_i/1024.0 %>
    const double adm_param = pow(MEMORY, RATE) / pow(2.0, BASE);
 }C
 

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -669,6 +669,14 @@ sub vcl_hit {
 sub vcl_miss {
 	# Add X-Cache header
 	set req.http.X-Cache = "<%= @facts['networking']['hostname'] %> MISS";
+
+    // Convert range requests into pass
+    if (req.http.Range) {
+        // Varnish strips the Range header before copying req into bereq. Save it into
+        // a header and restore it in cluster_fe_backend_fetch
+        set req.http.X-Range = req.http.Range;
+        return (pass);
+    }
 }
 
 # Pass code, default logic is appended

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -649,16 +649,6 @@ sub vcl_backend_response {
 		return(pass(601s));
 	}
 
-	// hit-for-pass objects >= 8388608 size and if domain == static.miraheze.org or
-	// hit-for-pass objects >= 67108864 size and if domain != static.miraheze.org.
-	// Do cache if Content-Length is missing.
-	if (std.integer(beresp.http.Content-Length, 0) >= 8388608 && bereq.http.Host == "static.miraheze.org" ||
-		std.integer(beresp.http.Content-Length, 0) >= 67108864 && bereq.http.Host != "static.miraheze.org"
-	) {
-		// HFP
-		return(pass(beresp.ttl));
-	}
-
 	// It is important that this happens after the code responsible for translating TTL<=0
 	// (uncacheable) responses into hit-for-pass.
 	call mf_admission_policies;

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -463,12 +463,12 @@ sub vcl_backend_response {
         set beresp.ttl = 0s;
         // translated to hit-for-pass below
     }
-    // Set a maximum cap on the TTL for 404s. Objects that don't exist now may
-    // be created later on, and we want to put a limit on the amount of time
-    // it takes for new resources to be visible.
-    elsif (beresp.status == 404 && beresp.ttl > 10m) {
-        set beresp.ttl = "10m";
-    }
+	// Set a maximum cap on the TTL for 404s. Objects that don't exist now may
+	// be created later on, and we want to put a limit on the amount of time
+	// it takes for new resources to be visible.
+	elsif (beresp.status == 404 && beresp.ttl > 10m) {
+		set beresp.ttl = 10m;
+	}
 
 	# Cookie magic as we did before
 	if (bereq.http.Cookie ~ "([Ss]ession|Token)=") {

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -586,10 +586,10 @@ sub vcl_backend_response {
 			unset bereq.http.Cookie;
 			unset beresp.http.Set-Cookie;
 		} else {
-	        set beresp.grace = 31s;
-	        set beresp.keep = 0s;
-	        set beresp.http.X-CDIS = "pass";
-	        // HFP
+			set beresp.grace = 31s;
+			set beresp.keep = 0s;
+			set beresp.http.X-CDIS = "pass";
+			// HFP
 			return(pass(607s));
 		}
 	} elseif (beresp.http.Set-Cookie) {

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -519,11 +519,11 @@ sub vcl_backend_response {
 		// translated to hit-for-pass below
 	}
 
-    /* Especially don't cache Set-Cookie responses. */
-    if ((beresp.ttl > 0s || beresp.http.Cache-Control ~ "public") && beresp.http.Set-Cookie) {
-        set beresp.ttl = 0s;
-        // translated to hit-for-pass below
-    }
+	/* Especially don't cache Set-Cookie responses. */
+	if ((beresp.ttl > 0s || beresp.http.Cache-Control ~ "public") && beresp.http.Set-Cookie) {
+		set beresp.ttl = 0s;
+		// translated to hit-for-pass below
+	}
 	// Set a maximum cap on the TTL for 404s. Objects that don't exist now may
 	// be created later on, and we want to put a limit on the amount of time
 	// it takes for new resources to be visible.
@@ -586,6 +586,10 @@ sub vcl_backend_response {
 			unset bereq.http.Cookie;
 			unset beresp.http.Set-Cookie;
 		} else {
+	        set beresp.grace = 31s;
+	        set beresp.keep = 0s;
+	        set beresp.http.X-CDIS = "pass";
+	        // HFP
 			return(pass(607s));
 		}
 	} elseif (beresp.http.Set-Cookie) {

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -478,9 +478,6 @@ C{
        const double admissionprob = exp(clen_neg/adm_param);
        const double urand = drand48();
 
-       Vmod_std_Func.log(ctx, "Admission Probability: ", VRT_REAL_string(ctx, admissionprob), vrt_magic_string_end);
-       Vmod_std_Func.log(ctx, "Admission Urand: ", VRT_REAL_string(ctx, urand), vrt_magic_string_end);
-
        // If admission test succeeds, mark as uncacheable
        if (admissionprob < urand) {
            // HFM with ttl=67 to avoid stalling

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -477,10 +477,10 @@ C{
 
 # Backend response, defines cacheability
 sub vcl_backend_response {
-    // This prevents the application layer from setting this in a response.
-    // We'll be setting this same variable internally in VCL in hit-for-pass
-    // cases later.
-    unset beresp.http.X-CDIS;
+	// This prevents the application layer from setting this in a response.
+	// We'll be setting this same variable internally in VCL in hit-for-pass
+	// cases later.
+	unset beresp.http.X-CDIS;
 
 	if (bereq.http.Cookie ~ "([sS]ession|Token)=") {
 		set bereq.http.Cookie = "Token=1";

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -673,7 +673,7 @@ sub vcl_miss {
     // Convert range requests into pass
     if (req.http.Range) {
         // Varnish strips the Range header before copying req into bereq. Save it into
-        // a header and restore it in cluster_fe_backend_fetch
+        // a header and restore it in vcl_backend_fetch
         set req.http.X-Range = req.http.Range;
         return (pass);
     }

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -669,16 +669,17 @@ sub vcl_backend_response {
 
 # Last sub route activated, clean up of HTTP headers etc.
 sub vcl_deliver {
-    if (req.method != "PURGE") {
-        // we copy through from beresp->resp->req here for the initial hit-for-pass case
-        if (resp.http.X-CDIS) {
-            set req.http.X-CDIS = resp.http.X-CDIS;
-            unset resp.http.X-CDIS;
-        }
+	if (req.method != "PURGE") {
+		// we copy through from beresp->resp->req here for the initial hit-for-pass case
+		if (resp.http.X-CDIS) {
+			set req.http.X-CDIS = resp.http.X-CDIS;
+			unset resp.http.X-CDIS;
+		}
 
-        if (!req.http.X-CDIS) {
-            set req.http.X-CDIS = "bug";
-    }
+		if (!req.http.X-CDIS) {
+			set req.http.X-CDIS = "bug";
+		}
+	}
 
 	if (resp.http.X-Content-Range) {
 		set resp.http.Content-Range = resp.http.X-Content-Range;

--- a/modules/varnish/templates/initscripts/varnish.systemd.erb
+++ b/modules/varnish/templates/initscripts/varnish.systemd.erb
@@ -33,6 +33,7 @@ ExecStart=/usr/sbin/varnishd \
 -p thread_pool_timeout=120 \
 -p vsl_reclen=2048 \
 -p workspace_backend=128k \
+-p vcc_allow_inline_c=true \
 -S /etc/varnish/secret \
 <%= @storage %> \
 -p http_req_size=24576 \

--- a/modules/varnish/templates/initscripts/varnish.systemd.erb
+++ b/modules/varnish/templates/initscripts/varnish.systemd.erb
@@ -39,7 +39,7 @@ ExecStart=/usr/sbin/varnishd \
 -p http_req_size=24576 \
 -p listen_depth=16384 -p vcc_err_unref=off \
 -p http_max_hdr=128 \
--p default_ttl=3600 \
+-p default_ttl=86400 \
 -p nuke_limit=1000
 
 [Install]


### PR DESCRIPTION
* Removes query parameters so cache hit increases.
* Lowercases extensions to also increase cache hits.
* Pipes dump requests.
* Unset Cache-Control header.
* And more improvements!

Note: Some of this code is from Wikimedia puppet repo (https://github.com/wikimedia/operations-puppet/blob/4f7dcacd8fc378b15db131f0f79be26cbec9182a/modules/varnish/templates/upload-frontend.inc.vcl.erb)