### PR TITLE
cache::haproxy: Remove X-OpenStack-Request-ID header if X-Wikitide-Debug isn't present

### DIFF
--- a/hieradata/role/common/cache/cache.yaml
+++ b/hieradata/role/common/cache/cache.yaml
@@ -256,6 +256,9 @@ role::cache::haproxy::del_headers:
       name: 'Backend-Timing'
       acl: missing_xwd
     - direction: response
+      name: 'X-OpenStack-Request-ID'
+      acl: missing_xwd
+    - direction: response
       name: 'X-Powered-By'
       acl: missing_xwd
     - direction: response

--- a/hieradata/role/common/cache/cache.yaml
+++ b/hieradata/role/common/cache/cache.yaml
@@ -197,7 +197,7 @@ role::cache::haproxy::vars:
   tls:
     - direction: request
       name: 'txn.xwd_count'
-      value: 'req.hdr_cnt(X-Miraheze-Debug)'
+      value: 'req.hdr_cnt(X-Wikitide-Debug)'
   http:
     - direction: request
       name: 'req.dummy_silent_drop_port80'  # exists only for logging purposes


### PR DESCRIPTION
Also corrects what header to look at for debug.