### PR TITLE
deploy-mediawiki: force use of --pull to update world

### DIFF
--- a/modules/mediawiki/files/bin/deploy-mediawiki.py
+++ b/modules/mediawiki/files/bin/deploy-mediawiki.py
@@ -193,12 +193,8 @@ def run(args: argparse.Namespace, start: float) -> None:
         else:
             print(text)
         pull = []
-        if args.world and not args.pull:
-            pull = ['world']
         if args.pull:
             pull = str(args.pull).split(',')
-        if args.world and 'world' not in pull:
-            pull.append('world')
         if pull:
             for repo in pull:
                 if repo == 'world':


### PR DESCRIPTION
This is to speed up deploying.

git pull --recursive-submodule takes ages so when you know the repo is already up-to-date we can skip this step.