### PR TITLE
grafana: use grafana.wikitide.net

### DIFF
--- a/modules/grafana/files/nginx/grafana.conf
+++ b/modules/grafana/files/nginx/grafana.conf
@@ -8,7 +8,7 @@ server {
 	listen 80;
 	listen [::]:80;
 
-	server_name grafana.miraheze.org;
+	server_name grafana.wikitide.net;
 	root /usr/share/grafana/public;
 
 	location /php_status {
@@ -20,7 +20,7 @@ server {
 	}
 
 	location / {
-		return 301 https://grafana.miraheze.org/;
+		return 301 https://grafana.wikitide.net/;
 	}
 }
 
@@ -28,11 +28,11 @@ server {
 	listen 443 ssl http2;
 	listen [::]:443 ssl http2;
 
-	server_name grafana.miraheze.org;
+	server_name grafana.wikitide.net;
 	root /usr/share/grafana/public;
 
-	ssl_certificate /etc/ssl/localcerts/wildcard.miraheze.org-2020-2.crt;
-	ssl_certificate_key /etc/ssl/private/wildcard.miraheze.org-2020-2.key;
+	ssl_certificate /etc/ssl/localcerts/wikitide.net.crt;
+	ssl_certificate_key /etc/ssl/private/wikitide.net.key;
 
 	add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload";
 

--- a/modules/grafana/manifests/init.pp
+++ b/modules/grafana/manifests/init.pp
@@ -58,7 +58,7 @@ class grafana (
 
     ssl::wildcard { 'grafana wildcard': }
 
-    nginx::site { 'grafana.miraheze.org':
+    nginx::site { 'grafana.wikitide.net':
         ensure => present,
         source => 'puppet:///modules/grafana/nginx/grafana.conf',
     }
@@ -71,12 +71,12 @@ class grafana (
         $address = $facts['networking']['ip6']
     }
 
-    monitoring::services { 'grafana.miraheze.org HTTPS':
+    monitoring::services { 'grafana.wikitide.net HTTPS':
         check_command => 'check_http',
         vars          => {
             address6   => $address,
             http_ssl   => true,
-            http_vhost => 'grafana.miraheze.org',
+            http_vhost => 'grafana.wikitide.net',
         },
     }
 }

--- a/modules/grafana/templates/grafana.ini.erb
+++ b/modules/grafana/templates/grafana.ini.erb
@@ -1,5 +1,5 @@
 [server]
-domain = grafana.miraheze.org
+domain = grafana.wikitide.net
 root_url = %(protocol)s://%(domain)s/
 enable_gzip = true
 

--- a/modules/varnish/templates/default.vcl
+++ b/modules/varnish/templates/default.vcl
@@ -409,7 +409,7 @@ sub vcl_recv {
 	}
 
 	# Do not cache requests from this domain
-	if (req.http.Host == "icinga.miraheze.org" || req.http.Host == "grafana.miraheze.org") {
+	if (req.http.Host == "icinga.miraheze.org" || req.http.Host == "grafana.wikitide.net") {
 		set req.backend_hint = mon181;
 
 		if (req.http.upgrade ~ "(?i)websocket") {


### PR DESCRIPTION
Internal services can match hostnames on wikitide.net, which is the purpose of that domain to not have internal stuff on miraheze.org much.