### PR TITLE
mariadb: default to read_only on startup

### DIFF
--- a/modules/mariadb/templates/config/mw.cnf.erb
+++ b/modules/mariadb/templates/config/mw.cnf.erb
@@ -17,6 +17,10 @@ bind-address                   = 0.0.0.0,::
 key-buffer-size                = 16M
 myisam-recover-options         = FORCE,BACKUP
 
+# Default to read only on startup.
+# Unset it by doing `set global read_only = 0`
+read_only                      = 1
+
 max-allowed-packet             = 64M
 max-connect-errors             = 1000000
 sql-mode                       = STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_AUTO_VALUE_ON_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE


### PR DESCRIPTION
Temporarily for maintenance.