### PR TITLE
cloud: install proxmox-firewall

### DIFF
--- a/modules/cloud/manifests/init.pp
+++ b/modules/cloud/manifests/init.pp
@@ -27,7 +27,7 @@ class cloud {
         require     => Apt::Pin['proxmox_pin'],
     }
 
-    package { ['proxmox-ve', 'open-iscsi']:
+    package { ['proxmox-ve', 'proxmox-firewall', 'open-iscsi']:
         ensure  => present,
         require => Apt::Source['proxmox_apt']
     }


### PR DESCRIPTION
The nftables version of pve-firewall. We don't actively use it, but without it it still tries to use iptables rules, so this is just better.