### PR TITLE
add cron to deploy Semantic MediaWiki

### DIFF
--- a/modules/mediawiki/manifests/jobqueue/runner.pp
+++ b/modules/mediawiki/manifests/jobqueue/runner.pp
@@ -129,6 +129,20 @@ class mediawiki::jobqueue::runner (
             require           => File['/var/log/mediawiki/cron'],
         }
 
+        systemd::timer::job { 'semanticmediawiki':
+            description       => 'Deploy Semantic MediaWiki files',
+            command           => "/usr/local/bin/mwdeploy --files=../mediawiki/<version>/extensions/SemanticMediaWiki/.smw.json --servers=all --no-log",
+            interval          => {
+                'start'    => 'OnCalendar',
+                'interval' => '*/15 * * * *',
+            },
+            logfile_basedir   => '/var/log/mediawiki/cron',
+            logfile_name      => 'semanticmediawikideploy.log',
+            syslog_identifier => 'semanticmediawikideploy',
+            user              => 'www-data',
+            require           => File['/var/log/mediawiki/cron'],
+        }
+
         if $wiki == 'loginwiki' {
             $swift_password = lookup('mediawiki::swift_password')
 


### PR DESCRIPTION
It may not be the nicest way but there's been quite a few SMW requests recently and it really slows the process down to need a steward and member of tech in order to enable it.

Until we figure out how to fix the bug that requires us to use deploy, this is the easiest way to allow stewards to enable it directly (and have the maint scripts ran in ManageWiki)