### PR TITLE
role::cache::varnish: Stop using fail2ban

### DIFF
--- a/modules/role/manifests/cache/varnish.pp
+++ b/modules/role/manifests/cache/varnish.pp
@@ -8,6 +8,8 @@ class role::cache::varnish (
         use_nginx => false,
     }
 
-    include fail2ban
+    class { 'fail2ban':
+        ensure => absent,
+    }
     include prometheus::exporter::varnishreqs
 }


### PR DESCRIPTION
It won't work with how we have it setup (needs nginx) and we're behind cloudflare now.