### PR TITLE
matomo: Set assume_secure_protocol to 1

### DIFF
--- a/modules/matomo/templates/config.ini.php.erb
+++ b/modules/matomo/templates/config.ini.php.erb
@@ -13,6 +13,7 @@ charset = "utf8mb4"
 
 [General]
 browser_archiving_disabled_enforce = 1
+assume_secure_protocol = 1
 force_ssl = 1
 noreply_email_address = "noreply@miraheze.org"
 enable_load_data_infile = 0


### PR DESCRIPTION
We use a reverse-proxy (nginx) now for varnish -> backend tls. Without this config, a indefinite redirect happened.