### PR TITLE
mediawiki: update php-fpm config

### DIFF
--- a/hieradata/role/common/mediawiki.yaml
+++ b/hieradata/role/common/mediawiki.yaml
@@ -10,6 +10,7 @@ mediawiki::jobqueue::runner::redis_ip: '10.0.17.120:6379'
 role::mediawiki::use_strict_firewall: true
 role::mediawiki::is_beta: false
 
+mediawiki::php::request_timeout: 201
 mediawiki::php::fpm::fpm_workers_multiplier: 2.0
 mediawiki::php::apc_shm_size: 4096M
 mediawiki::php::fpm_config:

--- a/hieradata/role/common/mediawiki.yaml
+++ b/hieradata/role/common/mediawiki.yaml
@@ -10,7 +10,6 @@ mediawiki::jobqueue::runner::redis_ip: '10.0.17.120:6379'
 role::mediawiki::use_strict_firewall: true
 role::mediawiki::is_beta: false
 
-mediawiki::php::emergency_restart_threshold: 10
 mediawiki::php::fpm::fpm_workers_multiplier: 2.0
 mediawiki::php::apc_shm_size: 4096M
 mediawiki::php::fpm_config:

--- a/hieradata/role/common/mediawiki.yaml
+++ b/hieradata/role/common/mediawiki.yaml
@@ -10,9 +10,8 @@ mediawiki::jobqueue::runner::redis_ip: '10.0.17.120:6379'
 role::mediawiki::use_strict_firewall: true
 role::mediawiki::is_beta: false
 
-mediawiki::php::fpm::fpm_min_child: 20
-mediawiki::php::emergency_restart_threshold: 12
-mediawiki::php::fpm::fpm_workers_multiplier: 1.0
+mediawiki::php::emergency_restart_threshold: 10
+mediawiki::php::fpm::fpm_workers_multiplier: 2.0
 mediawiki::php::apc_shm_size: 4096M
 mediawiki::php::fpm_config:
   post_max_size: '250M'

--- a/hieradata/role/common/mediawiki_beta.yaml
+++ b/hieradata/role/common/mediawiki_beta.yaml
@@ -16,6 +16,7 @@ mediawiki::use_cpjobqueue: false
 role::mediawiki::use_strict_firewall: true
 role::mediawiki::is_beta: true
 
+mediawiki::php::request_timeout: 201
 mediawiki::php::fpm::fpm_workers_multiplier: 2.0
 mediawiki::php::fpm_config:
   post_max_size: '250M'

--- a/hieradata/role/common/mediawiki_beta.yaml
+++ b/hieradata/role/common/mediawiki_beta.yaml
@@ -16,9 +16,7 @@ mediawiki::use_cpjobqueue: false
 role::mediawiki::use_strict_firewall: true
 role::mediawiki::is_beta: true
 
-mediawiki::php::fpm::fpm_min_child: 15
-mediawiki::php::emergency_restart_threshold: 6
-mediawiki::php::fpm::fpm_workers_multiplier: 1.0
+mediawiki::php::fpm::fpm_workers_multiplier: 2.0
 mediawiki::php::fpm_config:
   post_max_size: '250M'
   upload_max_filesize: '250M'

--- a/hieradata/role/common/mediawiki_task.yaml
+++ b/hieradata/role/common/mediawiki_task.yaml
@@ -13,9 +13,7 @@ mediawiki::use_cpjobqueue: true
 role::mediawiki::use_strict_firewall: true
 role::mediawiki::is_beta: false
 
-mediawiki::php::fpm::fpm_min_child: 20
-mediawiki::php::emergency_restart_threshold: 8
-mediawiki::php::fpm::fpm_workers_multiplier: 1.0
+mediawiki::php::fpm::fpm_workers_multiplier: 2.0
 mediawiki::php::request_timeout: 259200
 mediawiki::php::apc_shm_size: 4096M
 mediawiki::php::fpm_config:

--- a/modules/mediawiki/manifests/php.pp
+++ b/modules/mediawiki/manifests/php.pp
@@ -1,7 +1,7 @@
 # === Class mediawiki::php
 class mediawiki::php (
     Float $fpm_workers_multiplier        = lookup('mediawiki::php::fpm::fpm_workers_multiplier', {'default_value' => 1.5}),
-    Integer $request_timeout             = lookup('mediawiki::php::request_timeout', {'default_value' => 60}),
+    Integer $request_timeout             = lookup('mediawiki::php::request_timeout', {'default_value' => 240}),
     String $apc_shm_size                 = lookup('mediawiki::php::apc_shm_size', {'default_value' => '3072M'}),
     VMlib::Php_version $php_version      = lookup('php::php_version', {'default_value' => '8.2'}),
     Boolean $enable_fpm                  = lookup('mediawiki::php::enable_fpm', {'default_value' => true}),

--- a/modules/mediawiki/manifests/php.pp
+++ b/modules/mediawiki/manifests/php.pp
@@ -1,7 +1,6 @@
 # === Class mediawiki::php
 class mediawiki::php (
     Float $fpm_workers_multiplier        = lookup('mediawiki::php::fpm::fpm_workers_multiplier', {'default_value' => 1.5}),
-    Integer $fpm_min_child               = lookup('mediawiki::php::fpm::fpm_min_child', {'default_value' => 4}),
     Integer $request_timeout             = lookup('mediawiki::php::request_timeout', {'default_value' => 60}),
     String $apc_shm_size                 = lookup('mediawiki::php::apc_shm_size', {'default_value' => '3072M'}),
     VMlib::Php_version $php_version      = lookup('php::php_version', {'default_value' => '8.2'}),
@@ -9,7 +8,6 @@ class mediawiki::php (
     Boolean $enable_request_profiling    = lookup('mediawiki::php::enable_request_profiling', {'default_value' => false}),
     String $memory_limit                 = lookup('mediawiki::php::memory_limit', {'default_value' => '256M'}),
     Optional[Hash] $fpm_config           = lookup('mediawiki::php::fpm_config', {default_value => undef}),
-    Integer $emergency_restart_threshold = lookup('mediawiki::php::emergency_restart_threshold', {default_value => $facts['processors']['count']}),
     Boolean $increase_open_files         = lookup('mediawiki::php::increase_open_files', {'default_value' => false}),
 ) {
 
@@ -178,14 +176,14 @@ class mediawiki::php (
             ensure => present,
             config => {
                 'emergency_restart_interval'  => '60s',
-                'emergency_restart_threshold' => $emergency_restart_threshold,
+                'emergency_restart_threshold' => $facts['processors']['count'],
                 'process.priority'            => -19,
             }
         }
 
         # This will add an fpm pool
-        # We want a minimum of $fpm_min_child workers
-        $num_workers = max(floor($facts['processors']['count'] * $fpm_workers_multiplier), $fpm_min_child)
+        # We want a minimum of 8 workers
+        $num_workers = max(floor($facts['processors']['count'] * $fpm_workers_multiplier), 8)
         php::fpm::pool { 'www':
             config => {
                 'pm'                        => 'static',


### PR DESCRIPTION
* Use a multiplier instead of manually defining the php childs. We multiple by 2 so (12 * 2).
* We use total cores for emergency restart threshold. We no longer manually define it.