### PR TITLE
mediawiki: prevent mwdeploy from upgrading extensions configured to checkout a specific commit

### DIFF
--- a/modules/mediawiki/files/bin/mwdeploy.py
+++ b/modules/mediawiki/files/bin/mwdeploy.py
@@ -441,7 +441,7 @@ def run_process(args: argparse.Namespace, version: str = '') -> list[int]:  # pr
                     if not os.path.exists(_get_staging_path(f'extensions/{extension}', version)):
                         print(f'{extension} does not exist for {version}. Skipping...')
                         continue
-                    if os.path.exists(_get_local_path(extension))
+                    if os.path.exists(_get_local_path(extension)):
                         print(f'Skipping upgrade of {extension} because it is configured in mediawiki-repos to checkout a specific commit')
                         continue
                     process = os.popen(_construct_git_pull(f'extensions/{extension}', submodules=True, quiet=False, version=version))

--- a/modules/mediawiki/files/bin/mwdeploy.py
+++ b/modules/mediawiki/files/bin/mwdeploy.py
@@ -247,6 +247,8 @@ def _get_staging_path(repo: str, version: str = '') -> str:
 
     return f'/srv/mediawiki-staging/{repos[repo]}/'
 
+def _get_local_path(extension: str) -> str:
+    return f'/var/local/mwdeploy/{extension}'
 
 def _get_deployed_path(repo: str) -> str:
     return f'/srv/mediawiki/{repos[repo]}/'
@@ -439,6 +441,9 @@ def run_process(args: argparse.Namespace, version: str = '') -> list[int]:  # pr
                     if not os.path.exists(_get_staging_path(f'extensions/{extension}', version)):
                         print(f'{extension} does not exist for {version}. Skipping...')
                         continue
+                    if os.path.exists(_get_local_path(extension))
+                        print(f'Skipping upgrade of {extension} because it is configured in mediawiki-repos to checkout a specific commit')
+                        continue
                     process = os.popen(_construct_git_pull(f'extensions/{extension}', submodules=True, quiet=False, version=version))
                     output = process.read().strip()
                     status = process.close()
@@ -487,6 +492,9 @@ def run_process(args: argparse.Namespace, version: str = '') -> list[int]:  # pr
                 for skin in args.upgrade_skins:
                     if not os.path.exists(_get_staging_path(f'skins/{skin}', version)):
                         print(f'{skin} does not exist for {version}. Skipping...')
+                        continue
+                    if os.path.exists(_get_local_path(skin)):
+                        print(f'Skipping upgrade of {skin} because it is configured in mediawiki-repos to checkout a specific commit')
                         continue
                     process = os.popen(_construct_git_pull(f'skins/{skin}', quiet=False, version=version))
                     output = process.read().strip()

--- a/modules/mediawiki/files/bin/mwdeploy.py
+++ b/modules/mediawiki/files/bin/mwdeploy.py
@@ -247,8 +247,10 @@ def _get_staging_path(repo: str, version: str = '') -> str:
 
     return f'/srv/mediawiki-staging/{repos[repo]}/'
 
+
 def _get_local_path(extension: str) -> str:
     return f'/var/local/mwdeploy/{extension}'
+
 
 def _get_deployed_path(repo: str) -> str:
     return f'/srv/mediawiki/{repos[repo]}/'

--- a/modules/mediawiki/manifests/extensionsetup.pp
+++ b/modules/mediawiki/manifests/extensionsetup.pp
@@ -18,6 +18,13 @@ define mediawiki::extensionsetup (
             require => Exec["OAuth-${branch} composer"],
     }
 
