### PR TITLE
Don't unset X-Miraheze-Debug

### DIFF
--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -245,8 +245,6 @@ sub mw_request {
 				set req.backend_hint = <%= name %>_test;
 			}
 			return (pass);
-		} else {
-			unset req.http.X-Miraheze-Debug;
 		}
 <%- end -%>
 <%- end -%>


### PR DESCRIPTION
This causes it to be unset on the first-non-match making it basically only work for the very first backend making things like mwdeploy always fail after the first backend