### PR TITLE
T12554: Trust the internal client certificate on mirabeta.org

### DIFF
--- a/modules/mediawiki/templates/mediawiki.conf.erb
+++ b/modules/mediawiki/templates/mediawiki.conf.erb
@@ -392,6 +392,11 @@ server {
 	# cp* will not present one that'd be signed by Cloudflare
 	ssl_verify_client off;
 	<%- end -%>
+	<%- if property['url'] == "mirabeta.org" -%>
+	# Same as ssl_client_certificate, but we don't send the certificate
+	# to the client
+	ssl_trusted_certificate /etc/ssl/localcerts/internal-client-cert.crt
+	<%- end -%>
 	ssl_client_certificate /etc/ssl/localcerts/authenticated_origin_pull_ca.crt;
 
 	<%- if property['hsts'] == "strict" -%>


### PR DESCRIPTION
Also a test for if we can have both of the client certificate directives together