### PR TITLE
cache: include nftables alongside ferm

### DIFF
--- a/hieradata/role/common/cache/cache.yaml
+++ b/hieradata/role/common/cache/cache.yaml
@@ -320,4 +320,5 @@ role::cache::haproxy::extended_logging: true
 
 # base
 
+base::firewall::provider: 'both'
 base::syslog::rsyslog_udp_localhost: true


### PR DESCRIPTION
Migration stage 1, once all servers are set to 'both', we will slowly
set them to 'nftables' to remove ferm.