### PR TITLE
[MediaWiki 1.44-alpha will be branched as a beta on 01-05-2025] beta: use REL1_44 for beta

### DIFF
--- a/hieradata/role/common/mediawiki_beta.yaml
+++ b/hieradata/role/common/mediawiki_beta.yaml
@@ -31,7 +31,7 @@ mediawiki::multiversion::versions:
   '1.43':
     branch: 'REL1_43'
   '1.44':
-    branch: 'master'
+    branch: 'REL1_44'
     default: true
 
 php::php_version: '8.2'


### PR DESCRIPTION
MERGE AFTER 22-04-2025

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated MediaWiki 1.44’s branch designation to a release-specific naming scheme, aligning with our standardized versioning approach. All other system settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->