### PR TITLE
mediawiki: remove Cloudflare from firewall

### DIFF
--- a/modules/role/manifests/mediawiki.pp
+++ b/modules/role/manifests/mediawiki.pp
@@ -16,11 +16,8 @@ class role::mediawiki (
     include mediawiki
 
     if $strict_firewall {
-        $cloudflare_ipv4 = split(file('/etc/puppetlabs/puppet/private/files/firewall/cloudflare_ipv4'), /[\r\n]/)
-        $cloudflare_ipv6 = split(file('/etc/puppetlabs/puppet/private/files/firewall/cloudflare_ipv6'), /[\r\n]/)
-
         $firewall_rules_str = join(
-            $cloudflare_ipv4 + $cloudflare_ipv6 + query_facts('Class[Role::Mediawiki] or Class[Role::Mediawiki_task] or Class[Role::Varnish] or Class[Role::Icinga2] or Class[Role::Prometheus] or Class[Role::Bastion]', ['networking'])
+            query_facts('Class[Role::Mediawiki] or Class[Role::Mediawiki_task] or Class[Role::Varnish] or Class[Role::Icinga2] or Class[Role::Prometheus] or Class[Role::Bastion]', ['networking'])
             .map |$key, $value| {
                 if ( $value['networking']['interfaces']['he-ipv6'] ) {
                     "${value['networking']['ip']} ${value['networking']['interfaces']['he-ipv6']['ip6']}"


### PR DESCRIPTION
Requests go through varnish now. So we don't need to open MW firewall to Cloudflare anymore.