### PR TITLE
varnish: Disable writing to access logs in reverse proxy

### DIFF
--- a/modules/varnish/templates/mediawiki.conf
+++ b/modules/varnish/templates/mediawiki.conf
@@ -10,6 +10,8 @@ server {
 
 	server_name localhost;
 
+	access_log  off;
+
 	location / {
 		proxy_pass https://<%= name %>.miraheze.org;
 		proxy_http_version 1.1;


### PR DESCRIPTION
We don't need duplicate stuff, mw* will have it if we need it.

Don't disable error log as that will be useful in case.