### PR TITLE
Add support for composable index templates

### DIFF
--- a/modules/opensearch/README.md
+++ b/modules/opensearch/README.md
@@ -238,6 +238,16 @@ opensearch::template { 'templatename':
 }
 ```
 
+From version 7.8 elasticserch provides a new composable templates functionality, both legacy templates api and new composable templates api are supported using different data types.
+
+#### Data types & defines
+
+For legacy templates `template` is used.
+
+For composable templates `component_template` and `index_template` are used.
+
+Both types can be used at the same time
+
 #### Add a new template using a file
 
 This will install and/or replace the template in Opensearch:

--- a/modules/opensearch/REFERENCE.md
+++ b/modules/opensearch/REFERENCE.md
@@ -13,7 +13,9 @@
 
 ### Defined types
 
+* [`opensearch::component_template`](#opensearch--component_template): This define allows you to insert, update or delete Opensearch component  templates.   Template content should be defined through either th
 * [`opensearch::index`](#opensearchindex): A defined type to control Opensearch index-level settings.
+* [`opensearch::index_template`](#opensearch--index_template): This define allows you to insert, update or delete Opensearch index  templates (using new composable api).   Template content should be de
 * [`opensearch::pipeline`](#opensearchpipeline): This define allows you to insert, update or delete Opensearch index  ingestion pipelines.   Pipeline content should be defined through the
 * [`opensearch::plugin`](#opensearchhplugin): This define allows you to install arbitrary Opensearch plugins either by using the default repositories or by specifying an URL
 * [`opensearch::role`](#opensearchrole): Manage x-pack roles.
@@ -24,7 +26,9 @@
 
 ### Resource types
 
+* [`opensearch_component_template`](#opensearch_component_template): Manages Opensearch component templates.
 * [`opensearch_index`](#opensearch_index): Manages Opensearch index settings.
+* [`opensearch_index_template`](#opensearch_index_template): Manages Opensearch index templates.
 * [`opensearch_keystore`](#opensearch_keystore): Manages an Opensearch keystore settings file.
 * [`opensearch_pipeline`](#opensearch_pipeline): Manages Opensearch ingest pipelines.
 * [`opensearch_plugin`](#opensearch_plugin): Plugin installation type
@@ -162,6 +166,8 @@ The following parameters are available in the `opensearch` class:
 * [`system_key`](#system_key)
 * [`systemd_service_path`](#systemd_service_path)
 * [`templates`](#templates)
+* [`index_templates`](#index_templates)
+* [`component_templates`](#component_templates)
 * [`users`](#users)
 * [`validate_tls`](#validate_tls)
 * [`version`](#version)
@@ -702,6 +708,22 @@ Data type: `Hash`
 
 Define templates via a hash. This is mainly used with Hiera's auto binding.
 
+##### <a name="index_templates"></a>`index_templates`
+
+Data type: `Hash`
+
+Define index_templates via a hash. This is mainly used with Hiera's auto binding.
+
+Default value: `{}`
+
+##### <a name="component_templates"></a>`component_templates`
+
+Data type: `Hash`
+
+Define component_templates via a hash. This is mainly used with Hiera's auto binding.
+
+Default value: `{}`
+
 ##### <a name="users"></a>`users`
 
 Data type: `Hash`
@@ -764,6 +786,136 @@ in general and is used in a platform-independent way. E.g. "service" means
 "daemon" in relation to Unix-like systems.
 
 ## Defined types
+
+### <a name="component_template"></a>`opensearch::component_template`
+
+This define allows you to insert, update or delete Opensearch component
+ templates.
+
+ Template content should be defined through either the `content` parameter
+ (when passing a hash or json string) or the `source` parameter (when passing
+ the puppet file URI to a template json file).
+
+#### Parameters
+
+The following parameters are available in the `opensearch::component_template` defined type:
+
+* [`ensure`](#component_template--ensure)
+* [`api_basic_auth_password`](#component_template--api_basic_auth_password)
+* [`api_basic_auth_username`](#component_template--api_basic_auth_username)
+* [`api_ca_file`](#component_template--api_ca_file)
+* [`api_ca_path`](#component_template--api_ca_path)
+* [`api_host`](#component_template--api_host)
+* [`api_port`](#component_template--api_port)
+* [`api_protocol`](#component_template--api_protocol)
+* [`api_timeout`](#component_template--api_timeout)
+* [`content`](#component_template--content)
+* [`source`](#component_template--source)
+* [`validate_tls`](#component_template--validate_tls)
+
+##### <a name="component_template--ensure"></a>`ensure`
+
+Data type: `Enum['absent', 'present']`
+
+Controls whether the named component template should be present or absent in
+the cluster.
+
+Default value: `'present'`
+
+##### <a name="component_template--api_basic_auth_password"></a>`api_basic_auth_password`
+
+Data type: `Optional[String]`
+
+HTTP basic auth password to use when communicating over the Opensearch
+API.
+
+Default value: `$opensearch::api_basic_auth_password`
+
+##### <a name="component_template--api_basic_auth_username"></a>`api_basic_auth_username`
+
+Data type: `Optional[String]`
+
+HTTP basic auth username to use when communicating over the Opensearch
+API.
+
+Default value: `$opensearch::api_basic_auth_username`
+
+##### <a name="component_template--api_ca_file"></a>`api_ca_file`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+Path to a CA file which will be used to validate server certs when
+communicating with the Opensearch API over HTTPS.
+
+Default value: `$opensearch::api_ca_file`
+
+##### <a name="component_template--api_ca_path"></a>`api_ca_path`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+Path to a directory with CA files which will be used to validate server
+certs when communicating with the Opensearch API over HTTPS.
+
+Default value: `$opensearch::api_ca_path`
+
+##### <a name="component_template--api_host"></a>`api_host`
+
+Data type: `String`
+
+Host name or IP address of the OS instance to connect to.
+
+Default value: `$opensearch::api_host`
+
+##### <a name="component_template--api_port"></a>`api_port`
+
+Data type: `Integer[0, 65535]`
+
+Port number of the OS instance to connect to
+
+Default value: `$opensearch::api_port`
+
+##### <a name="component_template--api_protocol"></a>`api_protocol`
+
+Data type: `Enum['http', 'https']`
+
+Protocol that should be used to connect to the Opensearch API.
+
+Default value: `$opensearch::api_protocol`
+
+##### <a name="component_template--api_timeout"></a>`api_timeout`
+
+Data type: `Integer`
+
+Timeout period (in seconds) for the Opensearch API.
+
+Default value: `$opensearch::api_timeout`
+
+##### <a name="component_template--content"></a>`content`
+
+Data type: `Optional[Variant[String, Hash]]`
+
+Contents of the template. Can be either a puppet hash or a string
+containing JSON.
+
+Default value: `undef`
+
+##### <a name="component_template--source"></a>`source`
+
+Data type: `Optional[String]`
+
+Source path for the template file. Can be any value similar to `source`
+values for `file` resources.
+
+Default value: `undef`
+
+##### <a name="component_template--validate_tls"></a>`validate_tls`
+
+Data type: `Boolean`
+
+Determines whether the validity of SSL/TLS certificates received from the
+Opensearch API should be verified or ignored.
+
+Default value: `$opensearch::validate_tls`
 
 ### <a name="opensearchindex"></a>`opensearch::index`
 
@@ -871,6 +1023,136 @@ Index settings in hash form (typically nested).
 Default value: `{}`
 
 ##### <a name="validate_tls"></a>`validate_tls`
+
+Data type: `Boolean`
+
+Determines whether the validity of SSL/TLS certificates received from the
+Opensearch API should be verified or ignored.
+
+Default value: `$opensearch::validate_tls`
+
+### <a name="index_template"></a>`opensearch::index_template`
+
+This define allows you to insert, update or delete Opensearch index
+ templates (using new composable api).
+
+ Template content should be defined through either the `content` parameter
+ (when passing a hash or json string) or the `source` parameter (when passing
+ the puppet file URI to a template json file).
+
+#### Parameters
+
+The following parameters are available in the `opensearch::index_template` defined type:
+
+* [`ensure`](#index_template--ensure)
+* [`api_basic_auth_password`](#index_template--api_basic_auth_password)
+* [`api_basic_auth_username`](#index_template--api_basic_auth_username)
+* [`api_ca_file`](#index_template--api_ca_file)
+* [`api_ca_path`](#index_template--api_ca_path)
+* [`api_host`](#index_template--api_host)
+* [`api_port`](#index_template--api_port)
+* [`api_protocol`](#index_template--api_protocol)
+* [`api_timeout`](#index_template--api_timeout)
+* [`content`](#index_template--content)
+* [`source`](#index_template--source)
+* [`validate_tls`](#index_template--validate_tls)
+
+##### <a name="index_template--ensure"></a>`ensure`
+
+Data type: `Enum['absent', 'present']`
+
+Controls whether the named index template should be present or absent in
+the cluster.
+
+Default value: `'present'`
+
+##### <a name="index_template--api_basic_auth_password"></a>`api_basic_auth_password`
+
+Data type: `Optional[String]`
+
+HTTP basic auth password to use when communicating over the Opensearch
+API.
+
+Default value: `$opensearch::api_basic_auth_password`
+
+##### <a name="index_template--api_basic_auth_username"></a>`api_basic_auth_username`
+
+Data type: `Optional[String]`
+
+HTTP basic auth username to use when communicating over the Opensearch
+API.
+
+Default value: `$opensearch::api_basic_auth_username`
+
+##### <a name="index_template--api_ca_file"></a>`api_ca_file`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+Path to a CA file which will be used to validate server certs when
+communicating with the Opensearch API over HTTPS.
+
+Default value: `$opensearch::api_ca_file`
+
+##### <a name="index_template--api_ca_path"></a>`api_ca_path`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+Path to a directory with CA files which will be used to validate server
+certs when communicating with the Opensearch API over HTTPS.
+
+Default value: `$opensearch::api_ca_path`
+
+##### <a name="index_template--api_host"></a>`api_host`
+
+Data type: `String`
+
+Host name or IP address of the OS instance to connect to.
+
+Default value: `$opensearch::api_host`
+
+##### <a name="index_template--api_port"></a>`api_port`
+
+Data type: `Integer[0, 65535]`
+
+Port number of the OS instance to connect to
+
+Default value: `$opensearch::api_port`
+
+##### <a name="index_template--api_protocol"></a>`api_protocol`
+
+Data type: `Enum['http', 'https']`
+
+Protocol that should be used to connect to the Opensearch API.
+
+Default value: `$opensearch::api_protocol`
+
+##### <a name="index_template--api_timeout"></a>`api_timeout`
+
+Data type: `Integer`
+
+Timeout period (in seconds) for the Opensearch API.
+
+Default value: `$opensearch::api_timeout`
+
+##### <a name="index_template--content"></a>`content`
+
+Data type: `Optional[Variant[String, Hash]]`
+
+Contents of the template. Can be either a puppet hash or a string
+containing JSON.
+
+Default value: `undef`
+
+##### <a name="index_template--source"></a>`source`
+
+Data type: `Optional[String]`
+
+Source path for the template file. Can be any value similar to `source`
+values for `file` resources.
+
+Default value: `undef`
+
+##### <a name="index_template--validate_tls"></a>`validate_tls`
 
 Data type: `Boolean`
 
@@ -1559,6 +1841,49 @@ Default value: `[]`
 
 ## Resource types
 
+### <a name="opensearch_component_template"></a>`opensearch_component_template`
+
+Manages Opensearch component templates.
+
+#### Properties
+
+The following properties are available in the `opensearch_component_template` type.
+
+##### `content`
+
+Structured content of template.
+
+##### `ensure`
+
+Valid values: `present`, `absent`
+
+The basic property that the resource should be in.
+
+Default value: `present`
+
+#### Parameters
+
+The following parameters are available in the `opensearch_component_template` type.
+
+* [`name`](#component_template--name)
+* [`provider`](#component_template--provider)
+* [`source`](#component_template--source)
+
+##### <a name="component_template--name"></a>`name`
+
+namevar
+
+Template name.
+
+##### <a name="component_template--provider"></a>`provider`
+
+The specific backend to use for this `opensearch_component_template` resource. You will seldom need to specify this
+--- Puppet will usually discover the appropriate provider for your platform.
+
+##### <a name="component_template--source"></a>`source`
+
+Puppet source to file containing template contents.
+
 ### <a name="opensearch_index"></a>`opensearch_index`
 
 Manages Opensearch index settings.
@@ -1596,6 +1921,49 @@ Index name.
 
 The specific backend to use for this `opensearch_index` resource. You will seldom need to specify this --- Puppet
 will usually discover the appropriate provider for your platform.
+
+### <a name="opensearch_index_template"></a>`opensearch_index_template`
+
+Manages Opensearch index templates.
+
+#### Properties
+
+The following properties are available in the `opensearch_index_template` type.
+
+##### `content`
+
+Structured content of template.
+
+##### `ensure`
+
+Valid values: `present`, `absent`
+
+The basic property that the resource should be in.
+
+Default value: `present`
+
+#### Parameters
+
+The following parameters are available in the `opensearch_index_template` type.
+
+* [`name`](#index_template--name)
+* [`provider`](#index_template--provider)
+* [`source`](#index_template--source)
+
+##### <a name="index_template--name"></a>`name`
+
+namevar
+
+Template name.
+
+##### <a name="index_template--provider"></a>`provider`
+
+The specific backend to use for this `opensearch_index_template` resource. You will seldom need to specify this ---
+Puppet will usually discover the appropriate provider for your platform.
+
+##### <a name="index_template--source"></a>`source`
+
+Puppet source to file containing template contents.
 
 ### <a name="opensearch_keystore"></a>`opensearch_keystore`
 

--- a/modules/opensearch/lib/puppet/provider/opensearch_component_template/ruby.rb
+++ b/modules/opensearch/lib/puppet/provider/opensearch_component_template/ruby.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..', '..'))
+
+require 'puppet/provider/opensearch_rest'
+
+require 'puppet_x/opensearch/deep_to_i'
+require 'puppet_x/opensearch/deep_to_s'
+
+Puppet::Type.type(:opensearch_component_template).provide(
+  :ruby,
+  parent: Puppet::Provider::OpensearchREST,
+  api_uri: '_component_template',
+  metadata: :content,
+  metadata_pipeline: [
+    lambda { |data|
+      # As api returns values keyed under component_template
+      data.merge!(data['component_template']) if data['component_template'].is_a? Hash
+      data.delete('component_template')
+    },
+    ->(data) { Puppet_X::Opensearch.deep_to_s data },
+    ->(data) { Puppet_X::Opensearch.deep_to_i data }
+  ]
+) do
+  desc 'A REST API based provider to manage Opensearch component templates.'
+
+  mk_resource_methods
+
+  # We need to override parent since actual data comes as array under component_templates key
+  def self.process_body(body)
+    JSON.parse(body).fetch('component_templates', []).map do |item|
+      {
+        :name => item['name'],
+        :ensure => :present,
+        metadata => process_metadata(item.keep_if { |key| key != 'name' }),
+        :provider => name
+      }
+    end
+  end
+end

--- a/modules/opensearch/lib/puppet/provider/opensearch_index_template/ruby.rb
+++ b/modules/opensearch/lib/puppet/provider/opensearch_index_template/ruby.rb
@@ -1,0 +1,41 @@
+
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..', '..'))
+
+require 'puppet/provider/opensearch_rest'
+
+require 'puppet_x/opensearch/deep_to_i'
+require 'puppet_x/opensearch/deep_to_s'
+
+Puppet::Type.type(:opensearch_index_template).provide(
+  :ruby,
+  parent: Puppet::Provider::OpensearchREST,
+  api_uri: '_index_template',
+  metadata: :content,
+  metadata_pipeline: [
+    lambda { |data|
+      # As api returns values keyed under index_template
+      data.merge!(data['index_template']) if data['index_template'].is_a? Hash
+      data.delete('index_template')
+    },
+    ->(data) { Puppet_X::Opensearch.deep_to_s data },
+    ->(data) { Puppet_X::Opensearch.deep_to_i data }
+  ]
+) do
+  desc 'A REST API based provider to manage Opensearch index templates.'
+
+  mk_resource_methods
+
+  # We need to override parent since actual data comes as array under index_templates key
+  def self.process_body(body)
+    JSON.parse(body).fetch('index_templates', []).map do |item|
+      {
+        :name => item['name'],
+        :ensure => :present,
+        metadata => process_metadata(item.keep_if { |key| key != 'name' }),
+        :provider => name
+      }
+    end
+  end
+end

--- a/modules/opensearch/lib/puppet/type/opensearch_component_template.rb
+++ b/modules/opensearch/lib/puppet/type/opensearch_component_template.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..'))
+
+require 'puppet/file_serving/content'
+require 'puppet/file_serving/metadata'
+
+require 'puppet_x/opensearch/deep_implode'
+require 'puppet_x/opensearch/deep_to_i'
+require 'puppet_x/opensearch/deep_to_s'
+require 'puppet_x/opensearch/opensearch_rest_resource'
+
+Puppet::Type.newtype(:opensearch_component_template) do
+  extend OpensearchRESTResource
+
+  desc 'Manages Opensearch component templates.'
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'Template name.'
+  end
+
+  newproperty(:content) do
+    desc 'Structured content of template.'
+
+    validate do |value|
+      raise Puppet::Error, 'hash expected' unless value.is_a? Hash
+    end
+
+    def insync?(value)
+      Puppet_X::Opensearch.deep_implode(value) == \
+        Puppet_X::Opensearch.deep_implode(should)
+    end
+
+    munge do |value|
+      # The value is first stringified, then integers are parse out as
+      # necessary, since the Opensearch API enforces some fields to be
+      # integers.
+      #
+      # We also need to fully qualify index settings, since users
+      # can define those with the index json key absent, but the API
+      # always fully qualifies them.
+      Puppet_X::Opensearch.deep_to_i(
+        Puppet_X::Opensearch.deep_to_s(
+          value.tap do |val|
+            if val.key?('template') && val['template'].key?('settings')
+              val['template']['settings']['index'] = {} unless val['template']['settings'].key? 'index'
+              (val['template']['settings'].keys - ['index']).each do |setting|
+                new_key = if setting.start_with? 'index.'
+                            setting[6..-1]
+                          else
+                            setting
+                          end
+                val['template']['settings']['index'][new_key] = \
+                  val['template']['settings'].delete setting
+              end
+            end
+          end
+        )
+      )
+    end
+  end
+
+  newparam(:source) do
+    desc 'Puppet source to file containing template contents.'
+
+    validate do |value|
+      raise Puppet::Error, 'string expected' unless value.is_a? String
+    end
+  end
+
+  # rubocop:disable Style/SignalException
+  validate do
+    # Ensure that at least one source of template content has been provided
+    if self[:ensure] == :present
+      fail Puppet::ParseError, '"content" or "source" required' \
+        if self[:content].nil? && self[:source].nil?
+
+      if !self[:content].nil? && !self[:source].nil?
+        fail(
+          Puppet::ParseError,
+          "'content' and 'source' cannot be simultaneously defined"
+        )
+      end
+    end
+
+    # If a source was passed, retrieve the source content from Puppet's
+    # FileServing indirection and set the content property
+    unless self[:source].nil?
+      fail(format('Could not retrieve source %s', self[:source])) unless Puppet::FileServing::Metadata.indirection.find(self[:source])
+
+      tmp = if !catalog.nil? \
+                && catalog.respond_to?(:environment_instance)
+              Puppet::FileServing::Content.indirection.find(
+                self[:source],
+                environment: catalog.environment_instance
+              )
+            else
+              Puppet::FileServing::Content.indirection.find(self[:source])
+            end
+
+      fail(format('Could not find any content at %s', self[:source])) unless tmp
+
+      self[:content] = if Puppet::Util::Package.versioncmp(Puppet.version, '8.0.0').negative?
+                   PSON.load(tmp.content)
+                 else
+                   JSON.parse(tmp.content)
+                 end
+    end
+  end
+  # rubocop:enable Style/SignalException
+end

--- a/modules/opensearch/lib/puppet/type/opensearch_index_template.rb
+++ b/modules/opensearch/lib/puppet/type/opensearch_index_template.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..'))
+
+require 'puppet/file_serving/content'
+require 'puppet/file_serving/metadata'
+
+require 'puppet_x/opensearch/deep_implode'
+require 'puppet_x/opensearch/deep_to_i'
+require 'puppet_x/opensearch/deep_to_s'
+require 'puppet_x/opensearch/opsearch_rest_resource'
+
+Puppet::Type.newtype(:opensearch_index_template) do
+  extend OpensearchRESTResource
+
+  desc 'Manages Opensearch index templates.'
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'Template name.'
+  end
+
+  newproperty(:content) do
+    desc 'Structured content of template.'
+
+    validate do |value|
+      raise Puppet::Error, 'hash expected' unless value.is_a? Hash
+    end
+
+    def insync?(value)
+      Puppet_X::Opensearch.deep_implode(value) == \
+        Puppet_X::Opensearch.deep_implode(should)
+    end
+
+    munge do |value|
+      # The Opensearch API will return default empty values for composed_of
+      # if it isn't defined in the user index template, so we need to set
+      # defaults here to keep the `in` and `should` states consistent if the
+      # user hasn't provided any.
+      #
+      # The value is first stringified, then integers are parse out as
+      # necessary, since the Opensearch API enforces some fields to be
+      # integers.
+      #
+      # We also need to fully qualify index settings, since users
+      # can define those with the index json key absent, but the API
+      # always fully qualifies them.
+      { 'composed_of' => [] }.merge(
+        Puppet_X::Opensearch.deep_to_i(
+          Puppet_X::Opensearch.deep_to_s(
+            value.tap do |val|
+              if val.key?('template') && val['template'].key?('settings')
+                val['template']['settings']['index'] = {} unless val['template']['settings'].key? 'index'
+                (val['template']['settings'].keys - ['index']).each do |setting|
+                  new_key = if setting.start_with? 'index.'
+                              setting[6..-1]
+                            else
+                              setting
+                            end
+                  val['template']['settings']['index'][new_key] = \
+                    val['template']['settings'].delete setting
+                end
+              end
+            end
+          )
+        )
+      )
+    end
+  end
+
+  newparam(:source) do
+    desc 'Puppet source to file containing template contents.'
+
+    validate do |value|
+      raise Puppet::Error, 'string expected' unless value.is_a? String
+    end
+  end
+
+  # rubocop:disable Style/SignalException
+  validate do
+    # Ensure that at least one source of template content has been provided
+    if self[:ensure] == :present
+      fail Puppet::ParseError, '"content" or "source" required' \
+        if self[:content].nil? && self[:source].nil?
+
+      if !self[:content].nil? && !self[:source].nil?
+        fail(
+          Puppet::ParseError,
+          "'content' and 'source' cannot be simultaneously defined"
+        )
+      end
+    end
+
+    # If a source was passed, retrieve the source content from Puppet's
+    # FileServing indirection and set the content property
+    unless self[:source].nil?
+      fail(format('Could not retrieve source %s', self[:source])) unless Puppet::FileServing::Metadata.indirection.find(self[:source])
+
+      tmp = if !catalog.nil? \
+                && catalog.respond_to?(:environment_instance)
+              Puppet::FileServing::Content.indirection.find(
+                self[:source],
+                environment: catalog.environment_instance
+              )
+            else
+              Puppet::FileServing::Content.indirection.find(self[:source])
+            end
+
+      fail(format('Could not find any content at %s', self[:source])) unless tmp
+
+      self[:content] = if Puppet::Util::Package.versioncmp(Puppet.version, '8.0.0').negative?
+                   PSON.load(tmp.content)
+                 else
+                   JSON.parse(tmp.content)
+                 end
+    end
+  end
+  # rubocop:enable Style/SignalException
+end

--- a/modules/opensearch/manifests/component_template.pp
+++ b/modules/opensearch/manifests/component_template.pp
@@ -1,0 +1,100 @@
+#  This define allows you to insert, update or delete Opensearch component
+#  templates.
+#
+#  Template content should be defined through either the `content` parameter
+#  (when passing a hash or json string) or the `source` parameter (when passing
+#  the puppet file URI to a template json file).
+#
+# @param ensure
+#   Controls whether the named component template should be present or absent in
+#   the cluster.
+#
+# @param api_basic_auth_password
+#   HTTP basic auth password to use when communicating over the Opensearch
+#   API.
+#
+# @param api_basic_auth_username
+#   HTTP basic auth username to use when communicating over the Opensearch
+#   API.
+#
+# @param api_ca_file
+#   Path to a CA file which will be used to validate server certs when
+#   communicating with the Opensearch API over HTTPS.
+#
+# @param api_ca_path
+#   Path to a directory with CA files which will be used to validate server
+#   certs when communicating with the Opensearch API over HTTPS.
+#
+# @param api_host
+#   Host name or IP address of the ES instance to connect to.
+#
+# @param api_port
+#   Port number of the ES instance to connect to
+#
+# @param api_protocol
+#   Protocol that should be used to connect to the Opensearch API.
+#
+# @param api_timeout
+#   Timeout period (in seconds) for the Opensearch API.
+#
+# @param content
+#   Contents of the template. Can be either a puppet hash or a string
+#   containing JSON.
+#
+# @param source
+#   Source path for the template file. Can be any value similar to `source`
+#   values for `file` resources.
+#
+# @param validate_tls
+#   Determines whether the validity of SSL/TLS certificates received from the
+#   Opensearch API should be verified or ignored.
+#
+# @author Richard Pijnenburg <richard.pijnenburg@elasticsearch.com>
+# @author Tyler Langlois <tyler.langlois@elastic.co>
+#
+define opensearch::component_template (
+  Enum['absent', 'present']       $ensure                  = 'present',
+  Optional[String]                $api_basic_auth_password = $opensearch::api_basic_auth_password,
+  Optional[String]                $api_basic_auth_username = $opensearch::api_basic_auth_username,
+  Optional[Stdlib::Absolutepath]  $api_ca_file             = $opensearch::api_ca_file,
+  Optional[Stdlib::Absolutepath]  $api_ca_path             = $opensearch::api_ca_path,
+  String                          $api_host                = $opensearch::api_host,
+  Integer[0, 65535]               $api_port                = $opensearch::api_port,
+  Enum['http', 'https']           $api_protocol            = $opensearch::api_protocol,
+  Integer                         $api_timeout             = $opensearch::api_timeout,
+  Optional[Variant[String, Hash]] $content                 = undef,
+  Optional[String]                $source                  = undef,
+  Boolean                         $validate_tls            = $opensearch::validate_tls,
+) {
+  if $content =~ String {
+    $_content = parsejson($content)
+  } else {
+    $_content = $content
+  }
+
+  if $ensure == 'present' and $source == undef and $_content == undef {
+    fail('one of "file" or "content" required.')
+  } elsif $source != undef and $_content != undef {
+    fail('"file" and "content" cannot be simultaneously defined.')
+  }
+
+  os_instance_conn_validator { "${name}-component_template-conn-validator":
+    server  => $api_host,
+    port    => $api_port,
+    timeout => $api_timeout,
+  }
+  -> opensearch_component_template { $name:
+    ensure       => $ensure,
+    content      => $_content,
+    source       => $source,
+    protocol     => $api_protocol,
+    host         => $api_host,
+    port         => $api_port,
+    timeout      => $api_timeout,
+    username     => $api_basic_auth_username,
+    password     => $api_basic_auth_password,
+    ca_file      => $api_ca_file,
+    ca_path      => $api_ca_path,
+    validate_tls => $validate_tls,
+  }
+}

--- a/modules/opensearch/manifests/index_template.pp
+++ b/modules/opensearch/manifests/index_template.pp
@@ -1,0 +1,100 @@
+#  This define allows you to insert, update or delete Opensearch index
+#  templates (using new composable api).
+#
+#  Template content should be defined through either the `content` parameter
+#  (when passing a hash or json string) or the `source` parameter (when passing
+#  the puppet file URI to a template json file).
+#
+# @param ensure
+#   Controls whether the named index template should be present or absent in
+#   the cluster.
+#
+# @param api_basic_auth_password
+#   HTTP basic auth password to use when communicating over the Opensearch
+#   API.
+#
+# @param api_basic_auth_username
+#   HTTP basic auth username to use when communicating over the Opensearch
+#   API.
+#
+# @param api_ca_file
+#   Path to a CA file which will be used to validate server certs when
+#   communicating with the Opensearch API over HTTPS.
+#
+# @param api_ca_path
+#   Path to a directory with CA files which will be used to validate server
+#   certs when communicating with the Opensearch API over HTTPS.
+#
+# @param api_host
+#   Host name or IP address of the ES instance to connect to.
+#
+# @param api_port
+#   Port number of the ES instance to connect to
+#
+# @param api_protocol
+#   Protocol that should be used to connect to the Opensearch API.
+#
+# @param api_timeout
+#   Timeout period (in seconds) for the Opensearch API.
+#
+# @param content
+#   Contents of the template. Can be either a puppet hash or a string
+#   containing JSON.
+#
+# @param source
+#   Source path for the template file. Can be any value similar to `source`
+#   values for `file` resources.
+#
+# @param validate_tls
+#   Determines whether the validity of SSL/TLS certificates received from the
+#   Opensearch API should be verified or ignored.
+#
+# @author Richard Pijnenburg <richard.pijnenburg@elasticsearch.com>
+# @author Tyler Langlois <tyler.langlois@elastic.co>
+#
+define opensearch::index_template (
+  Enum['absent', 'present']       $ensure                  = 'present',
+  Optional[String]                $api_basic_auth_password = $opensearch::api_basic_auth_password,
+  Optional[String]                $api_basic_auth_username = $opensearch::api_basic_auth_username,
+  Optional[Stdlib::Absolutepath]  $api_ca_file             = $opensearch::api_ca_file,
+  Optional[Stdlib::Absolutepath]  $api_ca_path             = $opensearch::api_ca_path,
+  String                          $api_host                = $opensearch::api_host,
+  Integer[0, 65535]               $api_port                = $opensearch::api_port,
+  Enum['http', 'https']           $api_protocol            = $opensearch::api_protocol,
+  Integer                         $api_timeout             = $opensearch::api_timeout,
+  Optional[Variant[String, Hash]] $content                 = undef,
+  Optional[String]                $source                  = undef,
+  Boolean                         $validate_tls            = $opensearch::validate_tls,
+) {
+  if $content =~ String {
+    $_content = parsejson($content)
+  } else {
+    $_content = $content
+  }
+
+  if $ensure == 'present' and $source == undef and $_content == undef {
+    fail('one of "file" or "content" required.')
+  } elsif $source != undef and $_content != undef {
+    fail('"file" and "content" cannot be simultaneously defined.')
+  }
+
+  os_instance_conn_validator { "${name}-index_template-conn-validator":
+    server  => $api_host,
+    port    => $api_port,
+    timeout => $api_timeout,
+  }
+  -> opensearch_index_template { $name:
+    ensure       => $ensure,
+    content      => $_content,
+    source       => $source,
+    protocol     => $api_protocol,
+    host         => $api_host,
+    port         => $api_port,
+    timeout      => $api_timeout,
+    username     => $api_basic_auth_username,
+    password     => $api_basic_auth_password,
+    ca_file      => $api_ca_file,
+    ca_path      => $api_ca_path,
+    validate_tls => $validate_tls,
+  }
+}


### PR DESCRIPTION
This copies [0] but modifies it for opensearch.

[0] https://github.com/voxpupuli/puppet-elasticsearch/commit/37cda0c1ac602492088770a7553df5e712818f47