### PR TITLE
mediawiki_task: increase apcu and opcache memory to 8gb (8192)

### DIFF
--- a/hieradata/role/common/mediawiki_task.yaml
+++ b/hieradata/role/common/mediawiki_task.yaml
@@ -14,12 +14,13 @@ role::mediawiki::is_beta: false
 
 mediawiki::php::fpm::fpm_workers_multiplier: 2.0
 mediawiki::php::request_timeout: 259201
-mediawiki::php::apc_shm_size: '6096M'
+mediawiki::php::apc_shm_size: '8192M'
 mediawiki::php::fpm_config:
   post_max_size: '250M'
   upload_max_filesize: '250M'
-  opcache.interned_strings_buffer: 256
-  opcache.memory_consumption: 6096
+  opcache.interned_strings_buffer: 384
+  opcache.memory_consumption: 8192
+  opcache.max_accelerated_files: 130987
   max_execution_time: 1200
 
 mediawiki::php::increase_open_files: true


### PR DESCRIPTION
Also increase opcache.max_accelerated_files to 131k