### PR TITLE
remove Paladox ssh key

### DIFF
--- a/modules/users/data/data.yaml
+++ b/modules/users/data/data.yaml
@@ -133,7 +133,7 @@ users:
     uid: 1009
     name: paladox
     realname: Paladox
-    ssh_keys: [ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJF/bY6KnOxux3v5KIDDsBWbaut2LY/mGSd6rSyN2dcl paladox@wikitide.org]
+    ssh_keys: []
   macfan:
     ensure: present
     uid: 1010


### PR DESCRIPTION
Removed SSH keys for user 'paladox' in data.yaml.