### PR TITLE
mediawiki::deploy: install langcodes with --break-system-packages

### DIFF
--- a/modules/mediawiki/manifests/deploy.pp
+++ b/modules/mediawiki/manifests/deploy.pp
@@ -43,6 +43,7 @@ class mediawiki::deploy {
         {
             ensure   => '3.3.0',
             provider => 'pip3',
+            install_options => [ '--break-system-packages' ],
             before   => File['/usr/local/bin/mwdeploy'],
             require  => Package['python3-pip'],
         },


### PR DESCRIPTION
Requires on Debian 12.