### PR TITLE
wikitide-backup: add except to pca_connection

### DIFF
--- a/modules/base/templates/backups/wikitide-backup.py.erb
+++ b/modules/base/templates/backups/wikitide-backup.py.erb
@@ -30,7 +30,9 @@ def pca_connection(status, *args):
             try:
                 c.put(*args)
             except IOError:
-                print(f'WARNING: encountered IOError uploading {args[0]} to {args[1]}') 
+                print(f'WARNING: encountered IOError uploading {args[0]} to {args[1]}')
+            except:
+                print(f'WARNING: encountered error uploading {args[0]} to {args[1]}')
 
 
 def pca_web(method: str, url: str, expiry: int):


### PR DESCRIPTION
Means we know if an error occurred and no ioerror happened.