+    file { '/var/local/mwdeploy':
+        ensure => directory,
+        owner => 'www-data',
+        group => 'www-data',
+        mode => '0644',
+    }
+
     $repos = loadyaml('/etc/puppetlabs/puppet/mediawiki-repos/mediawiki-repos.yaml')
 
     $repos.each |$name, $params| {
@@ -69,6 +76,19 @@ define mediawiki::extensionsetup (
             require            => Git::Clone["MediaWiki-${branch} core"],
         }
         # lint:endignore
+
+        if $params['commit'] {
+           file { "/var/local/mwdeploy/${name}":
+               ensure => 'present',
+               owner => 'www-data',
+               group => 'www-data',
+               mode => '0644',
+           }
+        } else {
+          file { "/var/local/mwdeploy/${name}":
+              ensure => 'absent',
+          }
+        }
 
         if $should_install {
             if $params['composer'] {

--- a/modules/mediawiki/manifests/extensionsetup.pp
+++ b/modules/mediawiki/manifests/extensionsetup.pp
@@ -79,14 +79,14 @@ define mediawiki::extensionsetup (
 
         if $params['commit'] {
             file { "/var/local/mwdeploy/${name}":
-               ensure => 'present',
-               owner => 'www-data',
-               group => 'www-data',
-               mode => '0644',
+                ensure => 'present',
+                owner => 'www-data',
+                group => 'www-data',
+                mode => '0644',
            }
         } else {
            file { "/var/local/mwdeploy/${name}":
-              ensure => 'absent',
+               ensure => 'absent',
           }
         }
 

--- a/modules/mediawiki/manifests/extensionsetup.pp
+++ b/modules/mediawiki/manifests/extensionsetup.pp
@@ -20,9 +20,9 @@ define mediawiki::extensionsetup (
 
     file { '/var/local/mwdeploy':
         ensure => directory,
-        owner => 'www-data',
-        group => 'www-data',
-        mode => '0644',
+        owner  => 'www-data',
+        group  => 'www-data',
+        mode   => '0644',
     }
 
     $repos = loadyaml('/etc/puppetlabs/puppet/mediawiki-repos/mediawiki-repos.yaml')
@@ -79,10 +79,10 @@ define mediawiki::extensionsetup (
 
         if $params['commit'] {
             file { "/var/local/mwdeploy/${name}":
-                ensure => 'present',
-                owner => 'www-data',
-                group => 'www-data',
-                mode => '0644',
+                ensure  => 'present',
+                owner   => 'www-data',
+                group   => 'www-data',
+                mode    => '0644',
                 content => 'This extension is configured to checkout a specific commit in mediawiki-repos',
             }
         } else {

--- a/modules/mediawiki/manifests/extensionsetup.pp
+++ b/modules/mediawiki/manifests/extensionsetup.pp
@@ -83,11 +83,11 @@ define mediawiki::extensionsetup (
                 owner => 'www-data',
                 group => 'www-data',
                 mode => '0644',
-           }
+            }
         } else {
-           file { "/var/local/mwdeploy/${name}":
-               ensure => 'absent',
-          }
+            file { "/var/local/mwdeploy/${name}":
+                ensure => 'absent',
+            }
         }
 
         if $should_install {

--- a/modules/mediawiki/manifests/extensionsetup.pp
+++ b/modules/mediawiki/manifests/extensionsetup.pp
@@ -78,14 +78,14 @@ define mediawiki::extensionsetup (
         # lint:endignore
 
         if $params['commit'] {
-           file { "/var/local/mwdeploy/${name}":
+            file { "/var/local/mwdeploy/${name}":
                ensure => 'present',
                owner => 'www-data',
                group => 'www-data',
                mode => '0644',
            }
         } else {
-          file { "/var/local/mwdeploy/${name}":
+           file { "/var/local/mwdeploy/${name}":
               ensure => 'absent',
           }
         }

--- a/modules/mediawiki/manifests/extensionsetup.pp
+++ b/modules/mediawiki/manifests/extensionsetup.pp
@@ -83,6 +83,7 @@ define mediawiki::extensionsetup (
                 owner => 'www-data',
                 group => 'www-data',
                 mode => '0644',
+                content => 'This extension is configured to checkout a specific commit in mediawiki-repos',
             }
         } else {
             file { "/var/local/mwdeploy/${name}":


### PR DESCRIPTION
https://github.com/miraheze/mediawiki-repos supports configuring an extension to checkout a specific commit. However, if the extension is upgraded by mwdeploy, such as during `--upgrade-world`, then it will just pull the latest commit from the configured branch, which is not desired behavior. Puppet will restore the extension to the commit configured in mediawiki-repos, but by then the rsync has already happened.

This pull request aims to fix that by creating a file with the name of the extension on `/var/local/mwdeploy`, which if mwdeploy sees while upgrading an extension, will tell the script to not attempt to upgrade. This file is created automatically by Puppet, and removed automatically when the `commit` parameter for that extension is removed from mediawiki-repos