### PR TITLE
db161: Remove mhglobal from weekly backup

### DIFF
--- a/hieradata/hosts/db161.yaml
+++ b/hieradata/hosts/db161.yaml
@@ -1,6 +1,6 @@
 users::groups: 'database-admins'
 http_proxy: 'http://bastion.wikitide.net:8080'
-role::db::weekly_misc: ['mhglobal']
+role::db::weekly_misc: []
 mariadb::config::innodb_buffer_pool_size: '30G'
 mariadb::version: '10.11'
 role::db::enable_ssl: false


### PR DESCRIPTION
The database is not on db161, it's on db171.