### PR TITLE
Set autocommit to 0

### DIFF
--- a/modules/mariadb/templates/config/mw.cnf.erb
+++ b/modules/mariadb/templates/config/mw.cnf.erb
@@ -17,6 +17,12 @@ bind-address                   = 0.0.0.0,::
 key-buffer-size                = 16M
 myisam-recover-options         = FORCE,BACKUP
 
+# Helps soften the blow of cockups such as T12886 and T12974
+# Please, please, please don't reenable unless if there is a substitute
+# to easily rolling back bad SQL statements when manually interfacing with
+# the database.
+autocommit                     = 0
+
 max-allowed-packet             = 64M
 max-connect-errors             = 1000000
 sql-mode                       = STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_AUTO_VALUE_ON_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE


### PR DESCRIPTION
This helps soften the blow of cockups where erroneous SQL statements are run directly against the database, as it would be trivial to ROLLBACK if statements were not automatically committed right after they were run.

Incidents that would not have happened if this were the case:
* https://meta.miraheze.org/wiki/Tech:Incidents/2024-11-13-mhglobal-data-loss-and-recovery
* https://meta.miraheze.org/wiki/Tech:Incidents/2024-12-08-mw-permissions-data-loss-and-recovery