### PR TITLE
MirahezeLogbot: Don't join #miraheze-sre-security

### DIFF
--- a/modules/irc/templates/logbot/config.py
+++ b/modules/irc/templates/logbot/config.py
@@ -29,7 +29,7 @@ twitter_api_params = {
 }
 
 # Channels to join
-targets = ("#miraheze-sre", "#miraheze-sre-security")
+targets = ("#miraheze-sre",)
 
 # Name of nickserv user
 nickserv = "nickserv"


### PR DESCRIPTION
I previously tried this in #1757 and it was reverted in #1759 as only one made it not being able to join at all, but I realized why: if there is not a comma after a single-element tuple, Python will not recognize it as a tuple at all, amd thus the for loop that makes it connect to IRC channels does nothing. So I want to see if this works. If it doesn't, we can revert again.

### EXAMPLE:
```py
targets = ("#miraheze-sre",)
print(type(targets))

<class 'tuple'>

targets = ("#miraheze-sre")
print(type(targets))

<class 'str'>
```