### PR TITLE
opensearch: use opensearch.wikitide.net

### DIFF
--- a/hieradata/hosts/graylog161.yaml
+++ b/hieradata/hosts/graylog161.yaml
@@ -1,4 +1,4 @@
 mongodb::repo::aptkey_options: 'http-proxy="http://bastion.wikitide.net:8080"'
 http_proxy: 'http://bastion.wikitide.net:8080'
-elasticsearch_host: 'https://opensearch.miraheze.org'
+elasticsearch_host: 'https://opensearch.wikitide.net'
 mongodb_version: '7.0.5'

--- a/modules/prometheus/templates/initscripts/prometheus-es-exporter.systemd_override.erb
+++ b/modules/prometheus/templates/initscripts/prometheus-es-exporter.systemd_override.erb
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=/usr/bin/prometheus-es-exporter --config-dir /etc/prometheus-es-exporter --es-cluster https://opensearch.miraheze.org --ca-certs /etc/ssl/certs/Sectigo.crt --addr :: --cluster-health-disable --nodes-stats-disable --indices-aliases-disable --indices-mappings-disable --indices-stats-disable
+ExecStart=/usr/bin/prometheus-es-exporter --config-dir /etc/prometheus-es-exporter --es-cluster https://opensearch.wikitide.net --ca-certs /etc/ssl/certs/LetsEncrypt.crt --addr :: --cluster-health-disable --nodes-stats-disable --indices-aliases-disable --indices-mappings-disable --indices-stats-disable

--- a/modules/role/manifests/opensearch.pp
+++ b/modules/role/manifests/opensearch.pp
@@ -24,8 +24,8 @@ class role::opensearch (
             'plugins.security.ssl.transport.pemtrustedcas_filepath' => '/etc/opensearch/ssl/opensearch-ca.pem',
             'plugins.security.ssl_cert_reload_enabled'              => true,
             # TODO: Admin must use its own certificate.
-            'plugins.security.authcz.admin_dn'                      => ['CN=ADMIN_MIRAHEZE,O=Miraheze LTD,L=Worksop,ST=Nottinghamshire,C=GB'],
-            'plugins.security.nodes_dn'                             => ['CN=*.miraheze.org'],
+            'plugins.security.authcz.admin_dn'                      => ['CN=ADMIN_WIKITIDE,O=WikiTide Foundation,L=Washington,ST=DC,C=US'],
+            'plugins.security.nodes_dn'                             => ['CN=*.wikitide.net'],
             'plugins.security.restapi.roles_enabled'                => ['all_access', 'security_rest_api_access'],
         }
     } else {
@@ -38,7 +38,7 @@ class role::opensearch (
         config      => {
             'cluster.initial_master_nodes' => $os_master_hosts,
             'discovery.seed_hosts'         => $os_discovery,
-            'cluster.name'                 => 'miraheze-general',
+            'cluster.name'                 => 'wikitide-general',
             'node.master'                  => $os_master,
             'node.data'                    => $os_data,
             'network.host'                 => '0.0.0.0',
@@ -175,7 +175,7 @@ class role::opensearch (
         # For nginx
         ssl::wildcard { 'opensearch wildcard': }
 
-        nginx::site { 'opensearch.miraheze.org':
+        nginx::site { 'opensearch.wikitide.net':
             ensure  => present,
             content => template('role/opensearch/nginx.conf.erb'),
             monitor => false,

--- a/modules/role/templates/opensearch/nginx.conf.erb
+++ b/modules/role/templates/opensearch/nginx.conf.erb
@@ -2,25 +2,7 @@ server {
 	listen 443 ssl http2 deferred;
 	listen [::]:443 ssl http2 deferred;
 
-	server_name opensearch.miraheze.org;
-
-	ssl_certificate /etc/ssl/localcerts/wildcard.miraheze.org-2020-2.crt;
-	ssl_certificate_key /etc/ssl/private/wildcard.miraheze.org-2020-2.key;
-
-	location / {
-		proxy_pass <%= @os_master_host %>;
-		proxy_set_header Connection "Keep-Alive";
-		proxy_set_header Host $http_host;
-		proxy_set_header Proxy-Connection "Keep-Alive";
-		proxy_set_header X-Real-IP $remote_addr;
-	}
-}
-
-server {
-	listen 443 ssl http2;
-	listen [::]:443 ssl http2;
-
-	server_name opensearch-mw.wikitide.net;
+	server_name opensearch.wikitide.net opensearch-mw.wikitide.net;
 
 	ssl_certificate /etc/ssl/localcerts/wikitide.net.crt;
 	ssl_certificate_key /etc/ssl/private/wikitide.net.key;


### PR DESCRIPTION
Internal services can match hostnames on wikitide.net, which is the purpose of that domain to not have internal stuff on miraheze.org much.