### PR TITLE
Trust the internal client certificate CA as well

### DIFF
--- a/modules/mediawiki/files/bin/mwdeploy.py
+++ b/modules/mediawiki/files/bin/mwdeploy.py
@@ -217,7 +217,7 @@ def check_up(nolog: bool, Debug: str | None = None, Host: str | None = None, dom
         proto = 'https://'
     else:
         proto = 'http://'
-    req = requests.get(f'{proto}{domain}:{port}/w/api.php?action=query&meta=siteinfo&formatversion=2&format=json', headers=headers, verify=verify)
+    req = requests.get(f'{proto}{domain}:{port}/w/api.php?action=query&meta=siteinfo&formatversion=2&format=json', headers=headers, verify=verify, cert=('/etc/ssl/localcerts/mwdeploy.crt', '/srv/mediawiki-staging/mwdeploy-client-cert.key'))
     if req.status_code == 200 and 'miraheze' in req.text and (Debug is None or Debug in req.headers['X-Served-By']):
         up = True
     if not up:

--- a/modules/mediawiki/manifests/deploy.pp
+++ b/modules/mediawiki/manifests/deploy.pp
@@ -21,6 +21,15 @@ class mediawiki::deploy {
             before => File['/usr/local/bin/mwdeploy'],
         }
 
+        file { '/srv/mediawiki-staging/mwdeploy-client-cert.key':
+            ensure => present,
+            source => 'puppet:///ssl-keys/mwdeploy.key',
+            owner  => 'www-data',
+            group  => 'www-data',
+            mode   => '0444',
+            before => File['/usr/local/bin/mwdeploy'],
+        }
+
         file { '/var/www/.ssh':
             ensure => directory,
             owner  => 'www-data',

--- a/modules/mediawiki/templates/mediawiki.conf.erb
+++ b/modules/mediawiki/templates/mediawiki.conf.erb
@@ -17,7 +17,7 @@ server {
 	ssl_certificate_key /etc/ssl/private/miraheze-origin-cert.key;
 
 	ssl_verify_client optional;
-	ssl_client_certificate /etc/ssl/localcerts/authenticated_origin_pull_ca.crt;
+	ssl_client_certificate /etc/ssl/localcerts/origin-pull-and-internal-ca.crt;
 
 	add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";
 
@@ -115,7 +115,7 @@ server {
 	ssl_certificate_key /etc/ssl/private/miraheze-origin-cert.key;
 
 	ssl_verify_client optional;
-	ssl_client_certificate /etc/ssl/localcerts/authenticated_origin_pull_ca.crt;
+	ssl_client_certificate /etc/ssl/localcerts/origin-pull-and-internal-ca.crt;
 
 	add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";
 
@@ -200,7 +200,7 @@ server {
 	ssl_certificate_key /etc/ssl/private/miraheze-origin-cert.key;
 
 	ssl_verify_client optional;
-	ssl_client_certificate /etc/ssl/localcerts/authenticated_origin_pull_ca.crt;
+	ssl_client_certificate /etc/ssl/localcerts/origin-pull-and-internal-ca.crt;
 
 	add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";
 
@@ -249,7 +249,7 @@ server {
 	ssl_certificate_key /etc/ssl/private/miraheze-origin-cert.key;
 
 	ssl_verify_client optional;
-	ssl_client_certificate /etc/ssl/localcerts/authenticated_origin_pull_ca.crt;
+	ssl_client_certificate /etc/ssl/localcerts/origin-pull-and-internal-ca.crt;
 
 	add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";
 
@@ -392,10 +392,7 @@ server {
 	# cp* will not present one that'd be signed by Cloudflare
 	ssl_verify_client off;
 	<%- end -%>
-	ssl_client_certificate /etc/ssl/localcerts/authenticated_origin_pull_ca.crt;
-	# Same as ssl_client_certificate, but we don't send the certificate
-	# to the client
-	# ssl_trusted_certificate /etc/ssl/localcerts/internal-client-certificate.crt;
+	ssl_client_certificate /etc/ssl/localcerts/origin-pull-and-internal-ca.crt;
 
 	<%- if property['hsts'] == "strict" -%>
 	add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload";
@@ -454,10 +451,7 @@ server {
 	# cp* will not present one that'd be signed by Cloudflare
 	ssl_verify_client off;
 <%- end -%>
-	ssl_client_certificate /etc/ssl/localcerts/authenticated_origin_pull_ca.crt;
-	# Same as ssl_client_certificate, but we don't send the certificate
-	# to the client
-	# ssl_trusted_certificate /etc/ssl/localcerts/internal-client-certificate.crt;
+	ssl_client_certificate /etc/ssl/localcerts/origin-pull-and-internal-ca.crt;
 
 <%- if property['hsts'] == "strict" -%>  
 	add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";


### PR DESCRIPTION
https://issue-tracker.miraheze.org/T12554#251242

The perms are kind of bad for the private key, but this particular client certificate only allows making requests to mw*

It also needs to be accessed by the user running mwdeploy, setting mw-admins, for example, as the owner group would prevent ops from using mwdeploy