### PR TITLE
Set db182 wait_timeout to 28800

### DIFF
--- a/hieradata/hosts/db182.yaml
+++ b/hieradata/hosts/db182.yaml
@@ -8,3 +8,4 @@ role::db::enable_bin_logs: false
 mariadb::version: '11.8'
 role::db::enable_ssl: false
 role::db::is_beta_db: false
+role::db::wait_timeout: 28800

--- a/modules/mariadb/manifests/config.pp
+++ b/modules/mariadb/manifests/config.pp
@@ -15,6 +15,7 @@ class mariadb::config(
     String                $expire_logs_days             = '3',
     String                $sync_binlog                  = '1',
     String                $flush_log_at_trx_commit      = '1',
+    Integer               $wait_timeout                 = 3600,
 ) {
     $exporter_password = lookup('passwords::db::exporter')
     $ido_db_user_password = lookup('passwords::icinga_ido')

--- a/modules/mariadb/templates/config/mw.cnf.erb
+++ b/modules/mariadb/templates/config/mw.cnf.erb
@@ -61,7 +61,7 @@ query-cache-type               = 0
 query-cache-size               = 0
 thread_cache_size              = 300
 interactive_timeout            = 28800
-wait_timeout                   = 3600
+wait_timeout                   = <%= @wait_timeout %>
 
 innodb-flush-method            = O_DIRECT
 innodb_flush_neighbors         = 0

--- a/modules/role/manifests/db.pp
+++ b/modules/role/manifests/db.pp
@@ -9,6 +9,7 @@ class role::db (
     Boolean $backup_sql = lookup('role::db::backup_sql', {'default_value' => true}),
     Boolean $enable_ssl = lookup('role::db::enable_ssl', {'default_value' => true}),
     Boolean $is_beta_db = lookup('role::db::is_beta_db', {'default_value' => false}),
+    Integer $wait_timeout = lookup('role::db::wait_timeout', {'default_value' => 3600}),
 ) {
     include mariadb::packages
     include prometheus::exporter::mariadb
@@ -46,6 +47,7 @@ class role::db (
         enable_bin_logs => $enable_bin_logs,
         enable_ssl      => $enable_ssl,
         enable_slow_log => $enable_slow_log,
+        wait_timeout    => $wait_timeout,
     }
 
     file { '/etc/mysql/wikitide/mediawiki-grants.sql':


### PR DESCRIPTION
This is for matomo as getting "Mysqli prepare error: MySQL server has gone away".

This is recommended in https://matomo.org/faq/troubleshooting/faq_183/ and this is the default value for the variable anyways.