### PR TITLE
matomo: Set --concurrent-archivers to 3

### DIFF
--- a/modules/matomo/manifests/init.pp
+++ b/modules/matomo/manifests/init.pp
@@ -182,7 +182,7 @@ class matomo (
     # Install a systemd timer to run the Archive task periodically.
     # Running it once a day to avoid performance penalties on high trafficated websites
     # (https://matomo.org/faq/on-premise/how-to-set-up-auto-archiving-of-your-reports/#important-tips-for-medium-to-high-traffic-websites)
-    $archiver_command = "/usr/bin/php /srv/matomo/console core:archive --url=\"https://analytics.wikitide.net/\""
+    $archiver_command = "/usr/bin/php /srv/matomo/console core:archive --concurrent-archivers=3 --url=\"https://analytics.wikitide.net/\""
 
     # Create concurrent archivers
     # https://matomo.org/faq/on-premise/how-to-set-up-auto-archiving-of-your-reports/


### PR DESCRIPTION
Trying to fix:
> /srv/matomo/core/CliMulti.php(484): Warning - filemtime(): stat failed for /srv/matomo/tmp/climulti/archive.sharedsiteids.pid