### PR TITLE
ssl: switch off automatic cert renewal for custom domains

### DIFF
--- a/modules/monitoring/templates/ssl.conf.erb
+++ b/modules/monitoring/templates/ssl.conf.erb
@@ -38,9 +38,6 @@ apply Service "<%= property['url'] %> - <%= property['ca'] %>" {
   notes_url = "https://meta.miraheze.org/wiki/Tech:Icinga/MediaWiki_Monitoring#SSL_Validity_Checks"
   vars.host = "<% if property['url'].start_with?('*') and property['sslname'] %><%= property['sslname'] %><% else %><%= property['url'] %><% end %>"
   vars.time = "<% if property['ca'] == "LetsEncrypt" %>14<% else %>29<% end %>"
-  <%- if property['ca'] == "LetsEncrypt" and property['disable_event'] == false -%>
-  event_command = "eh_ssl_acme"
-  <%- end -%>
   assign where "sslchecks" in host.groups
 }
 <% end %>

--- a/modules/monitoring/templates/ssl.conf.erb
+++ b/modules/monitoring/templates/ssl.conf.erb
@@ -37,7 +37,7 @@ apply Service "<%= property['url'] %> - <%= property['ca'] %>" {
   check_interval = 30m
   notes_url = "https://meta.miraheze.org/wiki/Tech:Icinga/MediaWiki_Monitoring#SSL_Validity_Checks"
   vars.host = "<% if property['url'].start_with?('*') and property['sslname'] %><%= property['sslname'] %><% else %><%= property['url'] %><% end %>"
-  vars.time = "<% if property['ca'] == "LetsEncrypt" %>14<% else %>29<% end %>"
+  vars.time = "<% if property['ca'] == "LetsEncrypt" %>1<% else %>29<% end %>"
   assign where "sslchecks" in host.groups
 }
 <% end %>


### PR DESCRIPTION
No certificates are expected to require automatic renewal between now and May 16th when our Hosted DNS service is due to close. Therefore, these can be let to expire as all certs by then will be managed by Cloudflare.