### PR TITLE
wikitide-backup update find_backups

### DIFF
--- a/modules/base/templates/backups/wikitide-backup.py.erb
+++ b/modules/base/templates/backups/wikitide-backup.py.erb
@@ -235,9 +235,13 @@ def download(source: str, dt: str, database: str):
 
 def find_backups(source: str, database: str):
     all_backups = pca_web('GET', f'https://storage.bhs.cloud.ovh.net/v1/AUTH_76f9bc606a8044e08db7ebd118f6b19a/{source}', 0)
-    backups_list = list(all_backups.text.split("\n"))
+    backups_list = list(all_backups.text.strip().split('\n'))
+    # These web requests return a maximum of 10000 items at a time. The status code is 200 if objects are returned and 204 if there are no others
+    while all_backups.status_code == 200:
+        all_backups = pca_web('GET', f'https://storage.bhs.cloud.ovh.net/v1/AUTH_76f9bc606a8044e08db7ebd118f6b19a/{source}?marker={backups_list[-1]}', 0)
+        backups_list += list(all_backups.text.strip().split('\n'))
     
-    if source in ['database', 'mediawiki-xml']:
+    if source in ['sql', 'mediawiki-xml']:
         for backup_item in backups_list:
             if backup_item.split('/')[0] == database:
                 print(backup_item.split('/')[1].split('.')[0])


### PR DESCRIPTION
database source was renamed to sql

add support for there being more than 10000 objects in the container