### PR TITLE
mariadb: increase table_open_cache and table_definition_cache

### DIFF
--- a/modules/mariadb/templates/config/mw.cnf.erb
+++ b/modules/mariadb/templates/config/mw.cnf.erb
@@ -46,8 +46,8 @@ tmp-table-size                 = 64M
 max-heap-table-size            = 64M
 max-connections                = <%= @max_connections %>
 open-files-limit               = 200000
-table_open_cache               = 200000
-table_definition_cache         = 75400
+table_open_cache               = 210000
+table_definition_cache         = 200000
 
 # thread and connection handling
 thread_handling                = pool-of-threads


### PR DESCRIPTION
Increase table_open_cache  to 210k

Increase table_definition_cache to 200k