### PR TITLE
mediawiki: set opcache.max_wasted_percentage to 3%

### DIFF
--- a/hieradata/role/common/mediawiki.yaml
+++ b/hieradata/role/common/mediawiki.yaml
@@ -17,6 +17,7 @@ mediawiki::php::fpm_config:
   upload_max_filesize: '250M'
   opcache.interned_strings_buffer: 384
   opcache.memory_consumption: 8192
+  opcache.max_wasted_percentage: 3
 
 php::php_version: '8.2'
 

--- a/hieradata/role/common/mediawiki_task.yaml
+++ b/hieradata/role/common/mediawiki_task.yaml
@@ -22,6 +22,7 @@ mediawiki::php::fpm_config:
   opcache.memory_consumption: 8192
   opcache.max_accelerated_files: 130987
   max_execution_time: 1200
+  opcache.max_wasted_percentage: 3
 
 mediawiki::php::increase_open_files: true
 mediawiki::php::enable_request_profiling: true


### PR DESCRIPTION
We set opcache to 8gb so 3% of that is 245mb.