### PR TITLE
T11704: Install espeak and LAME on the MediaWiki appservers

### DIFF
--- a/modules/mediawiki/manifests/packages.pp
+++ b/modules/mediawiki/manifests/packages.pp
@@ -8,8 +8,8 @@ class mediawiki::packages {
     stdlib::ensure_packages([
         'djvulibre-bin',
         'dvipng',
-	'espeak-ng-espeak',
-	'lame',
+        'espeak-ng-espeak',
+        'lame',
         'ghostscript',
         'htmldoc',
         'inkscape',

--- a/modules/mediawiki/manifests/packages.pp
+++ b/modules/mediawiki/manifests/packages.pp
@@ -8,6 +8,8 @@ class mediawiki::packages {
     stdlib::ensure_packages([
         'djvulibre-bin',
         'dvipng',
+	'espeak-ng-espeak',
+	'lame',
         'ghostscript',
         'htmldoc',
         'inkscape',


### PR DESCRIPTION
Needed for the Phonos extension

https://issue-tracker.miraheze.org/T11704