### PR TITLE
pywikibot: ensure python3-pil is installed instead

### DIFF
--- a/modules/irc/manifests/pywikibot.pp
+++ b/modules/irc/manifests/pywikibot.pp
@@ -23,7 +23,7 @@ class irc::pywikibot {
         'python3-mwoauth',
         'python3-pydot',
         'python3-stdnum',
-        'python3-pillow',
+        'python3-pil',
         'python3-mysqldb',
         'python3-bs4',
     ])


### PR DESCRIPTION
On Bookworm python3-pillow is a virtual package (https://packages.debian.org/bookworm/python3-pillow)

The only package providing that is python3-pil. This makes it so that Puppet doesn't try again and again to install python3-pillow on every run