### PR TITLE
move all systemd units to /etc/systemd/system

### DIFF
--- a/modules/systemd/manifests/init.pp
+++ b/modules/systemd/manifests/init.pp
@@ -5,7 +5,7 @@
 #
 class systemd {
     # Directories for base units and overrides
-    $base_dir = '/lib/systemd/system'
+    $base_dir = '/etc/systemd/system'
     $override_dir = '/etc/systemd/system'
 
     file { '/usr/local/bin/systemd-timer-mail-wrapper':


### PR DESCRIPTION
`/lib/systemd/` is for vendor unit files and will be overwritten during updates. `/etc/systemd` is the preferred location for created units, as well as overrides. If a unit is defined in both locations `/etc/systemd` takes priority.

Fixes T15466