### PR TITLE
nginx: replace http2_max_field_size with large_client_header_buffers

### DIFF
--- a/modules/nginx/templates/nginx.conf.erb
+++ b/modules/nginx/templates/nginx.conf.erb
@@ -22,7 +22,7 @@ http {
 	tcp_nodelay on;
 	client_max_body_size <%= @nginx_client_max_body_size %>;
 	client_body_buffer_size 64k;
-	http2_max_field_size 8k;
+	large_client_header_buffers 4 16k;
 	types_hash_max_size 2048;
 	# 512 x 4
 	server_names_hash_max_size 2048;


### PR DESCRIPTION
Per "[warn] 684#684: the "http2_max_field_size" directive is obsolete, use the "large_client_header_buffers" directive instead in /etc/nginx/nginx.conf:21"