### PR TITLE
dns: fix recursor for ipv6 only hosts

### DIFF
--- a/modules/base/templates/dns/recursor.conf.erb
+++ b/modules/base/templates/dns/recursor.conf.erb
@@ -18,7 +18,7 @@ max-cache-ttl = 600
 stats-ringbuffer-entries=1000
 
 # Ensure transport for outgoing queries works for ipv4 and ipv6
-query-local-address=0.0.0.0,[::]
+query-local-address=::
 
 # This prevents pdns from polling a public server to check for sec fixes
 security-poll-suffix=


### PR DESCRIPTION
* It appears that sometimes ipv4 addresses are used. This appears to happen only when query-local-address contains 0.0.0.0.
  Fix this by only using ipv6 (::).