### PR TITLE
swift: Include ssl::wildcard after nginx::site

### DIFF
--- a/modules/swift/manifests/proxy.pp
+++ b/modules/swift/manifests/proxy.pp
@@ -45,13 +45,13 @@ class swift::proxy (
         content => systemd_template('swift-proxy'),
     }
 
-    ssl::wildcard { 'swift wildcard': }
-
     nginx::site { 'swift':
         ensure  => present,
         source  => 'puppet:///modules/swift/nginx/swift.conf',
         monitor => false,
     }
+
+    ssl::wildcard { 'swift wildcard': }
 
     nginx::site { 'default':
         ensure  => absent,


### PR DESCRIPTION
This is so it can detect the nginx service and reload it when the cert updates.