### PR TITLE
hack the ntp class for ntpsec compatibility

### DIFF
--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -56,10 +56,10 @@ class base (
     class { 'apt::security': }
 
     class { 'ntp':
-        servers  => [ 'time.cloudflare.com' ],
-        config => '/etc/ntpsec/ntp.conf',
+        servers   => [ 'time.cloudflare.com' ],
+        config    => '/etc/ntpsec/ntp.conf',
         driftfile => '/var/lib/ntpsec/ntp.drift',
-        restrict => [ 'default kod limited nomodify noquery', '-6 default kod limited nomodify noquery', '127.0.0.1', '-6 ::1' ],
+        restrict  => [ 'default kod limited nomodify noquery', '-6 default kod limited nomodify noquery', '127.0.0.1', '-6 ::1' ],
     }
 
     # Used by salt-user

--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -57,7 +57,9 @@ class base (
 
     class { 'ntp':
         servers  => [ 'time.cloudflare.com' ],
-        restrict => [ 'default kod nomodify notrap nopeer noquery', '-6 default kod nomodify notrap nopeer noquery', '127.0.0.1', '-6 ::1' ],
+        config => '/etc/ntpsec/ntp.conf',
+        driftfile => '/var/lib/ntpsec/ntp.drift',
+        restrict => [ 'default kod limited nomodify noquery', '-6 default kod limited nomodify noquery', '127.0.0.1', '-6 ::1' ],
     }
 
     # Used by salt-user


### PR DESCRIPTION
On Debian Bookworm, the ntp package is no longer the classic NTP daemon, but rather just a package that pulls in ntpsec as a dependency

This is a bit of a problem because https://github.com/puppetlabs/puppetlabs-ntp, the module we're using to manage ntp, is still built around classic NTP, and apparently Puppetlabs modules still only support as far as Debian Bullseye

This commit hacks that class enough for ntpsec support. Thankfully, we can use the generated config file still thanks to ntpsec keeping mostly the same config syntax and options

restrict has been modified according to the recommended values at https://github.com/ntpsec/ntpsec/blob/250d5896b053be5498c73b12e29a3c8b07aaf11a/etc/ntp.d/use-no-remote-configuration