### PR TITLE
T12244: pywikibot: Move config files to /var/local/, introduce pywikibot wrapper script

### DIFF
--- a/modules/irc/manifests/pywikibot.pp
+++ b/modules/irc/manifests/pywikibot.pp
@@ -25,7 +25,7 @@ class irc::pywikibot {
         mode   => '0644',
     }
 
-    file { 'usr/local/bin/pywikibot'
+    file { 'usr/local/bin/pywikibot':
         ensure => 'present',
         owner => 'irc',
         group => 'irc',

--- a/modules/irc/manifests/pywikibot.pp
+++ b/modules/irc/manifests/pywikibot.pp
@@ -1,6 +1,8 @@
 # class: irc::pywikibot
 class irc::pywikibot {
     $install_path = '/srv/pywikibot'
+    # The directory pointed to by the PYWIKIBOT_DIR environment variable
+    $base_path = '/var/local/pwb'
 
     $consumer_token = lookup('passwords::pywikibot::consumer_token')
     $consumer_secret = lookup('passwords::pywikibot::consumer_secret')
@@ -14,6 +16,21 @@ class irc::pywikibot {
         mode      => '0644',
         recurse   => true,
         max_files => 5000,
+    }
+
+    file { $base_path:
+        ensure => 'directory',
+        owner => 'irc',
+        group => 'irc',
+        mode => '0644',
+    }
+
+    file { 'usr/local/bin/pywikibot'
+        ensure => 'present',
+        owner => 'irc',
+        group => 'irc',
+        mode => '0555',
+        content => template('irc/pywikibot/pywikibot.sh'),
     }
 
     file { '/var/log/pwb':
@@ -47,7 +64,7 @@ class irc::pywikibot {
         require            => File[$install_path],
     }
 
-    file { "${install_path}/user-config.py":
+    file { "${base_dir}/user-config.py":
         ensure  => present,
         owner   => 'irc',
         group   => 'irc',
@@ -56,7 +73,7 @@ class irc::pywikibot {
         require => Git::Clone['PyWikiBot'],
     }
 
-    file { "${install_path}/families/wikitide_family.py":
+    file { "${base_dir}/families/wikitide_family.py":
         ensure  => present,
         owner   => 'irc',
         group   => 'irc',
@@ -67,7 +84,7 @@ class irc::pywikibot {
 
     cron { 'run pywikibot archivebot on meta':
         ensure  => present,
-        command => '/usr/bin/python3 /srv/pywikibot/pwb.py archivebot Template:Autoarchive/config -pt:0 -dir:/srv/pywikibot >> /var/log/pwb/archivebot-cron.log 2>&1',
+        command => '/usr/local/bin/pywikibot archivebot Template:Autoarchive/config -pt:0 -dir:/srv/pywikibot >> /var/log/pwb/archivebot-cron.log 2>&1',
         user    => 'irc',
         minute  => '0',
         hour    => '0',

--- a/modules/irc/manifests/pywikibot.pp
+++ b/modules/irc/manifests/pywikibot.pp
@@ -26,10 +26,10 @@ class irc::pywikibot {
     }
 
     file { 'usr/local/bin/pywikibot':
-        ensure => 'present',
-        owner => 'irc',
-        group => 'irc',
-        mode => '0555',
+        ensure  => 'present',
+        owner   => 'irc',
+        group   => 'irc',
+        mode    => '0555',
         content => template('irc/pywikibot/pywikibot.sh'),
     }
 

--- a/modules/irc/manifests/pywikibot.pp
+++ b/modules/irc/manifests/pywikibot.pp
@@ -25,7 +25,7 @@ class irc::pywikibot {
         mode   => '0644',
     }
 
-    file { "$base_path/families":
+    file { "${base_path}/families":
         ensure => 'directory',
         owner  => 'irc',
         group  => 'irc',

--- a/modules/irc/manifests/pywikibot.pp
+++ b/modules/irc/manifests/pywikibot.pp
@@ -25,7 +25,7 @@ class irc::pywikibot {
         mode   => '0644',
     }
 
-    file { $base_path/families:
+    file { "$base_path/families":
         ensure => 'directory',
         owner  => 'irc',
         group  => 'irc',

--- a/modules/irc/manifests/pywikibot.pp
+++ b/modules/irc/manifests/pywikibot.pp
@@ -20,9 +20,9 @@ class irc::pywikibot {
 
     file { $base_path:
         ensure => 'directory',
-        owner => 'irc',
-        group => 'irc',
-        mode => '0644',
+        owner  => 'irc',
+        group  => 'irc',
+        mode   => '0644',
     }
 
     file { 'usr/local/bin/pywikibot'

--- a/modules/irc/manifests/pywikibot.pp
+++ b/modules/irc/manifests/pywikibot.pp
@@ -84,7 +84,7 @@ class irc::pywikibot {
 
     cron { 'run pywikibot archivebot on meta':
         ensure  => present,
-        command => '/usr/local/bin/pywikibot archivebot Template:Autoarchive/config -pt:0 -dir:/srv/pywikibot >> /var/log/pwb/archivebot-cron.log 2>&1',
+        command => '/usr/local/bin/pywikibot archivebot Template:Autoarchive/config -pt:0 >> /var/log/pwb/archivebot-cron.log 2>&1',
         user    => 'irc',
         minute  => '0',
         hour    => '0',

--- a/modules/irc/manifests/pywikibot.pp
+++ b/modules/irc/manifests/pywikibot.pp
@@ -25,6 +25,13 @@ class irc::pywikibot {
         mode   => '0644',
     }
 
+    file { $base_path/families:
+        ensure => 'directory',
+        owner  => 'irc',
+        group  => 'irc',
+        mode   => '0644',
+    }
+
     file { 'usr/local/bin/pywikibot':
         ensure  => 'present',
         owner   => 'irc',
@@ -64,7 +71,7 @@ class irc::pywikibot {
         require            => File[$install_path],
     }
 
-    file { "${base_dir}/user-config.py":
+    file { "${base_path}/user-config.py":
         ensure  => present,
         owner   => 'irc',
         group   => 'irc',
@@ -73,7 +80,7 @@ class irc::pywikibot {
         require => Git::Clone['PyWikiBot'],
     }
 
-    file { "${base_dir}/families/wikitide_family.py":
+    file { "${base_path}/families/wikitide_family.py":
         ensure  => present,
         owner   => 'irc',
         group   => 'irc',

--- a/modules/irc/templates/pywikibot/pywikibot.sh
+++ b/modules/irc/templates/pywikibot/pywikibot.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Wrapper script that runs pwb.py with the correct env vars set
+# All parameters to this script are sent as-is to pwb.py
+
+PYWIKIBOT_DIR=<%= @base_path %> /usr/bin/python3 <%= @install_path %>/pwb.py $*


### PR DESCRIPTION
https://issue-tracker.miraheze.org/T12244

This commit prepares for the migration from git to an install managed by the archive module. It moves config files outside of the install directory of pywikibot, and introduces a wrapper script that runs pywikibot with the correct env vars set so that it is able to still find the family and user-config files