### PR TITLE
monitoring: Add check for letsencrypt again in ssl.conf

### DIFF
--- a/modules/monitoring/templates/ssl.conf.erb
+++ b/modules/monitoring/templates/ssl.conf.erb
@@ -38,7 +38,7 @@ apply Service "<%= property['url'] %> - <%= property['ca'] %>" {
   check_interval = 30m
   notes_url = "https://meta.miraheze.org/wiki/Tech:Icinga/MediaWiki_Monitoring#SSL_Validity_Checks"
   vars.host = "<% if property['url'].start_with?('*') and property['sslname'] %><%= property['sslname'] %><% else %><%= property['url'] %><% end %>"
-  vars.time = 28
+  vars.time = "<% if property['ca'] == "LetsEncrypt" %>14<% else %>28<% end %>"
   assign where "sslchecks" in host.groups
 }
 <% end %>


### PR DESCRIPTION
We still use a letsencrypt ssl certificate for swift-lb.wikitide.net.