### PR TITLE
mediawiki: set fastcgi_request_buffering to off

### DIFF
--- a/modules/mediawiki/templates/mediawiki-includes.conf.erb
+++ b/modules/mediawiki/templates/mediawiki-includes.conf.erb
@@ -25,6 +25,7 @@ location ~ ^/(w/)?\w+\.php {
 	fastcgi_buffers 32 32k;
 	fastcgi_buffer_size 64k;
 	fastcgi_pass unix:/run/<%= @php_fpm_sock %>;
+	fastcgi_request_buffering off;
 }
 
 location = /favicon.ico {
@@ -41,6 +42,7 @@ location ^~ /w/index.php {
 	fastcgi_buffers 32 32k;
 	fastcgi_buffer_size 64k;
 	fastcgi_pass unix:/run/<%= @php_fpm_sock %>;
+	fastcgi_request_buffering off;
 
 	if ($request_uri ~ OAuth) {
 		# Skip OAuth requests to prevent
@@ -88,6 +90,7 @@ location @wiki {
 	fastcgi_buffers 32 32k;
 	fastcgi_buffer_size 64k;
 	fastcgi_pass unix:/run/<%= @php_fpm_sock %>;
+	fastcgi_request_buffering off;
 }
 
 location ~ ^/m/(.*) {

--- a/modules/mediawiki/templates/mediawiki.conf.erb
+++ b/modules/mediawiki/templates/mediawiki.conf.erb
@@ -66,6 +66,7 @@ server {
 		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 		fastcgi_pass unix:/run/<%= @php_fpm_sock %>;
 		fastcgi_read_timeout 140;
+		fastcgi_request_buffering off
 		send_timeout 140;
 	}
 
@@ -173,6 +174,7 @@ server {
 		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 		fastcgi_buffers 32 32k;
 		fastcgi_buffer_size 64k;
+		fastcgi_request_buffering off
 		fastcgi_pass unix:/run/<%= @php_fpm_sock %>;
 	}
 
@@ -259,6 +261,7 @@ server {
 		fastcgi_pass unix:/run/<%= @php_fpm_sock %>;
 		fastcgi_read_timeout 140;
 		send_timeout 140;
+		fastcgi_request_buffering off
 	}
 
 	location ~ ^/((?!(css|img|js|lib|scss)).)*$ {
@@ -324,6 +327,7 @@ server {
 		fastcgi_pass unix:/run/<%= @php_fpm_sock %>;
 		fastcgi_read_timeout 140;
 		send_timeout 140;
+		fastcgi_request_buffering off
 	}
 
 	location ~ ^/((?!(css|img|js|lib|scss)).)*$ {

--- a/modules/mediawiki/templates/mediawiki.conf.erb
+++ b/modules/mediawiki/templates/mediawiki.conf.erb
@@ -17,6 +17,7 @@ server {
 		fastcgi_buffers 32 32k;
 		fastcgi_buffer_size 64k;
 		fastcgi_read_timeout 20;
+		fastcgi_request_buffering off;
 		send_timeout 20s;
 	}
 
@@ -66,7 +67,7 @@ server {
 		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 		fastcgi_pass unix:/run/<%= @php_fpm_sock %>;
 		fastcgi_read_timeout 140;
-		fastcgi_request_buffering off
+		fastcgi_request_buffering off;
 		send_timeout 140;
 	}
 
@@ -174,7 +175,7 @@ server {
 		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 		fastcgi_buffers 32 32k;
 		fastcgi_buffer_size 64k;
-		fastcgi_request_buffering off
+		fastcgi_request_buffering off;
 		fastcgi_pass unix:/run/<%= @php_fpm_sock %>;
 	}
 
@@ -261,7 +262,7 @@ server {
 		fastcgi_pass unix:/run/<%= @php_fpm_sock %>;
 		fastcgi_read_timeout 140;
 		send_timeout 140;
-		fastcgi_request_buffering off
+		fastcgi_request_buffering off;
 	}
 
 	location ~ ^/((?!(css|img|js|lib|scss)).)*$ {
@@ -327,7 +328,7 @@ server {
 		fastcgi_pass unix:/run/<%= @php_fpm_sock %>;
 		fastcgi_read_timeout 140;
 		send_timeout 140;
-		fastcgi_request_buffering off
+		fastcgi_request_buffering off;
 	}
 
 	location ~ ^/((?!(css|img|js|lib|scss)).)*$ {


### PR DESCRIPTION
Reading up, this is recommended for large uploads? And it's similar behaviour to apache which has less ability to configure behaviour with fastcgi.