### PR TITLE
T15160: Set slave_connections_needed_for_purge to 0

### DIFF
--- a/modules/mariadb/templates/config/mw.cnf.erb
+++ b/modules/mariadb/templates/config/mw.cnf.erb
@@ -33,6 +33,7 @@ expire_logs_days               = <%= @expire_logs_days %>
 sync_binlog                    = <%= @sync_binlog %>
 binlog_cache_size              = 10M
 slave_compressed_protocol      = 1
+slave_connections_needed_for_purge = 0
 <%- else -%>
 disable_log_bin
 <%- end -%>


### PR DESCRIPTION
Required to unbreak binlog purging - see https://jira.mariadb.org/browse/MDEV-38849