### PR TITLE
cp161: include nftables alongside ferm

### DIFF
--- a/hieradata/hosts/cp161.yaml
+++ b/hieradata/hosts/cp161.yaml
@@ -8,3 +8,4 @@ nginx::logrotate_number: 2
 nginx::logrotate_maxsize: '10G'
 
 base::dns::do_ipv4: true
+base::firewall::provider: 'both'


### PR DESCRIPTION
Migration stage 1, once all servers are set to 'both', we will slowly set them to 'nftables' to remove ferm.