### PR TITLE
Fix typo in variable name

### DIFF
--- a/modules/mediawiki/manifests/init.pp
+++ b/modules/mediawiki/manifests/init.pp
@@ -106,7 +106,7 @@ class mediawiki {
     $openai_apikey                = lookup('mediawiki::openai_apikey')
     $openai_assistantid           = lookup('mediawiki::openai_assistantid')
     $turnstile_sitekey            = lookup('mediawiki::turnstile_sitekey')
-    $turnstile_secreteky          = lookup('mediawiki::turnstile_secretkey')
+    $turnstile_secretkey          = lookup('mediawiki::turnstile_secretkey')
 
     file { '/srv/mediawiki/config/PrivateSettings.php':
         ensure  => 'present',


### PR DESCRIPTION
Not sure if this is even used since nobody noticed, but the variable is referred to as `turnstile_secretkey` in the template:
https://github.com/miraheze/puppet/blob/54476aff9180849fc8782a80c75cf7672c16fd82/modules/mediawiki/templates/PrivateSettings.php#L19