### PR TITLE
resolver: use our own ns servers for query lookups

### DIFF
--- a/modules/base/templates/dns/resolv.conf.erb
+++ b/modules/base/templates/dns/resolv.conf.erb
@@ -1,6 +1,7 @@
 search <%= @facts['networking']['domain'] %>
 options timeout:1 attempts:3 ndots:1
 nameserver ::1
-nameserver 2606:4700:4700::1111
-nameserver 2606:4700:4700::1001
-nameserver 1.1.1.1
+nameserver 2602:294:0:b23::111
+nameserver 2001:41d0:801:2000::4089
+nameserver 38.46.223.204
+nameserver 51.75.170.66


### PR DESCRIPTION
So that they can better access our internal network