### PR TITLE
mediawiki: Add a way to safely restart php-fpm in a systemd timer

### DIFF
--- a/modules/role/manifests/mediawiki.pp
+++ b/modules/role/manifests/mediawiki.pp
@@ -14,6 +14,7 @@ class role::mediawiki (
         include role::mediawiki::nutcracker
     }
     include mediawiki
+    include role::mediawiki::php::restarts
 
     if $strict_firewall {
         $firewall_rules_str = join(


### PR DESCRIPTION
Restart php-fpm if it meets certain conditions. E.g. if opcache is below a certain level.

Reset apcu cache if it's below a certain level.