### PR TITLE
opensearch: Fix graylog connecting to opensearch

### DIFF
--- a/modules/role/templates/opensearch/nginx.conf.erb
+++ b/modules/role/templates/opensearch/nginx.conf.erb
@@ -1,7 +1,6 @@
 server {
 	listen 443 ssl deferred;
 	listen [::]:443 ssl deferred;
-	http2 on;
 
 	server_name opensearch.wikitide.net opensearch-mw.wikitide.net;
 
@@ -9,6 +8,8 @@ server {
 	ssl_certificate_key /etc/ssl/private/wikitide.net.key;
 
 	location / {
+		proxy_http_version 1.1;
+		proxy_set_header Connection "";
 		proxy_pass http://<%= @os_manager_hosts[0] %>.fsslc.wtnet:9200;
 		proxy_set_header Host $http_host;
 		proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Using graylog 7.1 broke connecting to opensearch without this change.