### PR TITLE
add timeout to backup job starting

### DIFF
--- a/modules/backup/manifests/job.pp
+++ b/modules/backup/manifests/job.pp
@@ -36,6 +36,7 @@ define backup::job (
         description         => "Runs backup of ${title}",
         command             => "/usr/local/bin/wikitide-backup backup ${params}",
         interval            => { 'start' => 'OnCalendar', 'interval' => $interval },
+        timeout_start_sec   => '1d',
         logfile_basedir     => $logfile_basedir,
         logfile_name        => "${title}-backup.log",
         syslog_identifier   => "${title}-backup",


### PR DESCRIPTION
Backup jobs have a tendency to freeze when starting, and should not take more than a day to run. Therefore, if they've been running for more than a day, we can assume it failed.