### PR TITLE
changeprop201: Lower concurrency for LocalGlobalUserPageCacheUpdateJob to 25

### DIFF
--- a/hieradata/hosts/changeprop201.yaml
+++ b/hieradata/hosts/changeprop201.yaml
@@ -38,7 +38,7 @@ changeprop::high_traffic_jobs_config:
   LocalGlobalUserPageCacheUpdateJob:
     # This job is prone to large spikes, so having it on the low_traffic_jobs queue
     # blocks other jobs.
-    concurrency: 100
+    concurrency: 25
   notificationGetStartedJob:
     concurrency: 2
     # The jobs have a variable delay (several hours, up to 48 hours),


### PR DESCRIPTION
Having it at 100 causes the cpu to jump to 100% on mwtask and also the load gets very high. This is counter productive and won't make things go any faster. It does the opposite and will make things slower, as well as taking resources away from other jobs as well. Let's lower this to 25.