### PR TITLE
add Cache-Tag to mediawiki responses

### DIFF
--- a/modules/mediawiki/templates/mediawiki.conf.erb
+++ b/modules/mediawiki/templates/mediawiki.conf.erb
@@ -122,6 +122,8 @@ server {
 
 	add_header Content-Security-Policy "<%- @csp.each_pair do |type, value| -%> <%= type %> <%= value.join(' ') %>; <%- end -%>" always;
 
+        add_header Cache-Tag "mediawiki" always;
+
 	error_page 400 /ErrorPages/400.html;
 	error_page 401 /ErrorPages/401.html;
 	error_page 403 /ErrorPages/403.html;


### PR DESCRIPTION
This will allow us to blow up the CF mediawiki cache without also blowing up static.mh.o

This might help the usual broken caches after the MW upgrade.