### PR TITLE
db151: Remove mhglobal from weekly backup

### DIFF
--- a/hieradata/hosts/db151.yaml
+++ b/hieradata/hosts/db151.yaml
@@ -1,6 +1,6 @@
 users::groups: 'database-admins'
 http_proxy: 'http://bastion.wikitide.net:8080'
-role::db::weekly_misc: ['mhglobal']
+role::db::weekly_misc: []
 mariadb::config::innodb_buffer_pool_size: '30G'
 mariadb::version: '10.11'
 role::db::enable_ssl: false


### PR DESCRIPTION
The database is not on db151, it's on db171.