### PR TITLE
Revert "sshd: enforce use of PIN+Touch on FIDO SSH"

### DIFF
--- a/modules/ssh/templates/sshd_config.erb
+++ b/modules/ssh/templates/sshd_config.erb
@@ -19,7 +19,6 @@ LogLevel VERBOSE
 
 # Authentication:
 LoginGraceTime 120
-PubkeyAuthOptions verify-required
 <% if @permit_root %>
 PermitRootLogin yes
 <% else %>


### PR DESCRIPTION
Reverts miraheze/puppet#3204

My key malfunctions with this no matter what I do. Maybe we can do this when we all have Yubikey Bio keys, but not now.