### PR TITLE
mediawiki: support php 8.2 in php/admin/lib dump_apcu_full()

### DIFF
--- a/modules/mediawiki/files/php/admin/lib.php
+++ b/modules/mediawiki/files/php/admin/lib.php
@@ -385,7 +385,7 @@ function show_apcu_frag() {
 
 function dump_apcu_full() {
 	header("Content-Type: text/plain");
-	$stats = apcu_stats(true);
+	$stats = apcu_stats(false);
 	dump_file('/tmp/apcu_dump_meta', $stats['cache_list']);
 }
 


### PR DESCRIPTION
We have to set apcu_cache_info to false. Setting it to true causes cache_list not to be returned.