### PR TITLE
[BREAKING CHANGE] mwscript: make run.php no longer experimental

### DIFF
--- a/modules/mediawiki/files/bin/mwscript.py
+++ b/modules/mediawiki/files/bin/mwscript.py
@@ -38,8 +38,7 @@ def get_commands(args: argparse.Namespace) -> CommandInfo:
         print('Not enough Arguments given.')
         sys.exit(2)
     script = args.script
-    if not script.endswith('.php'):
-        if args.norunphp:
+    if not script.endswith('.php') and args.norunphp:
             print('Error: Specifiy --use-runner or --140 to enable MaintenanceRunner')
             sys.exit(2)
     if not args.norunphp:

--- a/modules/mediawiki/files/bin/mwscript.py
+++ b/modules/mediawiki/files/bin/mwscript.py
@@ -61,9 +61,9 @@ def get_commands(args: argparse.Namespace) -> CommandInfo:
             if scriptsplit[2] in longscripts:
                 long = True
     else:
-        script = f'{runner}{script}'
         if script.lower() in longscripts:
             long = True
+        script = f'{runner}{script}'
 
     if wiki == 'all':
         long = True

--- a/modules/mediawiki/files/bin/mwscript.py
+++ b/modules/mediawiki/files/bin/mwscript.py
@@ -39,15 +39,15 @@ def get_commands(args: argparse.Namespace) -> CommandInfo:
         sys.exit(2)
     script = args.script
     if not script.endswith('.php'):
-        if not args.runner:
+        if args.norunphp:
             print('Error: Specifiy --use-runner or --140 to enable MaintenanceRunner')
             sys.exit(2)
-        if args.runner and not args.confirm:
+        elif not args.confirm:
             print(f'WARNING: Please log usage of {longscripts}. Support for longscripts has not been added')
             print('WARNING: Use of classes is not well tested. Please use with caution.')
             if input("Type 'Y' to confirm (or any other key to stop - rerun without --140/--use-runner): ").upper() != 'Y':
                 sys.exit(2)
-    if args.runner:
+    if not args.norunphp:
         runner = '/srv/mediawiki/w/maintenance/run.php '
     else:
         runner = ''
@@ -113,7 +113,7 @@ def get_args() -> argparse.Namespace:
     parser.add_argument('--extension', '--skin', dest='extension')
     parser.add_argument('--no-log', dest='nolog', action='store_true')
     parser.add_argument('--confirm', '--yes', '-y', dest='confirm', action='store_true')
-    parser.add_argument('--use-runner', '--140', dest='runner', action='store_true')
+    parser.add_argument('--no-use-runner', dest='norunphp', action='store_true')
 
     args = parser.parse_known_args()[0]
     args.arguments += parser.parse_known_args()[1]

--- a/modules/mediawiki/files/bin/mwscript.py
+++ b/modules/mediawiki/files/bin/mwscript.py
@@ -45,7 +45,7 @@ def get_commands(args: argparse.Namespace) -> Union[CommandInfo, int]:
         return 2
     script = args.script
     if not script.endswith('.php') and args.norunphp:
