### PR TITLE
relaybot: remove #wikitide-cvt-feed

### DIFF
--- a/modules/irc/templates/relaybot/config-relaybot2.ini.erb
+++ b/modules/irc/templates/relaybot/config-relaybot2.ini.erb
@@ -12,7 +12,6 @@ Proxy = <%= @http_proxy %>
 [ChannelMapping]
 1088870295970009221 = #wikitide
 1159355587486810112 = #wikitide-cvt
-1175925489135784096 = #wikitide-cvt-feed
 1130665399386656838 = #wikitide-sre
 1190824030853406761 = #wikitide-sre-security
 


### PR DESCRIPTION
cvtbot has been shutdown for WT so channel no longer needed