### PR TITLE
revert nginx rate-limits

### DIFF
--- a/modules/varnish/templates/mediawiki.conf
+++ b/modules/varnish/templates/mediawiki.conf
@@ -3,9 +3,9 @@ map $http_upgrade $connection_upgrade {
         ''      close;
 }
 
-limit_req_zone $binary_remote_addr zone=one:50m rate=1000r/s;
+limit_req_zone $binary_remote_addr zone=one:50m rate=100r/s;
 limit_req_dry_run on;
-limit_req zone=one burst=500 nodelay;
+limit_req zone=one burst=50 nodelay;
 
 server {
 	listen 80 deferred backlog=16384 reuseport;

--- a/modules/varnish/templates/mediawiki.conf
+++ b/modules/varnish/templates/mediawiki.conf
@@ -3,10 +3,6 @@ map $http_upgrade $connection_upgrade {
         ''      close;
 }
 
-limit_req_zone $binary_remote_addr zone=one:50m rate=100r/s;
-limit_req_dry_run on;
-limit_req zone=one burst=50 nodelay;
-
 server {
 	listen 80 deferred backlog=16384 reuseport;
 	listen [::]:80 deferred backlog=16384 reuseport;


### PR DESCRIPTION
Our bursts for static are too high for these rate limits to work effectively. Will work on other detection methods for now.