### PR TITLE
eventgate: install libssl-dev

### DIFF
--- a/modules/eventgate/manifests/init.pp
+++ b/modules/eventgate/manifests/init.pp
@@ -1,7 +1,7 @@
 # == Class: eventgate
 
 class eventgate {
-    stdlib::ensure_packages(['nodejs', 'libssl1.1'])
+    stdlib::ensure_packages(['nodejs', 'libssl-dev'])
 
     group { 'eventgate':
         ensure => present,


### PR DESCRIPTION
libssl1.1 is not available on bookworm. Instead use libssl-dev which will install what ever newer version is available.