### PR TITLE
dns: set query-local-address to ::

### DIFF
--- a/modules/base/templates/dns/recursor.conf.erb
+++ b/modules/base/templates/dns/recursor.conf.erb
@@ -17,6 +17,8 @@ max-cache-ttl = 600
 
 stats-ringbuffer-entries=1000
 
+query-local-address=::
+
 # This prevents pdns from polling a public server to check for sec fixes
 security-poll-suffix=
 


### PR DESCRIPTION
Uses ipv6 for outgoing queries otherwise it's disabled and only ipv4 is used.
