### PR TITLE
swift: Allow bastion to connect to swift-lb

### DIFF
--- a/modules/role/manifests/swift.pp
+++ b/modules/role/manifests/swift.pp
@@ -7,7 +7,7 @@ class role::swift (
     include ::swift::ring
 
     $firewall_rules_str = join(
-        query_facts("networking.domain='${facts['networking']['domain']}' and (Class[Role::Swift] or Class[Role::Mediawiki] or Class[Role::Icinga2] or Class[Role::Prometheus])", ['networking'])
+        query_facts("networking.domain='${facts['networking']['domain']}' and (Class[Role::Swift] or Class[Role::Mediawiki] or Class[Role::Icinga2] or Class[Role::Prometheus] or Class[Role::Bastion])", ['networking'])
         .map |$key, $value| {
             "${value['networking']['ip']} ${value['networking']['ip6']}"
         }


### PR DESCRIPTION
This is because we use the http proxy in MediaWIki and thus need bastions to be allowed to talk to swift-lb.