### PR TITLE
mediawiki: use python3-internetarchive deb package on bookworm+

### DIFF
--- a/modules/mediawiki/manifests/init.pp
+++ b/modules/mediawiki/manifests/init.pp
@@ -38,15 +38,19 @@ class mediawiki(
     }
 
     if lookup('jobrunner::intensive', {'default_value' => false}) {
-        stdlib::ensure_packages(
-            'internetarchive',
-            {
-                ensure   => '3.3.0',
-                provider => 'pip3',
-                before   => File['/usr/local/bin/iaupload'],
-                require  => Package['python3-pip'],
-            },
-        )
+        if ($facts['os']['distro']['codename'] == 'bookworm') {
+            stdlib::ensure_packages(['python3-internetarchive'])
+        } else {
+            stdlib::ensure_packages(
+                'internetarchive',
+                {
+                    ensure   => '3.3.0',
+                    provider => 'pip3',
+                    before   => File['/usr/local/bin/iaupload'],
+                    require  => Package['python3-pip'],
+                },
+            )
+        }
 
         file { '/usr/local/bin/iaupload':
             ensure => present,


### PR DESCRIPTION
On bookworm we get with pip3:

```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.11/README.venv for more information.
```