### PR TITLE
mediawiki::jobqueue::runer: remove managewikis systemd timer for now

### DIFF
--- a/modules/mediawiki/manifests/jobqueue/runner.pp
+++ b/modules/mediawiki/manifests/jobqueue/runner.pp
@@ -60,6 +60,7 @@ class mediawiki::jobqueue::runner (
         }
 
         systemd::timer::job { 'managewikis':
+            ensure            => absent,
             description       => 'Check for inactive wikis',
             command           => "/usr/bin/php /srv/mediawiki/${version}/maintenance/run.php CreateWiki:ManageInactiveWikis --wiki ${wiki} --write",
             interval          => {


### PR DESCRIPTION
It's causing issues internally.