### PR TITLE
nginx: set ssl_session_tickets to off

### DIFF
--- a/modules/nginx/templates/nginx.conf.erb
+++ b/modules/nginx/templates/nginx.conf.erb
@@ -45,6 +45,9 @@ http {
 	ssl_session_cache shared:SSL:300m;
 	ssl_session_timeout 6h;
 
+	# Disable RFC5077 tickets (may revisit later when client support is better)
+	ssl_session_tickets off;
+
 	# GZIP Settings
 	gzip off;
 	gzip_disable "msie6";


### PR DESCRIPTION
This is similar to wikimedias config https://github.com/wikimedia/operations-puppet/blob/4f4c75d518edf5121802eca475e20800f0fcc5c8/modules/profile/templates/tlsproxy/nginx.conf.erb#L77