### PR TITLE
puppetserver: Add -w 10 to nc command

### DIFF
--- a/modules/puppetserver/templates/listdomains.py
+++ b/modules/puppetserver/templates/listdomains.py
@@ -153,7 +153,7 @@ def git_push(workdir):
 
     subprocess.run([
         "git", "config", "--global", "core.sshCommand",
-        "ssh -i /var/lib/nagios/id_ed25519 -F /dev/null -o ProxyCommand='nc -X connect -x bastion.fsslc.wtnet:8080 %h %p'"
+        "ssh -i /var/lib/nagios/id_ed25519 -F /dev/null -o ProxyCommand='nc -w 10 -X connect -x bastion.fsslc.wtnet:8080 %h %p'"
     ], check=True)
 
     subprocess.run(["git", "-C", workdir, "config", "user.name", "WikiTideBot"], check=True)


### PR DESCRIPTION
> This instructs netcat to quit if the proxy connection or destination drops or remains silent for more than 10 seconds.