### PR TITLE
pywikibot: make user-config read-only for the irc user

### DIFF
--- a/modules/irc/manifests/pywikibot.pp
+++ b/modules/irc/manifests/pywikibot.pp
@@ -43,7 +43,7 @@ class irc::pywikibot {
         ensure  => present,
         owner   => 'irc',
         group   => 'irc',
-        mode    => '0644',
+        mode    => '0400',
         content => template('irc/pywikibot/user-config.py'),
         require => Git::Clone['PyWikiBot'],
     }


### PR DESCRIPTION
Only the irc user should ever need to read this file anyway, and there's no reason to edit it outside of puppet