### PR TITLE
Allow varnish to use mediawiki port 80

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -34,51 +34,71 @@ varnish::backends:
     probe: mwhealth
     pool: true
     xdebug: true
+    private_ip: 10.0.15.115
+    private_ip_port: 80
   mw152:
     port: 8114
     probe: mwhealth
     pool: true
     xdebug: true
+    private_ip: 10.0.15.116
+    private_ip_port: 80
   mw161:
     port: 8115
     probe: mwhealth
     pool: true
     xdebug: true
+    private_ip: 10.0.16.132
+    private_ip_port: 80
   mw162:
     port: 8116
     probe: mwhealth
     pool: true
     xdebug: true
+    private_ip: 10.0.16.133
+    private_ip_port: 80
   mw171:
     port: 8117
     probe: mwhealth
     pool: true
     xdebug: true
+    private_ip: 10.0.17.122
+    private_ip_port: 80
   mw172:
     port: 8118
     probe: mwhealth
     pool: true
     xdebug: true
+    private_ip: 10.0.17.123
+    private_ip_port: 80
   mw181:
     port: 8119
     probe: mwhealth
     pool: true
     xdebug: true
+    private_ip: 10.0.18.104
+    private_ip_port: 80
   mw182:
     port: 8120
     probe: mwhealth
     pool: true
     xdebug: true
+    private_ip: 10.0.18.105
+    private_ip_port: 80
   mwtask181:
     port: 8160
     probe: false
     pool: false
     xdebug: true
+    private_ip: 10.0.18.106
+    private_ip_port: 80
   test151:
     port: 8181
     probe: false
     pool: false
     xdebug: true
+    private_ip: 10.0.15.118
+    private_ip_port: 80
   mon181:
     port: 8201
     probe: false

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -35,70 +35,70 @@ varnish::backends:
     pool: true
     xdebug: true
     private_ip: 10.0.15.115
-    private_ip_port: 80
+    private_ip_port: 8080
   mw152:
     port: 8114
     probe: mwhealth
     pool: true
     xdebug: true
     private_ip: 10.0.15.116
-    private_ip_port: 80
+    private_ip_port: 8080
   mw161:
     port: 8115
     probe: mwhealth
     pool: true
     xdebug: true
     private_ip: 10.0.16.132
-    private_ip_port: 80
+    private_ip_port: 8080
   mw162:
     port: 8116
     probe: mwhealth
     pool: true
     xdebug: true
     private_ip: 10.0.16.133
-    private_ip_port: 80
+    private_ip_port: 8080
   mw171:
     port: 8117
     probe: mwhealth
     pool: true
     xdebug: true
     private_ip: 10.0.17.122
-    private_ip_port: 80
+    private_ip_port: 8080
   mw172:
     port: 8118
     probe: mwhealth
     pool: true
     xdebug: true
     private_ip: 10.0.17.123
-    private_ip_port: 80
+    private_ip_port: 8080
   mw181:
     port: 8119
     probe: mwhealth
     pool: true
     xdebug: true
     private_ip: 10.0.18.104
-    private_ip_port: 80
+    private_ip_port: 8080
   mw182:
     port: 8120
     probe: mwhealth
     pool: true
     xdebug: true
     private_ip: 10.0.18.105
-    private_ip_port: 80
+    private_ip_port: 8080
   mwtask181:
     port: 8160
     probe: false
     pool: false
     xdebug: true
     private_ip: 10.0.18.106
-    private_ip_port: 80
+    private_ip_port: 8080
   test151:
     port: 8181
     probe: false
     pool: false
     xdebug: true
     private_ip: 10.0.15.118
-    private_ip_port: 80
+    private_ip_port: 8080
   mon181:
     port: 8201
     probe: false

--- a/hieradata/hosts/cp36.yaml
+++ b/hieradata/hosts/cp36.yaml
@@ -5,3 +5,4 @@ nginx::worker_processes: 6
 
 base::syslog::rsyslog_udp_localhost: true
 nginx::logrotate_number: 2
+varnish::use_private_ip: true

--- a/hieradata/hosts/cp37.yaml
+++ b/hieradata/hosts/cp37.yaml
@@ -5,3 +5,4 @@ nginx::worker_processes: 6
 
 base::syslog::rsyslog_udp_localhost: true
 nginx::logrotate_number: 2
+varnish::use_private_ip: true

