### PR TITLE
Automate custom domain removal

### DIFF
--- a/modules/ssl/manifests/custom_domain_checker.pp
+++ b/modules/ssl/manifests/custom_domain_checker.pp
@@ -1,0 +1,40 @@
+# === Class ssl::custom_domain_checker
+class ssl::custom_domain_checker {
+    file { '/usr/local/bin/custom_domain_checker':
+        ensure => present,
+        owner  => 'root',
+        group  => 'root',
+        mode   => '0755',
+        source => 'puppet:///modules/ssl/bin/custom_domain_checker',
+    }
+
+    file { '/tokens/cloudflare_ssl.txt':
+        ensure => present,
+        content => lookup('passwords::mediawiki::cloudflare_requestcustomdomain_apikey')
+        owner  => 'root',
+        group  => 'root',
+        mode   => '0400',
+    }
+    file { '/tokens/cloudflare_zone.txt':
+        ensure => present,
+        content => lookup('cloudflare::zone_id')
+        owner  => 'root',
+        group  => 'root',
+        mode   => '0644',
+    }
+
+    systemd::timer::job { 'check-custom-domains':
+        ensure            => present,
+        description       => 'Check custom domain availability and remove if unavailable for 3 days',
+        command           => '/usr/local/bin/custom_domain_checker',
+        interval          => {
+            'start'    => 'OnCalendar',
+            'interval' => 'daily',
+        },
+        user              => 'root',
+        logfile_basedir   => '/var/log/ssl',
+        logfile_name      => 'check-custom-domains.log',
+        logfile_group     => 'root',
+        syslog_identifier => 'check-custom-domains',
+    }
+}


### PR DESCRIPTION
Adds PetraMagna's custom_domain_checker as a systemd timer that runs daily. 3 failures to query will lead to the domain being removed.

Compiled from https://github.com/SomeMWDev/mirarust/tree/ssl

T7582