### PR TITLE
switch cp* default ssl to CF origin cert

### DIFF
--- a/modules/ssl/manifests/wildcard.pp
+++ b/modules/ssl/manifests/wildcard.pp
@@ -20,14 +20,6 @@ define ssl::wildcard (
         $restart_nginx = undef
     }
 
-    if !defined(File["${ssl_cert_path}/wildcard.miraheze.org-2020-2.crt"]) {
-        file { "${ssl_cert_path}/wildcard.miraheze.org-2020-2.crt":
-            ensure => 'present',
-            source => 'puppet:///ssl/certificates/wildcard.miraheze.org-2020-2.crt',
-            notify => $restart_nginx,
-        }
-    }
-
     if !defined(File["${ssl_cert_path}/mirabeta-origin-cert.crt"]) {
         file { "${ssl_cert_path}/mirabeta-origin-cert.crt":
             ensure => 'present',

--- a/modules/varnish/templates/mediawiki.conf.erb
+++ b/modules/varnish/templates/mediawiki.conf.erb
@@ -98,8 +98,8 @@ server {
 	server_name miraheze.org *.miraheze.org;
 	root /var/www/html;
 
-	ssl_certificate /etc/ssl/localcerts/wildcard.miraheze.org-2020-2.crt;
-	ssl_certificate_key /etc/ssl/private/wildcard.miraheze.org-2020-2.key;
+	ssl_certificate /etc/ssl/localcerts/miraheze-origin-cert.crt;
+	ssl_certificate_key /etc/ssl/private/miraheze-origin-cert.key;
 
 	ssl_stapling_verify on;
 	


### PR DESCRIPTION
This is the final thing that still uses the now expired section cert. This also removes the cert definition for the old cert from the SSL module.