--- a/modules/mediawiki/templates/mediawiki.conf.erb
+++ b/modules/mediawiki/templates/mediawiki.conf.erb
@@ -144,6 +144,39 @@ server {
 }
 
 server {
+	listen 80 deferred backlog=4096 reuseport;
+	listen [::]:80 deferred backlog=4096 reuseport;
+
+	server_name *.wikitide.net.org;
+	root /srv/mediawiki;
+
+	add_header X-Served-By '<%= @facts['networking']['fqdn'] %>';
+
+	# XSS Protection
+	add_header x-xss-protection "1; mode=block" always;
+
+	add_header X-Frame-Options "ALLOW-FROM static.miraheze.org";
+
+	error_page 404 /ErrorPages/404.php;
+	error_page 502 /ErrorPages/502.html;
+	error_page 504 /ErrorPages/504.php;
+
+	include /etc/nginx/mediawiki-includes;
+
+	location = /robots.txt {
+		rewrite ^(.*)$ /robots.php;
+	}
+
+	location = /check {
+		rewrite ^(.*)$ /healthcheck.php;
+	}
+
+	location = /sitemap.xml {
+		rewrite ^(.*)$ /sitemap.php;
+	}
+}
+
+server {
 	listen 443 ssl http2;
 	listen [::]:443 ssl http2;
 

--- a/modules/mediawiki/templates/mediawiki.conf.erb
+++ b/modules/mediawiki/templates/mediawiki.conf.erb
@@ -147,7 +147,7 @@ server {
 	listen 80 deferred backlog=4096 reuseport;
 	listen [::]:80 deferred backlog=4096 reuseport;
 
-	server_name *.wikitide.net.org;
+	server_name <%= @facts['networking']['interfaces']['ens19']['ip'] %>;
 	root /srv/mediawiki;
 
 	add_header X-Served-By '<%= @facts['networking']['fqdn'] %>';

--- a/modules/mediawiki/templates/mediawiki.conf.erb
+++ b/modules/mediawiki/templates/mediawiki.conf.erb
@@ -144,8 +144,8 @@ server {
 }
 
 server {
-	listen 80 deferred backlog=4096 reuseport;
-	listen [::]:80 deferred backlog=4096 reuseport;
+	listen 8080 deferred backlog=4096 reuseport;
+	listen [::]:8080 deferred backlog=4096 reuseport;
 
 	server_name <%= @facts['networking']['interfaces']['ens19']['ip'] %>;
 	root /srv/mediawiki;

--- a/modules/role/manifests/mediawiki.pp
+++ b/modules/role/manifests/mediawiki.pp
@@ -46,6 +46,13 @@ class role::mediawiki (
             srange  => "(${firewall_rules_str})",
             notrack => true,
         }
+
+        ferm::service { 'http_8080':
+            proto   => 'tcp',
+            port    => '8080',
+            srange  => "(${firewall_rules_str})",
+            notrack => true,
+        }
     } else {
         ferm::service { 'http':
             proto   => 'tcp',

--- a/modules/varnish/manifests/init.pp
+++ b/modules/varnish/manifests/init.pp
@@ -43,6 +43,7 @@ class varnish (
     $backends = lookup('varnish::backends')
     $interval_check = lookup('varnish::interval-check')
     $interval_timeout = lookup('varnish::interval-timeout')
+    $use_private_ip = lookup('varnish::use_private_ip', {'default_value' => undef})
 
     $debug_access_key = lookup('passwords::varnish::debug_access_key')
 

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -32,8 +32,16 @@ probe mwhealth {
 
 <%- @backends.each_pair do | name, property | -%>
 backend <%= name %> {
+<%- if property['private_ip'] and @use_private_ip -%>
+	.host = "<%= property['private_ip'] %>";
+<%- else -%>
 	.host = "127.0.0.1";
+<%- end -%>
+<%- if property['private_ip_port'] and @use_private_ip -%>
+	.port = "<%= property['private_ip_port'] %>";
+<%- else -%>
 	.port = "<%= property['port'] %>";
+<%- end -%>
 <%- if property['probe'] -%>
 	.probe = <%= property['probe'] %>;
 <%- end -%>
@@ -45,8 +53,16 @@ backend <%= name %> {
 
 <%- if property['xdebug'] -%>
 backend <%= name %>_test {
+<%- if property['private_ip'] and @use_private_ip -%>
+	.host = "<%= property['private_ip'] %>";
+<%- else -%>
 	.host = "127.0.0.1";
+<%- end -%>
+<%- if property['private_ip_port'] and @use_private_ip -%>
+	.port = "<%= property['private_ip_port'] %>";
+<%- else -%>
 	.port = "<%= property['port'] %>";
+<%- end -%>
         .connect_timeout = 3s;
         .first_byte_timeout = 63s;
         .between_bytes_timeout = 31s;


### PR DESCRIPTION
This will only be used on cp36/37 that can use a internal private ip.