### PR TITLE
irc: include nftables alongside ferm

### DIFF
--- a/hieradata/role/common/irc.yaml
+++ b/hieradata/role/common/irc.yaml
@@ -1,1 +1,2 @@
 http_proxy: 'http://bastion.fsslc.wtnet:8080'
+base::firewall::provider: 'both'


### PR DESCRIPTION
Migration stage 1, once all servers are set to 'both', we will slowly set them to 'nftables' to remove ferm.