### PR TITLE
create new deploy test user for T12486

### DIFF
--- a/hieradata/hosts/test151.yaml
+++ b/hieradata/hosts/test151.yaml
@@ -2,6 +2,7 @@ users::groups:
   - mediawiki-admins
   - mediawiki-roots
   - mediawiki-test-admins
+  - mediawiki-test-deploy-users
 
 contactgroups: ['infra', 'mediawiki']
 

--- a/modules/users/data/data.yaml
+++ b/modules/users/data/data.yaml
@@ -72,7 +72,7 @@ groups:
     gid: 2009
     description: ability to deploy changes on the MediaWiki test server
     members: []
-    privileges: ['ALL = (ALL) NOPASSWD: /usr/sbin/service mwdeploy *',]
+    privileges: ['ALL = (ALL) NOPASSWD: /usr/local/bin/mwdeploy *',]
 
 users:
   johnflewis:

--- a/modules/users/data/data.yaml
+++ b/modules/users/data/data.yaml
@@ -75,7 +75,7 @@ groups:
     privileges: ['ALL = (ALL) NOPASSWD: /usr/sbin/service mwdeploy *',
                 'ALL = (ALL) NOPASSWD: /usr/bin/rsync *',
                 'ALL = (www-data) NOPASSWD: /bin/sudoedit /srv/mediawiki-staging/*',
-                'ALL = (www-data) NOPASSWD: /bin/rm /srv/mediawiki-staging/*',]
+                'ALL = (www-data) NOPASSWD: /bin/rm /srv/mediawiki-staging/*']
 users:
   johnflewis:
     ensure: absent

--- a/modules/users/data/data.yaml
+++ b/modules/users/data/data.yaml
@@ -72,8 +72,10 @@ groups:
     gid: 2009
     description: ability to deploy changes on the MediaWiki test server
     members: []
-    privileges: ['ALL = (ALL) NOPASSWD: /usr/local/bin/mwdeploy *',]
-
+    privileges: ['ALL = (ALL) NOPASSWD: /bin/nano /srv/mediawiki/*',
+                'ALL = (ALL) NOPASSWD: /bin/nano /srv/mediawiki-staging/*',
+                'ALL = (ALL) NOPASSWD: /bin/rm /srv/mediawiki/*',
+                'ALL = (ALL) NOPASSWD: /bin/rm /srv/mediawiki-staging/*',]
 users:
   johnflewis:
     ensure: absent
@@ -201,7 +203,7 @@ users:
     ssh_keys: [ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII58/9ujLHNt1p1YOlHJr7Y2D7laEkYzQSOKcAhF8r1Q]
   testuser:
     ensure: present
-    uid: 1020
+    uid: 3000
     name: Test User
     realname: Test User (user for testing access)
     ssh_keys:

--- a/modules/users/data/data.yaml
+++ b/modules/users/data/data.yaml
@@ -68,6 +68,11 @@ groups:
                  'ALL = (ALL) NOPASSWD: /usr/sbin/service mariadb status',
                  'ALL = (ALL) NOPASSWD: /usr/bin/puppet *',
                  'ALL = (ALL) NOPASSWD: /bin/journalctl *']
+  mediawiki-deploy-users:
+    gid: 2009
+    description: ability to deploy changes on the MediaWiki test server
+    members: []
+    privileges: ['ALL = (ALL) NOPASSWD: /usr/sbin/service mwdeploy *',]
 
 users:
   johnflewis:
@@ -194,3 +199,11 @@ users:
     name: evalprime
     realname: EvalPrime
     ssh_keys: [ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII58/9ujLHNt1p1YOlHJr7Y2D7laEkYzQSOKcAhF8r1Q]
+  testuser:
+    ensure: present
+    uid: 1020
+    name: Test User
+    realname: Test User (user for testing access)
+    ssh_keys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIApGU+6cUDu6gLhJY547Ge/2r4FU382qFx6wVGHN/+FP
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILMGnrVrhB1ZfXRouXhLzjsWjx3dTVYxxvsIzTD2JJg/ reception

--- a/modules/users/data/data.yaml
+++ b/modules/users/data/data.yaml
@@ -74,7 +74,7 @@ groups:
     members: []
     privileges: ['ALL = (ALL) NOPASSWD: /usr/sbin/service mwdeploy *',
                 'ALL = (ALL) NOPASSWD: /usr/bin/rsync *',
-                'ALL = (ALL) NOPASSWD: /bin/nano /srv/mediawiki-staging/*',
+                'ALL = (ALL) NOPASSWD: /bin/sudoedit /srv/mediawiki-staging/*',
                 'ALL = (ALL) NOPASSWD: /bin/rm /srv/mediawiki-staging/*',]
 users:
   johnflewis:

--- a/modules/users/data/data.yaml
+++ b/modules/users/data/data.yaml
@@ -72,9 +72,9 @@ groups:
     gid: 2009
     description: ability to deploy changes on the MediaWiki test server
     members: []
-    privileges: ['ALL = (ALL) NOPASSWD: /bin/nano /srv/mediawiki/*',
+    privileges: ['ALL = (ALL) NOPASSWD: /usr/sbin/service mwdeploy *',
+                'ALL = (ALL) NOPASSWD: /usr/bin/rsync *',
                 'ALL = (ALL) NOPASSWD: /bin/nano /srv/mediawiki-staging/*',
-                'ALL = (ALL) NOPASSWD: /bin/rm /srv/mediawiki/*',
                 'ALL = (ALL) NOPASSWD: /bin/rm /srv/mediawiki-staging/*',]
 users:
   johnflewis:

--- a/modules/users/data/data.yaml
+++ b/modules/users/data/data.yaml
@@ -68,7 +68,7 @@ groups:
                  'ALL = (ALL) NOPASSWD: /usr/sbin/service mariadb status',
                  'ALL = (ALL) NOPASSWD: /usr/bin/puppet *',
                  'ALL = (ALL) NOPASSWD: /bin/journalctl *']
-  mediawiki-deploy-users:
+  mediawiki-test-deploy-users:
     gid: 2009
     description: ability to deploy changes on the MediaWiki test server
     members: []

--- a/modules/users/data/data.yaml
+++ b/modules/users/data/data.yaml
@@ -74,8 +74,8 @@ groups:
     members: []
     privileges: ['ALL = (ALL) NOPASSWD: /usr/sbin/service mwdeploy *',
                 'ALL = (ALL) NOPASSWD: /usr/bin/rsync *',
-                'ALL = (ALL) NOPASSWD: /bin/sudoedit /srv/mediawiki-staging/*',
-                'ALL = (ALL) NOPASSWD: /bin/rm /srv/mediawiki-staging/*',]
+                'ALL = (www-data) NOPASSWD: /bin/sudoedit /srv/mediawiki-staging/*',
+                'ALL = (www-data) NOPASSWD: /bin/rm /srv/mediawiki-staging/*',]
 users:
   johnflewis:
     ensure: absent


### PR DESCRIPTION
In order to have a group that will only be able to deploy changes on beta, we need a new group as well as a test user that will allow us to make sure that access is limited before adding users to the group.