### PR TITLE
mediawiki: use a variable for swift-lb in nginx

### DIFF
--- a/modules/mediawiki/templates/mediawiki.conf.erb
+++ b/modules/mediawiki/templates/mediawiki.conf.erb
@@ -168,7 +168,8 @@ server {
 	}
 
         location / {
-                proxy_pass https://swift-lb.miraheze.org;
+                set $swift_proxy swift-lb.miraheze.org;
+                proxy_pass https://$swift_proxy;
                 proxy_http_version 1.1;
                 proxy_set_header Connection close; # should be default
 


### PR DESCRIPTION
See https://stackoverflow.com/questions/56486489/nginx-caching-dns-look-ups-and-ignoring-my-resolver-settings