### PR TITLE
mediawiki_task: include nftables alongside ferm

### DIFF
--- a/hieradata/role/common/mediawiki_task.yaml
+++ b/hieradata/role/common/mediawiki_task.yaml
@@ -44,6 +44,7 @@ php::php_version: '8.4'
 
 http_proxy: 'http://bastion.fsslc.wtnet:8080'
 
+base::firewall::provider: 'both'
 base::syslog::rsyslog_udp_localhost: true
 
 # NGINX


### PR DESCRIPTION
Migration stage 1, once all servers are set to 'both', we will slowly set them to 'nftables' to remove ferm.