### PR TITLE
speedscope211: include nftables alongside ferm

### DIFF
--- a/hieradata/hosts/speedscope211.yaml
+++ b/hieradata/hosts/speedscope211.yaml
@@ -4,3 +4,4 @@ base::syslog::rsyslog_udp_localhost: true
 
 base::dns::do_ipv4: true
 base::dns::forward_use_internal: true
+base::firewall::provider: 'both'


### PR DESCRIPTION
Migration stage 1, once all servers are set to 'both', we will slowly set them to 'nftables' to remove ferm.