### PR TITLE
nginx: use TLS v1.3

### DIFF
--- a/modules/mediawiki/templates/mediawiki.conf.erb
+++ b/modules/mediawiki/templates/mediawiki.conf.erb
@@ -210,6 +210,7 @@ server {
 
         location / {
                 proxy_pass https://swift-lb.wikitide.net;
+                proxy_ssl_protocols TLSv1.3;
                 proxy_http_version 1.1;
                 proxy_set_header Connection close; # should be default
 

--- a/modules/nginx/templates/nginx.conf.erb
+++ b/modules/nginx/templates/nginx.conf.erb
@@ -38,9 +38,9 @@ http {
 	server_tokens off;
 
 	# SSL Settings
-	ssl_ciphers EECDH+CHACHA20:EECDH+AES128:EECDH+AES256:EECDH+3DES:!MD5;
-	ssl_protocols TLSv1.2 TLSv1.3;
-	ssl_prefer_server_ciphers on;
+	ssl_protocols TLSv1.3;
+	ssl_ecdh_curve X25519:prime256v1:secp384r1;
+	ssl_prefer_server_ciphers off;
 	ssl_stapling on;
 	ssl_session_cache shared:SSL:<%= @ssl_session_cache %>m;
 	ssl_session_timeout 25h;

--- a/modules/role/templates/bastion/mediawiki.conf.erb
+++ b/modules/role/templates/bastion/mediawiki.conf.erb
@@ -17,6 +17,7 @@ server {
 
 	location / {
 		proxy_pass https://<%= name %>.wikitide.net;
+		proxy_ssl_protocols TLSv1.3;
 		proxy_http_version 1.1;
 		proxy_set_header Connection $connection_upgrade;
 		proxy_set_header Upgrade $http_upgrade;

--- a/modules/varnish/templates/mediawiki.conf.erb
+++ b/modules/varnish/templates/mediawiki.conf.erb
@@ -30,6 +30,7 @@ server {
 		proxy_pass https://<%= name %>.wikitide.net;
 		<%- end -%>
 		<%- end -%>
+		proxy_ssl_protocols TLSv1.3;
 		proxy_http_version 1.1;
 		proxy_set_header Connection $connection_upgrade;
 		proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
Also switch reverse proxies that use https:// to use tls v1.3. Solution found with https://unix.stackexchange.com/questions/706074/nginx-reverse-proxy-fails-with-tlsv1-3-on-backend-servers.