### PR TITLE
Add backup SSH key for myself

### DIFF
--- a/modules/users/data/data.yaml
+++ b/modules/users/data/data.yaml
@@ -172,7 +172,9 @@ users:
     uid: 1016
     name: alex
     realname: Alex
-    ssh_keys: [sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIK1eR7I1K/AL6R9RxDOaldPLSDRpN5jl0+lMJq1Fa4tzAAAABHNzaDo= alex@localhost.localdomain]
+    ssh_keys:
+      - sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIK1eR7I1K/AL6R9RxDOaldPLSDRpN5jl0+lMJq1Fa4tzAAAABHNzaDo= alex@localhost.localdomain
+      - sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIIFhlw40YKZdLPFIfhzApQpdwPC8rdxWD2kppomPt8OUAAAABHNzaDo= alex-wikitide-backup@yubikey-nfc2
   owen:
     ensure: absent
     uid: 1017


### PR DESCRIPTION
```
-----BEGIN PGP SIGNED MESSAGE-----
Hash: SHA512

This commit adds a new key for my shell account at WikiTide. It is also an ed25519-sk key, created with a newly purchased YubiKey. It is meant as a backup in case my main key breaks.

This commit message, as well as the commit itself, is signed with my OpenPGP key.
-----BEGIN PGP SIGNATURE-----

iHUEARYKAB0WIQQK+0J/GAD9iXUcQDUpIihzWucH/wUCZip0vgAKCRApIihzWucH
/wN4AQCEV5+hVEhNempO6+LHAOdJhcSoUeVJY9ua4Ntnjyme3wD/YtI+iVCIeX83
1SYvSTXAtd07EgQGxHvlftB/chk3gQ8=
=tx1s
-----END PGP SIGNATURE-----