### PR TITLE
exempt miraheze.org from RDNS checks; update domains_as_tlds

### DIFF
--- a/modules/monitoring/files/check_reverse_dns.py
+++ b/modules/monitoring/files/check_reverse_dns.py
@@ -59,7 +59,7 @@ def get_args():
 
 def check_records(hostname):
     """Check NS and CNAME records for given hostname."""
-    domains_as_tlds = ('eu.org','for.uz')
+    domains_as_tlds = ('eu.org','for.uz','liao.media')
     cname_check_impossible = False
 
     nameservers = []
@@ -125,8 +125,12 @@ def get_reverse_dnshostname(hostname):
 
         return rev_host
     except (resolver.NXDOMAIN, resolver.NoAnswer):
-        print(f'rDNS WARNING - reverse DNS entry for {hostname} could not be found')
-        sys.exit(1)
+        if ".miraheze.org" in hostname or hostname=="miraheze.org":
+                print(f'SSL OK - domain exempt from check')
+                sys.exit(0)
+        else:
+                print(f'rDNS WARNING - reverse DNS entry for {hostname} could not be found')
+                sys.exit(1)
 
 
 def main():

--- a/modules/monitoring/files/check_reverse_dns.py
+++ b/modules/monitoring/files/check_reverse_dns.py
@@ -126,7 +126,7 @@ def get_reverse_dnshostname(hostname):
         return rev_host
     except (resolver.NXDOMAIN, resolver.NoAnswer):
         if ".miraheze.org" in hostname or hostname=="miraheze.org":
-                print(f'SSL OK - domain exempt from check')
+                print('SSL OK - domain exempt from check')
                 sys.exit(0)
         else:
                 print(f'rDNS WARNING - reverse DNS entry for {hostname} could not be found')

--- a/modules/monitoring/files/check_reverse_dns.py
+++ b/modules/monitoring/files/check_reverse_dns.py
@@ -125,18 +125,17 @@ def get_reverse_dnshostname(hostname):
 
         return rev_host
     except (resolver.NXDOMAIN, resolver.NoAnswer):
-        if ".miraheze.org" in hostname or hostname=="miraheze.org":
-                print('SSL OK - domain exempt from check')
-                sys.exit(0)
-        else:
-                print(f'rDNS WARNING - reverse DNS entry for {hostname} could not be found')
-                sys.exit(1)
+        print(f'rDNS WARNING - reverse DNS entry for {hostname} could not be found')
+        sys.exit(1)
 
 
 def main():
     """Execute functions."""
 
     args = get_args()
+    if ".miraheze.org" in args.hostname or args.hostname=="miraheze.org":
+                print('SSL OK - domain exempt from check')
+                sys.exit(0)
     try:
         rdns_hostname = get_reverse_dnshostname(args.hostname)
     except resolver.NoNameservers:

--- a/modules/salt/files/keys.py
+++ b/modules/salt/files/keys.py
@@ -1,3 +1,4 @@
+# mypy: ignore-errors
 '''
 runner: do basic operations on keys for a specified minion
 '''


### PR DESCRIPTION
I think we can safely assume that miraheze.org will always be correctly pointed to Miraheze. This fixes the RDNS alerts due to cloudflare.

also adds liao.media to domains_as_tlds to fix another alert (NS set for subdomain, not root).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Exempted the domains `liao.media` and `miraheze.org` from reverse DNS checks, enhancing compatibility for these domains.
- **Bug Fixes**
	- Improved error handling for specific domain exemptions in reverse DNS checks.
- **Chores**
	- Added a directive to suppress mypy errors in key management scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->