### PR TITLE
cache::haproxy: Set http-reuse to never for frontend and use keepalive for varnish -> haproxy

### DIFF
--- a/modules/role/templates/cache/haproxy/tls_terminator.cfg.erb
+++ b/modules/role/templates/cache/haproxy/tls_terminator.cfg.erb
@@ -39,7 +39,7 @@ listen tls
     bind :::<%= @tls_port -%> tfo v6only ssl crt-list /etc/haproxy/crt-list.cfg<%- if @tls_ticket_keys_path -%> tls-ticket-keys <%= @tls_ticket_keys_path %><%- end %>
 
     option http-keep-alive
-    http-reuse always
+    http-reuse never
 
     # time to wait for a complete HTTP request, It only applies to the header part of the HTTP request (unless option http-buffer-request is used)
     timeout http-request <%= @timeout['http_request'] %>s
@@ -208,6 +208,7 @@ listen <%= name %>_backend_tls
     bind :<%= property['port'] %>
     bind :::<%= property['port'] %> v6only
 
+    option http-keep-alive
     http-reuse always
 
     # time to wait for a complete HTTP request, It only applies to the header part of the HTTP request (unless option http-buffer-request is used)


### PR DESCRIPTION
This is to fix sometimes the wrong request ending up at the wrong backend.