### PR TITLE
pywikibot: do not recursively apply mode 644 on $install_path

### DIFF
--- a/modules/irc/manifests/pywikibot.pp
+++ b/modules/irc/manifests/pywikibot.pp
@@ -14,7 +14,6 @@ class irc::pywikibot {
         owner     => 'irc',
         group     => 'irc',
         mode      => '0644',
-        recurse   => true,
         max_files => 5000,
     }
 


### PR DESCRIPTION
This commit prevents puppet from touching the mode of files in $install_path.

Some files in the git repository of pywikibot have the executable bit set, making them 755. If Puppet changes the mode of these files to 644, the Git::clone puppet manifest will not pull new changes due to there being local changes in the repository (https://issue-tracker.miraheze.org/T12244#245049).