### PR TITLE
Replace puppetlabs with openvox

### DIFF
--- a/modules/base/manifests/puppet.pp
+++ b/modules/base/manifests/puppet.pp
@@ -4,19 +4,19 @@ class base::puppet (
     Integer       $puppet_major_version  = lookup('puppet_major_version', {'default_value' => 8}),
     String        $puppetserver_hostname = lookup('puppetserver_hostname'),
 ) {
-    file { '/etc/apt/trusted.gpg.d/puppetlabs.asc':
+    file { '/etc/apt/trusted.gpg.d/openvox-keyring.gpg':
         ensure => present,
-        source => 'puppet:///modules/base/puppet/puppetlabs.asc',
+        source => 'puppet:///modules/base/puppet/openvox-keyring.gpg',
     }
 
-    apt::source { 'puppetlabs':
-        location => 'http://apt.puppetlabs.com',
-        repos    => "puppet${puppet_major_version}",
-        require  => File['/etc/apt/trusted.gpg.d/puppetlabs.asc'],
-        notify   => Exec['apt_update_puppetlabs'],
+    apt::source { 'openvox':
+        location => 'https://apt.voxpupuli.org',
+        repos    => "openvox${puppet_major_version}",
+        require  => File['/etc/apt/trusted.gpg.d/openvox-keyring.gpg'],
+        notify   => Exec['apt_update_openvox'],
     }
 
-    exec {'apt_update_puppetlabs':
+    exec {'apt_update_openvox':
         command     => '/usr/bin/apt-get update',
         refreshonly => true,
         logoutput   => true,
@@ -24,7 +24,7 @@ class base::puppet (
 
     package { 'puppet-agent':
         ensure  => present,
-        require => Apt::Source['puppetlabs'],
+        require => Apt::Source['openvox'],
     }
 
     # facter needs this for proper "virtual"/"is_virtual" resolution


### PR DESCRIPTION
We switch out the apt repo. Commans are the same, but package name is different.