### PR TITLE
Include nftables alongside ferm on all remaining servers

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -2,7 +2,7 @@ jobrunner: false
 jobrunner::intensive: false
 puppetserver: false
 
-base::firewall::provider: 'ferm'
+base::firewall::provider: 'both'
 
 puppet_major_version: 8
 


### PR DESCRIPTION
It should now be enabled on at least one server with every role in the fleet, so we should now be okay to do this for all remaining.