### PR TITLE
jobrunner: remove default ports from apache2

### DIFF
--- a/hieradata/hosts/mwtask171.yaml
+++ b/hieradata/hosts/mwtask171.yaml
@@ -34,3 +34,5 @@ nginx::keepalive_requests: 150
 nginx::logrotate_number: 2
 nginx::use_graylog: true
 nginx::remove_apache: false
+
+httpd::remove_default_ports: true

--- a/hieradata/hosts/mwtask181.yaml
+++ b/hieradata/hosts/mwtask181.yaml
@@ -34,3 +34,5 @@ nginx::keepalive_requests: 150
 nginx::logrotate_number: 2
 nginx::use_graylog: true
 nginx::remove_apache: false
+
+httpd::remove_default_ports: true

--- a/hieradata/hosts/test151.yaml
+++ b/hieradata/hosts/test151.yaml
@@ -51,6 +51,8 @@ nginx::logrotate_number: 2
 nginx::use_graylog: true
 nginx::remove_apache: false
 
+httpd::remove_default_ports: true
+
 # memcached
 role::memcached::threads: ~
 role::memcached::version: 'present'

--- a/modules/httpd/manifests/init.pp
+++ b/modules/httpd/manifests/init.pp
@@ -12,7 +12,7 @@
 # @param wait_network_online Set to true to have the service to run after
 #   network-online.target. Can be used when Apache is configured to Listen to
 #   an explicit IP address.
-class httpd(
+class httpd (
     Array[String]           $modules              = [],
     VMlib::Ensure           $legacy_compat        = present,
     Enum['daily', 'weekly'] $period               = 'daily',
@@ -20,9 +20,9 @@ class httpd(
     Boolean                 $enable_forensic_log  = false,
     Array[String]           $extra_pkgs           = [],
     Boolean                 $purge_manual_config  = true,
-    Boolean                 $remove_default_ports = false,
     Boolean                 $http_only            = false,
     Boolean                 $wait_network_online  = false,
+    Boolean                 $remove_default_ports = lookup('httpd::remove_default_ports', {'default_value' => false}),
 ) {
     # Package and service. Links is needed for the status page below
     $base_pkgs = ['apache2', 'links']


### PR DESCRIPTION
So that it does not conflict with nginx