### PR TITLE
ircecho: Fix print statement

### DIFF
--- a/modules/monitoring/files/bot/ircecho.py
+++ b/modules/monitoring/files/bot/ircecho.py
@@ -189,7 +189,7 @@ class EventHandler(pyinotify.ProcessEvent):
             except (irc.client.ServerNotConnectedError, irc.client.MessageTooLong,
                     UnicodeDecodeError) as e:
                 print('Error writing: %s'
-                      'Dropping this message: "%s"') % (e, s)
+                      'Dropping this message: "%s"' % (e, s))
 
     def process_IN_CREATE(self, event):
         try:


### PR DESCRIPTION
```
Feb 26 20:44:13 mon181 ircecho[601]:   File "/usr/local/bin/ircecho", line 191, in process_IN_MODIFY
Feb 26 20:44:13 mon181 ircecho[601]:     print('Error writing: %s'
Feb 26 20:44:13 mon181 ircecho[601]: TypeError: unsupported operand type(s) for %: 'NoneType' and 'tuple'
```