### PR TITLE
mediawiki::jobqueue::runner: remove "update rottenlinks on all wikis" cron

### DIFF
--- a/modules/mediawiki/manifests/jobqueue/runner.pp
+++ b/modules/mediawiki/manifests/jobqueue/runner.pp
@@ -70,16 +70,6 @@ class mediawiki::jobqueue::runner (
             hour    => '12',
         }
 
-        cron { 'update rottenlinks on all wikis':
-            ensure   => absent,
-            command  => "/usr/local/bin/fileLockScript.sh /tmp/rotten_links_file_lock \"/usr/bin/nice -n 15 /usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/databases.php ${runner}/srv/mediawiki/${version}/extensions/RottenLinks/maintenance/updateExternalLinks.php\"",
-            user     => 'www-data',
-            minute   => '0',
-            hour     => '0',
-            month    => '*',
-            monthday => [ '14', '28' ],
-        }
-
         cron { 'generate sitemaps for all wikis':
             ensure  => present,
             command => "/usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/databases.php ${runner}/srv/mediawiki/${version}/extensions/MirahezeMagic/maintenance/generateMirahezeSitemap.php",


### PR DESCRIPTION
This has been absented for quite a while. Remove it.