### PR TITLE
changeprop: install libssl-dev

### DIFF
--- a/modules/changeprop/manifests/init.pp
+++ b/modules/changeprop/manifests/init.pp
@@ -19,7 +19,7 @@ class changeprop (
     $redis_host                            = lookup('changeprop::redis_host', {'default_value' => 'localhost'}),
     $redis_password                        = lookup('passwords::redis::master')
 ) {
-    stdlib::ensure_packages(['nodejs', 'libssl1.1', 'libsasl2-dev'])
+    stdlib::ensure_packages(['nodejs', 'libssl-dev', 'libsasl2-dev'])
 
     group { 'changeprop':
         ensure => present,


### PR DESCRIPTION
libssl1.1 is not available on bookworm. Instead use libssl-dev which will install what ever newer version is available.