### PR TITLE
mediawiki::jobqueue::runner: remove clean_gu_cache cron

### DIFF
--- a/modules/mediawiki/manifests/jobqueue/runner.pp
+++ b/modules/mediawiki/manifests/jobqueue/runner.pp
@@ -171,14 +171,5 @@ class mediawiki::jobqueue::runner (
             hour     => '5',
             monthday => [ '5', '20' ],
         }
-
-        cron { 'clean_gu_cache':
-            ensure   => present,
-            command  => "/usr/local/bin/foreachwikiindblist /srv/mediawiki/cache/databases.php /srv/mediawiki/${version}/maintenance/run.php /srv/mediawiki/${version}/extensions/GlobalUsage/maintenance/refreshGlobalimagelinks.php --pages=existing,nonexisting > /dev/null",
-            user     => 'www-data',
-            minute   => '0',
-            hour     => '5',
-            monthday => [ '6', '21' ],
-        }
     }
 }


### PR DESCRIPTION
The documentation says you only need to run this once.