### PR TITLE
jobrunner-hi: tune real/time for jobs

### DIFF
--- a/modules/mediawiki/templates/jobrunner-hi.json.erb
+++ b/modules/mediawiki/templates/jobrunner-hi.json.erb
@@ -114,22 +114,14 @@
             "*": 3600,
             "DataDumpGenerateJob": 86400,
             "NamespaceMigrationJob": 9000,
-            "parsoidCachePrewarm": 9000,
-            "refreshLinks": 9000,
-            "refreshLinksDynamic": 9000,
-            "refreshLinksPrioritized": 9000,
             "webVideoTranscode": 86400,
             "webVideoTranscodePrioritized": 86400
         },
         // runJobs.php process time limits
         "real": {
             "*": 300,
-            "DataDumpGenerateJob": 21600,
+            "DataDumpGenerateJob": 86400,
             "NamespaceMigrationJob": 9000,
-            "parsoidCachePrewarm": 9000,
-            "refreshLinks": 9000,
-            "refreshLinksDynamic": 9000,
-            "refreshLinksPrioritized": 9000,
             "webVideoTranscode": 86400,
             "webVideoTranscodePrioritized": 86400
         },


### PR DESCRIPTION
* Removes parsoidCachePrewarm, refreshLinks* from claimTTL and real.
* Adjust DataDumpGenerateJob time for real.
