### PR TITLE
Temp allow cloud ssh without bastion

### DIFF
--- a/modules/role/manifests/cloud.pp
+++ b/modules/role/manifests/cloud.pp
@@ -49,6 +49,11 @@ class role::cloud {
         srange => "(${firewall_rules_str})",
     }
 
+    ferm::service { 'cloud-ssh':
+        proto => 'tcp',
+        port  => '22',
+    }
+
     system::role { 'cloud':
         description => 'Proxmox host',
     }


### PR DESCRIPTION
For maintenance when both bastions are temporarily down we will need to do this temporarily. Not to be merged until just before maintenance and reverted afterwards.