### PR TITLE
wikitide-backup: fix phorge compressed sql dump file name

### DIFF
--- a/modules/base/templates/backups/wikitide-backup.py.erb
+++ b/modules/base/templates/backups/wikitide-backup.py.erb
@@ -109,16 +109,16 @@ def backup_swift_account_container(dt: str):
 
 
 def backup_phorge(dt: str):
-    subprocess.check_call(f'/srv/phorge/phorge/bin/storage dump --compress --output backup.sql.gz', shell=True)
-    tar = tarfile.open('phorge.tar.gz', 'w:gz')
-    tar.add('backup.sql.gz', arcname='db')
-    subprocess.call(f'rm -f backup.sql.gz', shell=True)
+    subprocess.check_call(f'/srv/phorge/phorge/bin/storage dump --compress --output /srv/backups/backup.sql.gz', shell=True)
+    tar = tarfile.open('/srv/backups/phorge.tar.gz', 'w:gz')
+    tar.add('/srv/backups/backup.sql.gz', arcname='db')
+    subprocess.check_call(f'rm -f /srv/backups/backup.sql.gz', shell=True)
     tar.add('/srv/phorge/images', arcname='phorge')
     tar.close()
 
-    pca_connection('PUT', 'phorge.tar.gz', f'phorge/{dt}.tar.gz', False)
+    pca_connection('PUT', '/srv/backups/phorge.tar.gz', f'phorge/{dt}.tar.gz', False)
 
-    subprocess.call(f'rm -f phorge.tar.gz', shell=True)
+    subprocess.call(f'rm -f /srv/backups/phorge.tar.gz', shell=True)
 
     pca_web('POST', f'https://storage.bhs.cloud.ovh.net/v1/AUTH_76f9bc606a8044e08db7ebd118f6b19a/phorge/{dt}.tar.gz', 4)
     segments_expire(f'phorge', f'{dt}.tar.gz', 4)

--- a/modules/base/templates/backups/wikitide-backup.py.erb
+++ b/modules/base/templates/backups/wikitide-backup.py.erb
@@ -109,10 +109,10 @@ def backup_swift_account_container(dt: str):
 
 
 def backup_phorge(dt: str):
-    subprocess.check_call(f'/srv/phorge/phorge/bin/storage dump --compress --output backup.tar.gz', shell=True)
+    subprocess.check_call(f'/srv/phorge/phorge/bin/storage dump --compress --output backup.sql.gz', shell=True)
     tar = tarfile.open('phorge.tar.gz', 'w:gz')
-    tar.add('backup.tar.gz', arcname='db')
-    subprocess.call(f'rm -f backup.tar.gz', shell=True)
+    tar.add('backup.sql.gz', arcname='db')
+    subprocess.call(f'rm -f backup.sql.gz', shell=True)
     tar.add('/srv/phorge/images', arcname='phorge')
     tar.close()
 

--- a/modules/phorge/manifests/init.pp
+++ b/modules/phorge/manifests/init.pp
@@ -228,6 +228,11 @@ class phorge (
         command => '/usr/lib/nagios/plugins/check_procs -a phd -c 1:'
     }
 
+    # Backup provisioning
+    file { '/srv/backups':
+        ensure => directory,
+    }
+
     file { '/var/log/phorge-backup':
         ensure => 'directory',
         owner  => 'root',


### PR DESCRIPTION
Also changes location for where to store the backed up file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a dedicated backup directory at `/srv/backups` for improved organization of backup files.
	- Added a systemd timer job for scheduled backups of the Phorge component.
	- Implemented monitoring for backup logs to ensure timely oversight of backup processes.

- **Bug Fixes**
	- Updated file paths for backup outputs to ensure consistency and proper storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->