### PR TITLE
backup: Fix finding objects using a prefix

### DIFF
--- a/modules/backup/templates/wikitide-backup.py.epp
+++ b/modules/backup/templates/wikitide-backup.py.epp
@@ -103,6 +103,12 @@ parser.add_argument(
     help='Specific database to download or backup',
 )
 
+parser.add_argument(
+    '--prefix',
+    dest='prefix',
+    help='S3 object prefix to search for',
+)
+
 args = parser.parse_args()
 
 
@@ -1026,12 +1032,19 @@ def download(
 def find_backups(
     source: str,
     database: str,
+    prefix: str = None,
 ):
 
-    if database:
-        prefix = f"{source}/{database}"
-    else:
-        prefix = f"{source}"
+    if prefix is None:
+        if source is None:
+            raise ValueError(
+                'Either --prefix or type is required'
+            )
+
+        if database:
+            prefix = f"{source}/{database}"
+        else:
+            prefix = f"{source}/"
 
     backups = s3_list(
         prefix
@@ -1079,12 +1092,14 @@ if __name__ == "__main__":
             args.database,
         )
     elif args.action == 'find':
-        if not args.type:
+        if not args.type and not args.prefix:
             parser.error(
-                'find requires a backup type'
+                'find requires either a backup type '
+                'or --prefix'
             )
 
         find_backups(
             args.type,
             args.database,
+            args.prefix,
         )

--- a/modules/backup/templates/wikitide-backup.py.epp
+++ b/modules/backup/templates/wikitide-backup.py.epp
@@ -1028,13 +1028,9 @@ def find_backups(
     database: str,
 ):
 
-    if source == "sql" and database:
+    if database:
         prefix = (
-            f"sql/{database}/"
-        )
-    elif source == "mediawiki-xml" and database:
-        prefix = (
-            f"mediawiki-xml/{database}/"
+            f"{source}/{database}"
         )
     else:
         prefix = f"{source}/"

--- a/modules/backup/templates/wikitide-backup.py.epp
+++ b/modules/backup/templates/wikitide-backup.py.epp
@@ -1029,11 +1029,9 @@ def find_backups(
 ):
 
     if database:
-        prefix = (
-            f"{source}/{database}"
-        )
+        prefix = f"{source}/{database}"
     else:
-        prefix = f"{source}/"
+        prefix = f"{source}"
 
     backups = s3_list(
         prefix


### PR DESCRIPTION
This is so if you give for instance allthetropes, it should return allthetropeswiki.