### PR TITLE
mediawiki icinga permissions: monitoring -> icingadb

### DIFF
--- a/modules/icingaweb2/templates/roles.ini.erb
+++ b/modules/icingaweb2/templates/roles.ini.erb
@@ -4,4 +4,4 @@ permissions = "*"
 
 [sre-mediawiki]
 groups = "sre-mediawiki"
-permissions = "module/doc, module/icingadb, monitoring/command/acknowledge-problem, monitoring/command/comment/*, monitoring/command/downtime/*, monitoring/command/remove-acknowledgement"
+permissions = "module/doc, module/icingadb, icingadb/command/acknowledge-problem, icingadb/command/comment/*, icingadb/command/downtime/*, icingadb/command/remove-acknowledgement"


### PR DESCRIPTION
this replaces the monitoring permissions with their icingadb equivalents