### PR TITLE
ldap: use ldap.wikitide.net

### DIFF
--- a/modules/grafana/templates/ldap.toml.erb
+++ b/modules/grafana/templates/ldap.toml.erb
@@ -1,6 +1,6 @@
 [[servers]]
 # Ldap server host (specify multiple hosts space separated)
-host = "ldap.miraheze.org"
+host = "ldap.wikitide.net"
 # Default port is 389 or 636 if use_ssl = true
 port = 636
 # Set to true if ldap server supports TLS
@@ -10,7 +10,7 @@ start_tls = false
 # set to true if you want to skip ssl cert validation
 ssl_skip_verify = false
 # set to the path to your root CA certificate or leave unset to use system defaults
-root_ca_cert = "/etc/ssl/certs/Sectigo.crt"
+root_ca_cert = "/etc/ssl/certs/LetsEncrypt.crt"
 
 # Search user bind dn
 bind_dn = "cn=write-user,dc=miraheze,dc=org"

--- a/modules/icingaweb2/templates/resources.ini.erb
+++ b/modules/icingaweb2/templates/resources.ini.erb
@@ -1,6 +1,6 @@
 [auth_ldap]
 type = "ldap"
-hostname = "ldap.miraheze.org"
+hostname = "ldap.wikitide.net"
 port = "636"
 root_dn = "dc=miraheze,dc=org"
 bind_dn = "cn=write-user,dc=miraheze,dc=org"

--- a/modules/matomo/templates/config.ini.php.erb
+++ b/modules/matomo/templates/config.ini.php.erb
@@ -195,7 +195,7 @@ strip_domain_from_web_auth = 1
 enable_password_confirmation = 0
 
 [LoginLdap_WikiTide_Ldap]
-hostname = "ldaps://ldap.miraheze.org/"
+hostname = "ldaps://ldap.wikitide.net/"
 port = 636
 base_dn = "dc=miraheze,dc=org"
 admin_user = "cn=write-user,dc=miraheze,dc=org"

--- a/modules/role/manifests/openldap.pp
+++ b/modules/role/manifests/openldap.pp
@@ -13,9 +13,9 @@ class role::openldap (
 
     class { 'openldap::server':
         ldaps_ifs => ['/'],
-        ssl_ca    => '/etc/ssl/certs/Sectigo.crt',
-        ssl_cert  => '/etc/ssl/localcerts/wildcard.miraheze.org-2020-2.crt',
-        ssl_key   => '/etc/ssl/private/wildcard.miraheze.org-2020-2.key',
+        ssl_ca    => '/etc/ssl/certs/LetsEncrypt.crt',
+        ssl_cert  => '/etc/ssl/localcerts/wikitide.net.crt',
+        ssl_key   => '/etc/ssl/private/wikitide.net.key',
         require   => Ssl::Wildcard['openldap wildcard']
     }
 
@@ -146,7 +146,7 @@ class role::openldap (
     class { 'openldap::client':
         base       => 'dc=miraheze,dc=org',
         uri        => ["ldaps://${facts['networking']['fqdn']}"],
-        tls_cacert => '/etc/ssl/certs/Sectigo.crt',
+        tls_cacert => '/etc/ssl/certs/LetsEncrypt.crt',
     }
 
     include prometheus::exporter::openldap


### PR DESCRIPTION
Internal services can match hostnames on wikitide.net, which is the purpose of that domain to not have internal stuff on miraheze.org much.