### PR TITLE
cache::haproxy: remove option http-server-close from the varnish backends

### DIFF
--- a/modules/role/templates/cache/haproxy/tls_terminator.cfg.erb
+++ b/modules/role/templates/cache/haproxy/tls_terminator.cfg.erb
@@ -208,8 +208,6 @@ listen <%= name %>_backend_tls
     # timeout used after upgrading a connection (websockets) or after the first response when no keepalive/close option is specified
     timeout tunnel <%= @timeout['tunnel'] %>s
 
-    option http-server-close
-
     # We don't use a healthchecker because we use varnish for this.
     server <%= name %>_backend <%= name %>.<%= property['domain'] || 'wikitide.net' %>:443 ssl check-ssl verify none
 


### PR DESCRIPTION

Seems to interfere with grafana? I don't think this is needed or is what fixed the issue with random wiki requests ending up at grafana.