### PR TITLE
Allow dbadmins to use mysqldump

### DIFF
--- a/modules/users/data/data.yaml
+++ b/modules/users/data/data.yaml
@@ -62,6 +62,7 @@ groups:
     members: [alex]
     privileges: ['ALL = (ALL) NOPASSWD: /bin/bash -c mariadb',
                  'ALL = (ALL) NOPASSWD: /bin/bash -c mysql',
+                 'ALL = (ALL) NOPASSWD: /bin/bash -c mysqldump *',
                  'ALL = (ALL) NOPASSWD: /usr/sbin/service mariadb start',
                  'ALL = (ALL) NOPASSWD: /usr/sbin/service mariadb restart',
                  'ALL = (ALL) NOPASSWD: /usr/sbin/service mariadb status',


### PR DESCRIPTION
Needed to make renames and recreations safely by making a backup of the db prior to performing the rename/recreation.