### PR TITLE
dns: allow powerdns to use ipv4 to resolve domains

### DIFF
--- a/modules/base/templates/dns/recursor.conf.erb
+++ b/modules/base/templates/dns/recursor.conf.erb
@@ -18,7 +18,7 @@ max-cache-entries=500000
 
 stats-ringbuffer-entries=1000
 
-query-local-address=::
+query-local-address=::,0.0.0.0
 
 # This prevents pdns from polling a public server to check for sec fixes
 security-poll-suffix=


### PR DESCRIPTION
PowerDNS would not resolve IPv4 DNS nameservers. Since wikimedia.org's nameservers are all IPv4 (at the time of writing), this causes Wikimedia Commons to fail to resolve, which breaks QuickInstantCommons.

Debugging trail:
* https://discord.com/channels/407504499280707585/1006789349498699827/1408395878708023296
* https://wm-bot.wmcloud.org/logs/%23miraheze-tech/20250822.txt