### PR TITLE
Use ntp.fsslc.wtnet for ntp server

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -4,7 +4,7 @@ puppetserver: false
 
 puppet_major_version: 8
 
-base::ntp_server: 'bastion.fsslc.wtnet'
+base::ntp_server: 'ntp.fsslc.wtnet'
 
 mediawiki::multiversion::versions:
   '1.43':


### PR DESCRIPTION
Uses bast181 instead of bast161 which is used for most things right now. Just to split it up a bit.