### PR TITLE
Remove dead domain from CSP

### DIFF
--- a/modules/mediawiki/data/csp.yaml
+++ b/modules/mediawiki/data/csp.yaml
@@ -32,7 +32,6 @@ script-src:
   - 'www.google.com'
   - 'apis.google.com'
   - 'platform.twitter.com'
-  - 'wiki-assets.sumin.wiki'
   - 'ajax.cloudflare.com'
   - 'cdnjs.cloudflare.com'
   - 'cdn.jsdelivr.net'


### PR DESCRIPTION
```
> dig sumin.wiki | grep HEADER
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 30368
> dig wiki-assets.sumin.wiki | grep HEADER
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 658
> whois sumin.wiki | head
No Data Found
URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
>>> Last update of WHOIS database: 2024-07-14T06:56:02Z <<<

For more information on Whois status codes, please visit https://icann.org/epp

The Service is provided so that you may look up certain information in relation to domain names that we store in our database.

Use of the Service is subject to our policies, in particular you should familiarise yourself with our Acceptable Use Policy and our Privacy Policy.
```