### PR TITLE
mediawiki: nginx: allow passing of php-fpm error responses to nginx for handling via custom ErrorPages

### DIFF
--- a/modules/mediawiki/templates/mediawiki-includes.conf.erb
+++ b/modules/mediawiki/templates/mediawiki-includes.conf.erb
@@ -25,6 +25,18 @@ location ~ \.php {
 	fastcgi_buffers 32 32k;
 	fastcgi_buffer_size 64k;
 	fastcgi_pass unix:/run/<%= @php_fpm_sock %>;
+	fastcgi_intercept_errors on;
+}
+
+location ^~ /ErrorPages/ {
+	include fastcgi_params;
+	fastcgi_index index.php;
+	fastcgi_split_path_info ^(.+\.php)(.*)$;
+	fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+	fastcgi_buffers 32 32k;
+	fastcgi_buffer_size 64k;
+	fastcgi_pass unix:/run/<%= @php_fpm_sock %>;
+	fastcgi_intercept_errors off;
 }
 
 location = /favicon.ico {


### PR DESCRIPTION
this sets fastcgi_intercept_errors on; which means that error responses within php-fpm are passed to nginx for error handling rather than directly to the end user.

we define another location block for /ErrorPages so that php based error pages will work correctly.

this was done going by https://stackoverflow.com/questions/23106349/nginx-pass-all-404-errors-back-to-php-fpm-for-custom-error-page-processing