### PR TITLE
matomo: remove CustomReports

### DIFF
--- a/modules/matomo/templates/config.ini.php.erb
+++ b/modules/matomo/templates/config.ini.php.erb
@@ -22,10 +22,6 @@ enable_internet_features = 0
 enable_tracking_failures_notification = 0
 enable_browser_archiving_triggering = 0
 
-[CustomReports]
-custom_reports_max_execution_time = 2700
-custom_reports_disabled_dimensions = "CoreHome.VisitLastActionDate"
-
 [Tracker]
 bulk_requests_use_transaction = 0
 record_statistics = 1


### PR DESCRIPTION
We don't use the plugin, it's not installed and you have to pay for it.