### PR TITLE
Fix recursor if forward_use_internal

### DIFF
--- a/modules/base/templates/dns/recursor.conf.erb
+++ b/modules/base/templates/dns/recursor.conf.erb
@@ -2,7 +2,11 @@
 allow-from = 127.0.0.0/8, ::1/128
 config-dir = /etc/powerdns
 dnssec = off
+<%- if @forward_use_internal -%>
+local-address = 127.0.0.1
+<%- else -%>
 local-address = ::1
+<%- end -%>
 quiet = yes
 setgid = pdns
 setuid = pdns

--- a/modules/base/templates/dns/resolv.conf.erb
+++ b/modules/base/templates/dns/resolv.conf.erb
@@ -1,9 +1,10 @@
 search <%= @facts['networking']['domain'] %> miraheze.org
 options timeout:1 attempts:3 ndots:1
-nameserver ::1
 <%- if @forward_use_internal -%>
+nameserver 127.0.0.1
 nameserver 10.0.17.136
 <%- else -%>
+nameserver ::1
 nameserver 2602:294:0:b23::111
 nameserver 2001:41d0:801:2000::4089
 nameserver 38.46.223.204


### PR DESCRIPTION
This should allow local networking (like to fsslc.wtnet) to resolve locally rather than failing and then forwarding to ns1.