### PR TITLE
graylog: use logging.wikitide.net

### DIFF
--- a/modules/monitoring/manifests/init.pp
+++ b/modules/monitoring/manifests/init.pp
@@ -93,7 +93,7 @@ class monitoring (
     }
 
     class { '::icinga2::feature::gelf':
-        host => 'graylog.miraheze.org',
+        host => 'logging.wikitide.net',
     }
 
     file { '/etc/icinga2/conf.d/commands.conf':

--- a/modules/role/files/graylog/logging.wikitide.net.conf
+++ b/modules/role/files/graylog/logging.wikitide.net.conf
@@ -2,10 +2,10 @@ server {
 	listen 80;
 	listen [::]:80;
 
-	server_name graylog.miraheze.org;
+	server_name logging.wikitide.net;
 
 	location / {
-		return 301 https://graylog.miraheze.org/;
+		return 301 https://logging.wikitide.net/;
 	}
 }
 
@@ -13,10 +13,10 @@ server {
 	listen 443 ssl http2;
 	listen [::]:443 ssl http2;
 
-	server_name graylog.miraheze.org;
+	server_name logging.wikitide.net;
 
-	ssl_certificate /etc/ssl/localcerts/wildcard.miraheze.org-2020-2.crt;
-	ssl_certificate_key /etc/ssl/private/wildcard.miraheze.org-2020-2.key;
+	ssl_certificate /etc/ssl/localcerts/wikitide.net.crt;
+	ssl_certificate_key /etc/ssl/private/wikitide.net.key;
 
 	add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload";
 

--- a/modules/role/manifests/graylog.pp
+++ b/modules/role/manifests/graylog.pp
@@ -7,7 +7,7 @@ class role::graylog {
 
     nginx::site { 'graylog_proxy':
         ensure => present,
-        source => 'puppet:///modules/role/graylog/graylog.miraheze.org.conf',
+        source => 'puppet:///modules/role/graylog/logging.wikitide.net.conf',
     }
 
     class { 'mongodb::globals':

--- a/modules/role/manifests/prometheus.pp
+++ b/modules/role/manifests/prometheus.pp
@@ -5,7 +5,7 @@ class role::prometheus {
     $blackbox_web_urls = [
         'https://issue-tracker.miraheze.org',
         'https://analytics.wikitide.net',
-        'https://graylog.miraheze.org'
+        'https://logging.wikitide.net'
     ]
 
     file { '/etc/prometheus/targets/blackbox_web_urls.yaml':


### PR DESCRIPTION
Internal services can match hostnames on wikitide.net, which is the purpose of that domain to not have internal stuff on miraheze.org much.