-        print('Error: You can't use a class and specify --no-runner')
+        print('Error: You can not use a class and specify --no-runner')
         return 2
     if not args.norunphp:
         runner = '/srv/mediawiki/w/maintenance/run.php '

--- a/modules/mediawiki/files/bin/mwscript.py
+++ b/modules/mediawiki/files/bin/mwscript.py
@@ -7,7 +7,7 @@ import os
 import sys
 from typing import TYPE_CHECKING, TypedDict
 if TYPE_CHECKING:
-    from typing import Optional
+    from typing import Optional, Union
 
 
 class CommandInfo(TypedDict):
@@ -18,13 +18,13 @@ class CommandInfo(TypedDict):
     confirm: bool
 
 
-def syscheck(result: [CommandInfo, int]) -> CommandInfo:
+def syscheck(result: Union[CommandInfo, int]) -> CommandInfo:
     if isinstance(result, int):
         sys.exit(result)
     return result
 
 
-def get_commands(args: argparse.Namespace) -> CommandInfo:
+def get_commands(args: argparse.Namespace) -> Union[CommandInfo, int]:
     validDBLists = ('active', 'beta')
     longscripts = ('compressold', 'deletebatch', 'importdump', 'importimages', 'nukens', 'rebuildall', 'rebuildimages', 'refreshlinks', 'runjobs', 'purgelist', 'cargorecreatedata')
     long = False

--- a/modules/mediawiki/files/bin/mwscript.py
+++ b/modules/mediawiki/files/bin/mwscript.py
@@ -63,7 +63,7 @@ def get_commands(args: argparse.Namespace) -> Union[CommandInfo, int]:
                 long = True
         else:
             script = f'{runner}/srv/mediawiki/w/{scriptsplit[0]}/{scriptsplit[1]}/maintenance/{scriptsplit[2]}'
-            if scriptsplit[2] in longscripts:
+            if scriptsplit[2].split('.')[0].lower() in longscripts:
                 long = True
     else:
         if script.lower() in longscripts:

--- a/modules/mediawiki/files/bin/mwscript.py
+++ b/modules/mediawiki/files/bin/mwscript.py
@@ -18,8 +18,8 @@ class CommandInfo(TypedDict):
     confirm: bool
 
 
-def syscheck(result: [CommandInfo, Int]) -> CommandInfo:
-    if ininstance(result, int):
+def syscheck(result: [CommandInfo, int]) -> CommandInfo:
+    if isinstance(result, int):
         sys.exit(result)
     return result
 

--- a/modules/mediawiki/files/bin/mwscript.py
+++ b/modules/mediawiki/files/bin/mwscript.py
@@ -18,6 +18,12 @@ class CommandInfo(TypedDict):
     confirm: bool
 
 
+def syscheck(result: [CommandInfo, Int]) -> CommandInfo:
+    if ininstance(result, int):
+        sys.exit(result)
+    return result
+
+
 def get_commands(args: argparse.Namespace) -> CommandInfo:
     validDBLists = ('active', 'beta')
     longscripts = ('compressold', 'deletebatch', 'importdump', 'importimages', 'nukens', 'rebuildall', 'rebuildimages', 'refreshlinks', 'runjobs', 'purgelist', 'cargorecreatedata')
@@ -33,14 +39,14 @@ def get_commands(args: argparse.Namespace) -> CommandInfo:
                 args.arguments = False
         else:
             print(f'First argument should be a valid wiki if --extension not given DEBUG: {args.arguments[0]} / {args.extension} / {[*["all"], *validDBLists]}')
-            sys.exit(2)
+            return 2
     except IndexError:
         print('Not enough Arguments given.')
-        sys.exit(2)
+        return 2
     script = args.script
     if not script.endswith('.php') and args.norunphp:
-            print('Error: Specifiy --use-runner or --140 to enable MaintenanceRunner')
-            sys.exit(2)
+        print('Error: Specifiy --use-runner or --140 to enable MaintenanceRunner')
+        return 2
     if not args.norunphp:
         runner = '/srv/mediawiki/w/maintenance/run.php '
     else:
@@ -118,4 +124,4 @@ def get_args() -> argparse.Namespace:
 
 if __name__ == '__main__':
 
-    run(get_commands(get_args()))
+    run(syscheck(get_commands(get_args())))

--- a/modules/mediawiki/files/bin/mwscript.py
+++ b/modules/mediawiki/files/bin/mwscript.py
@@ -20,7 +20,7 @@ class CommandInfo(TypedDict):
 
 def get_commands(args: argparse.Namespace) -> CommandInfo:
     validDBLists = ('active', 'beta')
-    longscripts = ('compressOld.php', 'deleteBatch.php', 'importDump.php', 'importImages.php', 'nukeNS.php', 'rebuildall.php', 'rebuildImages.php', 'refreshLinks.php', 'runJobs.php', 'purgeList.php', 'cargoRecreateData.php')
+    longscripts = ('compressold', 'deletebatch', 'importdump', 'importimages', 'nukens', 'rebuildall', 'rebuildimages', 'refreshlinks', 'runjobs', 'purgelist', 'cargorecreatedata')
     long = False
     generate = None
     try:
@@ -42,24 +42,19 @@ def get_commands(args: argparse.Namespace) -> CommandInfo:
         if args.norunphp:
             print('Error: Specifiy --use-runner or --140 to enable MaintenanceRunner')
             sys.exit(2)
-        elif not args.confirm:
-            print(f'WARNING: Please log usage of {longscripts}. Support for longscripts has not been added')
-            print('WARNING: Use of classes is not well tested. Please use with caution.')
-            if input("Type 'Y' to confirm (or any other key to stop - rerun without --140/--use-runner): ").upper() != 'Y':
-                sys.exit(2)
     if not args.norunphp:
         runner = '/srv/mediawiki/w/maintenance/run.php '
     else:
         runner = ''
     if script.endswith('.php'):  # assume class if not
         scriptsplit = script.split('/')
-        if script in longscripts:
+        if script.split('.')[0].lower() in longscripts:
             long = True
         if len(scriptsplit) == 1:
             script = f'{runner}/srv/mediawiki/w/maintenance/{script}'
         elif len(scriptsplit) == 2:
             script = f'{runner}/srv/mediawiki/w/maintenance/{scriptsplit[0]}/{scriptsplit[1]}'
-            if scriptsplit[1] in longscripts:
+            if scriptsplit[1].split('.')[0].lower() in longscripts:
                 long = True
         else:
             script = f'{runner}/srv/mediawiki/w/{scriptsplit[0]}/{scriptsplit[1]}/maintenance/{scriptsplit[2]}'
@@ -67,6 +62,8 @@ def get_commands(args: argparse.Namespace) -> CommandInfo:
                 long = True
     else:
         script = f'{runner}{script}'
+        if script.lower() in longscripts:
+            long = True
 
     if wiki == 'all':
         long = True

--- a/modules/mediawiki/files/bin/mwscript.py
+++ b/modules/mediawiki/files/bin/mwscript.py
@@ -45,7 +45,7 @@ def get_commands(args: argparse.Namespace) -> Union[CommandInfo, int]:
         return 2
     script = args.script
     if not script.endswith('.php') and args.norunphp:
-        print('Error: Specifiy --use-runner or --140 to enable MaintenanceRunner')
+        print('Error: You can't use a class and specify --no-runner')
         return 2
     if not args.norunphp:
         runner = '/srv/mediawiki/w/maintenance/run.php '

--- a/modules/mediawiki/files/bin/test_mwscript.py
+++ b/modules/mediawiki/files/bin/test_mwscript.py
@@ -132,3 +132,25 @@ def test_get_command_class():
     args.arguments = ['metawiki', '--test']
     args.confirm = True
     assert mwscript.get_commands(args) == {'confirm': True, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php test --wiki=metawiki --test', 'generate': None, 'long': False, 'nolog': False}
+
+
+def test_get_command_long_runner():
+    args = mwscript.get_args()
+    args.script = 'rebuildall.php'
+    args.arguments = ['metawiki']
+    assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/maintenance/rebuildall.php --wiki=metawiki', 'generate': None, 'long': True, 'nolog': False}
+
+
+def test_get_command_long_runner_class_lower():
+    args = mwscript.get_args()
+    args.script = 'rebuildall'
+    args.arguments = ['metawiki']
+    assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php rebuildall --wiki=metawiki', 'generate': None, 'long': True, 'nolog': False}
+
+
+def test_get_command_long_runner_class_mixed():
+    args = mwscript.get_args()
+    args.script = 'rEbUiLdAll'
+    args.arguments = ['metawiki']
+    assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php rEbUiLdAll --wiki=metawiki', 'generate': None, 'long': True, 'nolog': False}
+

--- a/modules/mediawiki/files/bin/test_mwscript.py
+++ b/modules/mediawiki/files/bin/test_mwscript.py
@@ -171,7 +171,7 @@ def test_get_command_wiki_typo():
     assert mwscript.get_commands(args) == 2
 
 
-def test_get_command_nowiki):
+def test_get_command_nowiki():
     args = mwscript.get_args()
     args.script = 'test'
     args.arguments = []

--- a/modules/mediawiki/files/bin/test_mwscript.py
+++ b/modules/mediawiki/files/bin/test_mwscript.py
@@ -178,9 +178,9 @@ def test_get_command_nowiki():
     args.norunphp = True
     assert mwscript.get_commands(args) == 2
 
+
 def test_get_command_longextension():
     args = mwscript.get_args()
     args.script = 'extensions/Cargo/cargoRecreateData.php'
     args.arguments = ['metawiki']
     assert mwscript.syscheck(mwscript.get_commands(args)) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/extensions/Cargo/maintenance/cargoRecreateData.php --wiki=metawiki', 'generate': None, 'long': True, 'nolog': False}
-

--- a/modules/mediawiki/files/bin/test_mwscript.py
+++ b/modules/mediawiki/files/bin/test_mwscript.py
@@ -177,3 +177,10 @@ def test_get_command_nowiki():
     args.arguments = []
     args.norunphp = True
     assert mwscript.get_commands(args) == 2
+
+def test_get_command_longextension():
+    args = mwscript.get_args()
+    args.script = 'extensions/Cargo/cargoRecreateData.php'
+    args.arguments = []
+    assert mwscript.syscheck(mwscript.get_commands(args)) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/extensions/Cargo/maintenance/rebuilCargoData.php --wiki=metawiki', 'generate': None, 'long': True, 'nolog': False}
+

--- a/modules/mediawiki/files/bin/test_mwscript.py
+++ b/modules/mediawiki/files/bin/test_mwscript.py
@@ -181,6 +181,6 @@ def test_get_command_nowiki():
 def test_get_command_longextension():
     args = mwscript.get_args()
     args.script = 'extensions/Cargo/cargoRecreateData.php'
-    args.arguments = []
+    args.arguments = ['metawiki']
     assert mwscript.syscheck(mwscript.get_commands(args)) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/extensions/Cargo/maintenance/rebuilCargoData.php --wiki=metawiki', 'generate': None, 'long': True, 'nolog': False}
 

--- a/modules/mediawiki/files/bin/test_mwscript.py
+++ b/modules/mediawiki/files/bin/test_mwscript.py
@@ -8,7 +8,7 @@ def test_get_command_simple():
     args.script = 'test.php'
     args.arguments = ['metawiki']
     args.norunphp = True
-    assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/test.php --wiki=metawiki', 'generate': None, 'long': False, 'nolog': False}
+    assert mwscript.syscheck(mwscript.get_commands(args)) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/test.php --wiki=metawiki', 'generate': None, 'long': False, 'nolog': False}
 
 
 def test_get_command_extension():
@@ -16,7 +16,7 @@ def test_get_command_extension():
     args.script = 'extensions/CheckUser/test.php'
     args.arguments = ['metawiki']
     args.norunphp = True
-    assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/extensions/CheckUser/maintenance/test.php --wiki=metawiki', 'generate': None, 'long': False, 'nolog': False}
+    assert mwscript.syscheck(mwscript.get_commands(args)) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/extensions/CheckUser/maintenance/test.php --wiki=metawiki', 'generate': None, 'long': False, 'nolog': False}
 
 
 @patch.dict(os.environ, {'LOGNAME': 'test'})
@@ -27,7 +27,7 @@ def test_get_command_extension_list(mock_getlogin):
     args.script = 'test.php'
     args.extension = 'CheckUser'
     args.norunphp = True
-    assert mwscript.get_commands(args) == {
+    assert mwscript.syscheck(mwscript.get_commands(args)) == {
         'confirm': False,
         'command': f'sudo -u www-data /usr/local/bin/foreachwikiindblist /home/{os.environ["LOGNAME"]}/CheckUser.json /srv/mediawiki/w/maintenance/test.php',
         'generate': 'php /srv/mediawiki/w/extensions/MirahezeMagic/maintenance/generateExtensionDatabaseList.php --wiki=loginwiki --extension=CheckUser',
@@ -41,7 +41,7 @@ def test_get_command_all():
     args.script = 'test.php'
     args.arguments = ['all']
     args.norunphp = True
-    assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/databases.json /srv/mediawiki/w/maintenance/test.php', 'generate': None, 'long': True, 'nolog': False}
+    assert mwscript.syscheck(mwscript.get_commands(args)) == {'confirm': False, 'command': 'sudo -u www-data /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/databases.json /srv/mediawiki/w/maintenance/test.php', 'generate': None, 'long': True, 'nolog': False}
 
 
 def test_get_command_beta():
@@ -49,7 +49,7 @@ def test_get_command_beta():
     args.script = 'test.php'
     args.arguments = ['beta']
     args.norunphp = True
-    assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/beta.json /srv/mediawiki/w/maintenance/test.php', 'generate': None, 'long': True, 'nolog': False}
+    assert mwscript.syscheck(mwscript.get_commands(args)) == {'confirm': False, 'command': 'sudo -u www-data /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/beta.json /srv/mediawiki/w/maintenance/test.php', 'generate': None, 'long': True, 'nolog': False}
 
 
 def test_get_command_args():
@@ -57,7 +57,7 @@ def test_get_command_args():
     args.script = 'test.php'
     args.arguments = ['metawiki', '--test']
     args.norunphp = True
-    assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/test.php --wiki=metawiki --test', 'generate': None, 'long': False, 'nolog': False}
+    assert mwscript.syscheck(mwscript.get_commands(args)) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/test.php --wiki=metawiki --test', 'generate': None, 'long': False, 'nolog': False}
 
 
 def test_get_command_subdir():
@@ -65,21 +65,21 @@ def test_get_command_subdir():
     args.script = 'subdir/test.php'
     args.arguments = ['metawiki']
     args.norunphp = True
-    assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/subdir/test.php --wiki=metawiki', 'generate': None, 'long': False, 'nolog': False}
+    assert mwscript.syscheck(mwscript.get_commands(args)) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/subdir/test.php --wiki=metawiki', 'generate': None, 'long': False, 'nolog': False}
 
 
 def test_get_command_simple_runner():
     args = mwscript.get_args()
     args.script = 'test.php'
     args.arguments = ['metawiki']
-    assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/maintenance/test.php --wiki=metawiki', 'generate': None, 'long': False, 'nolog': False}
+    assert mwscript.syscheck(mwscript.get_commands(args)) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/maintenance/test.php --wiki=metawiki', 'generate': None, 'long': False, 'nolog': False}
 
 
 def test_get_command_extension_runner():
     args = mwscript.get_args()
     args.script = 'extensions/CheckUser/test.php'
     args.arguments = ['metawiki']
-    assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/extensions/CheckUser/maintenance/test.php --wiki=metawiki', 'generate': None, 'long': False, 'nolog': False}
+    assert mwscript.syscheck(mwscript.get_commands(args)) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/extensions/CheckUser/maintenance/test.php --wiki=metawiki', 'generate': None, 'long': False, 'nolog': False}
 
 
 @patch.dict(os.environ, {'LOGNAME': 'test'})
@@ -89,7 +89,7 @@ def test_get_command_extension_list_runner(mock_getlogin):
     args = mwscript.get_args()
     args.script = 'test.php'
     args.extension = 'CheckUser'
-    assert mwscript.get_commands(args) == {
+    assert mwscript.syscheck(mwscript.get_commands(args)) == {
         'confirm': False,
         'command': f'sudo -u www-data /usr/local/bin/foreachwikiindblist /home/{os.environ["LOGNAME"]}/CheckUser.json /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/maintenance/test.php',
         'generate': 'php /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/extensions/MirahezeMagic/maintenance/generateExtensionDatabaseList.php --wiki=loginwiki --extension=CheckUser',
@@ -102,28 +102,28 @@ def test_get_command_all_runner():
     args = mwscript.get_args()
     args.script = 'test.php'
     args.arguments = ['all']
-    assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/databases.json /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/maintenance/test.php', 'generate': None, 'long': True, 'nolog': False}
+    assert mwscript.syscheck(mwscript.get_commands(args)) == {'confirm': False, 'command': 'sudo -u www-data /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/databases.json /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/maintenance/test.php', 'generate': None, 'long': True, 'nolog': False}
 
 
 def test_get_command_beta_runner():
     args = mwscript.get_args()
     args.script = 'test.php'
     args.arguments = ['beta']
-    assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/beta.json /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/maintenance/test.php', 'generate': None, 'long': True, 'nolog': False}
+    assert mwscript.syscheck(mwscript.get_commands(args)) == {'confirm': False, 'command': 'sudo -u www-data /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/beta.json /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/maintenance/test.php', 'generate': None, 'long': True, 'nolog': False}
 
 
 def test_get_command_args_runner():
     args = mwscript.get_args()
     args.script = 'test.php'
     args.arguments = ['metawiki', '--test']
-    assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/maintenance/test.php --wiki=metawiki --test', 'generate': None, 'long': False, 'nolog': False}
+    assert mwscript.syscheck(mwscript.get_commands(args)) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/maintenance/test.php --wiki=metawiki --test', 'generate': None, 'long': False, 'nolog': False}
 
 
 def test_get_command_subdir_runner():
     args = mwscript.get_args()
     args.script = 'subdir/test.php'
     args.arguments = ['metawiki']
-    assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/maintenance/subdir/test.php --wiki=metawiki', 'generate': None, 'long': False, 'nolog': False}
+    assert mwscript.syscheck(mwscript.get_commands(args)) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/maintenance/subdir/test.php --wiki=metawiki', 'generate': None, 'long': False, 'nolog': False}
 
 
 def test_get_command_class():
@@ -131,25 +131,49 @@ def test_get_command_class():
     args.script = 'test'
     args.arguments = ['metawiki', '--test']
     args.confirm = True
-    assert mwscript.get_commands(args) == {'confirm': True, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php test --wiki=metawiki --test', 'generate': None, 'long': False, 'nolog': False}
+    assert mwscript.syscheck(mwscript.get_commands(args)) == {'confirm': True, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php test --wiki=metawiki --test', 'generate': None, 'long': False, 'nolog': False}
 
 
 def test_get_command_long_runner():
     args = mwscript.get_args()
     args.script = 'rebuildall.php'
     args.arguments = ['metawiki']
-    assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/maintenance/rebuildall.php --wiki=metawiki', 'generate': None, 'long': True, 'nolog': False}
+    assert mwscript.syscheck(mwscript.get_commands(args)) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/maintenance/rebuildall.php --wiki=metawiki', 'generate': None, 'long': True, 'nolog': False}
 
 
 def test_get_command_long_runner_class_lower():
     args = mwscript.get_args()
     args.script = 'rebuildall'
     args.arguments = ['metawiki']
-    assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php rebuildall --wiki=metawiki', 'generate': None, 'long': True, 'nolog': False}
+    assert mwscript.syscheck(mwscript.get_commands(args)) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php rebuildall --wiki=metawiki', 'generate': None, 'long': True, 'nolog': False}
 
 
 def test_get_command_long_runner_class_mixed():
     args = mwscript.get_args()
     args.script = 'rEbUiLdAll'
     args.arguments = ['metawiki']
-    assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php rEbUiLdAll --wiki=metawiki', 'generate': None, 'long': True, 'nolog': False}
+    assert mwscript.syscheck(mwscript.get_commands(args)) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php rEbUiLdAll --wiki=metawiki', 'generate': None, 'long': True, 'nolog': False}
+
+
+def test_get_command_class_norunner():
+    args = mwscript.get_args()
+    args.script = 'test'
+    args.arguments = ['metawiki']
+    args.norunphp = True
+    assert mwscript.get_commands(args) == 2
+
+
+def test_get_command_wiki_typo():
+    args = mwscript.get_args()
+    args.script = 'test'
+    args.arguments = ['metawik']
+    args.norunphp = True
+    assert mwscript.get_commands(args) == 2
+
+
+def test_get_command_nowiki):
+    args = mwscript.get_args()
+    args.script = 'test'
+    args.arguments = []
+    args.norunphp = True
+    assert mwscript.get_commands(args) == 2

--- a/modules/mediawiki/files/bin/test_mwscript.py
+++ b/modules/mediawiki/files/bin/test_mwscript.py
@@ -153,4 +153,3 @@ def test_get_command_long_runner_class_mixed():
     args.script = 'rEbUiLdAll'
     args.arguments = ['metawiki']
     assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php rEbUiLdAll --wiki=metawiki', 'generate': None, 'long': True, 'nolog': False}
-

--- a/modules/mediawiki/files/bin/test_mwscript.py
+++ b/modules/mediawiki/files/bin/test_mwscript.py
@@ -182,5 +182,5 @@ def test_get_command_longextension():
     args = mwscript.get_args()
     args.script = 'extensions/Cargo/cargoRecreateData.php'
     args.arguments = ['metawiki']
-    assert mwscript.syscheck(mwscript.get_commands(args)) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/extensions/Cargo/maintenance/rebuilCargoData.php --wiki=metawiki', 'generate': None, 'long': True, 'nolog': False}
+    assert mwscript.syscheck(mwscript.get_commands(args)) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/extensions/Cargo/maintenance/cargoRecreateData.php --wiki=metawiki', 'generate': None, 'long': True, 'nolog': False}
 

--- a/modules/mediawiki/files/bin/test_mwscript.py
+++ b/modules/mediawiki/files/bin/test_mwscript.py
@@ -7,6 +7,7 @@ def test_get_command_simple():
     args = mwscript.get_args()
     args.script = 'test.php'
     args.arguments = ['metawiki']
+    args.norunphp = True
     assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/test.php --wiki=metawiki', 'generate': None, 'long': False, 'nolog': False}
 
 
@@ -14,6 +15,7 @@ def test_get_command_extension():
     args = mwscript.get_args()
     args.script = 'extensions/CheckUser/test.php'
     args.arguments = ['metawiki']
+    args.norunphp = True
     assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/extensions/CheckUser/maintenance/test.php --wiki=metawiki', 'generate': None, 'long': False, 'nolog': False}
 
 
@@ -24,6 +26,7 @@ def test_get_command_extension_list(mock_getlogin):
     args = mwscript.get_args()
     args.script = 'test.php'
     args.extension = 'CheckUser'
+    args.norunphp = True
     assert mwscript.get_commands(args) == {
         'confirm': False,
         'command': f'sudo -u www-data /usr/local/bin/foreachwikiindblist /home/{os.environ["LOGNAME"]}/CheckUser.json /srv/mediawiki/w/maintenance/test.php',
@@ -37,6 +40,7 @@ def test_get_command_all():
     args = mwscript.get_args()
     args.script = 'test.php'
     args.arguments = ['all']
+    args.norunphp = True
     assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/databases.json /srv/mediawiki/w/maintenance/test.php', 'generate': None, 'long': True, 'nolog': False}
 
 
@@ -44,6 +48,7 @@ def test_get_command_beta():
     args = mwscript.get_args()
     args.script = 'test.php'
     args.arguments = ['beta']
+    args.norunphp = True
     assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/beta.json /srv/mediawiki/w/maintenance/test.php', 'generate': None, 'long': True, 'nolog': False}
 
 
@@ -51,6 +56,7 @@ def test_get_command_args():
     args = mwscript.get_args()
     args.script = 'test.php'
     args.arguments = ['metawiki', '--test']
+    args.norunphp = True
     assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/test.php --wiki=metawiki --test', 'generate': None, 'long': False, 'nolog': False}
 
 
@@ -58,6 +64,7 @@ def test_get_command_subdir():
     args = mwscript.get_args()
     args.script = 'subdir/test.php'
     args.arguments = ['metawiki']
+    args.norunphp = True
     assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/subdir/test.php --wiki=metawiki', 'generate': None, 'long': False, 'nolog': False}
 
 
@@ -65,7 +72,6 @@ def test_get_command_simple_runner():
     args = mwscript.get_args()
     args.script = 'test.php'
     args.arguments = ['metawiki']
-    args.runner = True
     assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/maintenance/test.php --wiki=metawiki', 'generate': None, 'long': False, 'nolog': False}
 
 
@@ -73,7 +79,6 @@ def test_get_command_extension_runner():
     args = mwscript.get_args()
     args.script = 'extensions/CheckUser/test.php'
     args.arguments = ['metawiki']
-    args.runner = True
     assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/extensions/CheckUser/maintenance/test.php --wiki=metawiki', 'generate': None, 'long': False, 'nolog': False}
 
 
@@ -84,7 +89,6 @@ def test_get_command_extension_list_runner(mock_getlogin):
     args = mwscript.get_args()
     args.script = 'test.php'
     args.extension = 'CheckUser'
-    args.runner = True
     assert mwscript.get_commands(args) == {
         'confirm': False,
         'command': f'sudo -u www-data /usr/local/bin/foreachwikiindblist /home/{os.environ["LOGNAME"]}/CheckUser.json /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/maintenance/test.php',
@@ -98,7 +102,6 @@ def test_get_command_all_runner():
     args = mwscript.get_args()
     args.script = 'test.php'
     args.arguments = ['all']
-    args.runner = True
     assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/databases.json /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/maintenance/test.php', 'generate': None, 'long': True, 'nolog': False}
 
 
@@ -106,7 +109,6 @@ def test_get_command_beta_runner():
     args = mwscript.get_args()
     args.script = 'test.php'
     args.arguments = ['beta']
-    args.runner = True
     assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/beta.json /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/maintenance/test.php', 'generate': None, 'long': True, 'nolog': False}
 
 
@@ -114,7 +116,6 @@ def test_get_command_args_runner():
     args = mwscript.get_args()
     args.script = 'test.php'
     args.arguments = ['metawiki', '--test']
-    args.runner = True
     assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/maintenance/test.php --wiki=metawiki --test', 'generate': None, 'long': False, 'nolog': False}
 
 
@@ -122,7 +123,6 @@ def test_get_command_subdir_runner():
     args = mwscript.get_args()
     args.script = 'subdir/test.php'
     args.arguments = ['metawiki']
-    args.runner = True
     assert mwscript.get_commands(args) == {'confirm': False, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php /srv/mediawiki/w/maintenance/subdir/test.php --wiki=metawiki', 'generate': None, 'long': False, 'nolog': False}
 
 
@@ -130,6 +130,5 @@ def test_get_command_class():
     args = mwscript.get_args()
     args.script = 'test'
     args.arguments = ['metawiki', '--test']
-    args.runner = True
     args.confirm = True
     assert mwscript.get_commands(args) == {'confirm': True, 'command': 'sudo -u www-data php /srv/mediawiki/w/maintenance/run.php test --wiki=metawiki --test', 'generate': None, 'long': False, 'nolog': False}


### PR DESCRIPTION
CHANGELOG

- Drops `--140`/`--use-runner` option (now default)
- adds `--no-runner` to switch to old behaviour
- added `syscheck` method
- `get_commands` can now return an int as well as CommandInfo. Result of get_commands can be passed to syscheck method which will pass int to sys.exit or return CommandInfo. Migration `X = get_commands(args)` becomes `X = syscheck(get_commands(args))`

Developer Notes:
- Added some extra tests
- `get_commands` no longer calls `sys.exit` at any point