### PR TITLE
mediawiki_task: unset memory_limit

### DIFF
--- a/hieradata/role/common/mediawiki_task.yaml
+++ b/hieradata/role/common/mediawiki_task.yaml
@@ -24,7 +24,6 @@ mediawiki::php::fpm_config:
   max_execution_time: 1200
 
 mediawiki::php::increase_open_files: true
-mediawiki::php::memory_limit: '1G'
 mediawiki::php::enable_request_profiling: true
 
 php::php_version: '8.2'


### PR DESCRIPTION
Use the default that we set which is 500M.

We override based on usage inside MW anyways.